### PR TITLE
Make `generate` an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ titlecase = { version = "1", optional = true }
 censor = { version = "0.2", optional = true }
 cached = { version = "0.26", default-features = false, features = ["proc_macro"], optional = true }
 uuid = { version = "0.8.2", features = ["v4"] }
-test-data-generation = "0.3"
+test-data-generation = { version = "0.3", optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }
@@ -74,3 +74,4 @@ default = ["mimalloc"]
 lua = ["hlua"]
 foreach = []
 apply = ["cached", "currency", "eudex", "titlecase", "censor", "strsim", "reverse_geocoder", "once_cell", "chrono"]
+generate = ["test-data-generation"]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,6 +14,7 @@ pub mod fmt;
 #[cfg(feature = "foreach")]
 pub mod foreach;
 pub mod frequency;
+#[cfg(feature = "generate")]
 pub mod generate;
 pub mod headers;
 pub mod index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ macro_rules! command_list {
     fmt         Format CSV output (change field delimiter)
     foreach*    Loop over a CSV file to execute bash commands (*nix only)
     frequency   Show frequency tables
-    generate    Generate test data by profiling a CSV
+    generate*   Generate test data by profiling a CSV
     headers     Show header names
     help        Show this usage message.
     index       Create CSV index for faster access
@@ -170,6 +170,7 @@ enum Command {
     #[cfg(feature = "foreach")]
     ForEach,
     Frequency,
+    #[cfg(feature = "generate")]
     Generate,
     Headers,
     Help,
@@ -223,6 +224,7 @@ impl Command {
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),
             Command::Frequency => cmd::frequency::run(argv),
+            #[cfg(feature = "generate")]
             Command::Generate => cmd::generate::run(argv),
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {


### PR DESCRIPTION
as the test-generation-data crate has a relatively large dependency tree