### PR TITLE
QSV_COMMENTS environment variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ to number of logical processors divided by four.  See [Parallelization](#paralle
 commands are not unicode-aware and will ignore unicode values when matching and will panic when unicode characters are used in the regex.
 * `QSV_RDR_BUFFER_CAPACITY` - set to change reader buffer size (bytes - default when not set: 16384)
 * `QSV_WTR_BUFFER_CAPACITY` - set to change writer buffer size (bytes - default when not set: 65536)
+* `QSV_COMMENTS` - set to a comment character which will ignore any lines that start with this character (default is no comment lines)
 
 Feature Flags
 -------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -320,6 +320,8 @@ impl Config {
             .unwrap_or_else(|_| DEFAULT_RDR_BUFFER_CAPACITY.to_string());
         let rdr_buffer: usize = rdr_capacitys.parse().unwrap_or(DEFAULT_RDR_BUFFER_CAPACITY);
 
+        let rdr_comment: Option<u8> = env::var("QSV_COMMENTS").ok().map(|s|s.as_bytes().first().unwrap().to_owned());
+
         csv::ReaderBuilder::new()
             .flexible(self.flexible)
             .delimiter(self.delimiter)
@@ -328,6 +330,7 @@ impl Config {
             .quoting(self.quoting)
             .escape(self.escape)
             .buffer_capacity(rdr_buffer)
+            .comment(rdr_comment)
             .from_reader(rdr)
     }
 

--- a/tests/test_comments.rs
+++ b/tests/test_comments.rs
@@ -1,0 +1,17 @@
+use crate::workdir::Workdir;
+
+#[test]
+fn comments() {
+    let wrk = Workdir::new("comments");
+    wrk.create(
+        "comments.csv",
+        vec![svec!["# test file to see how comments work",""], svec!["column1", "column2"], svec!["a", "1"], svec!["#b", "2"], svec!["c", "3"]],
+    );
+    let mut cmd = wrk.command("input");
+    cmd.env("QSV_COMMENTS", "#");
+    cmd.arg("comments.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["column1", "column2"], svec!["a", "1"], svec!["c", "3"]];
+    assert_eq!(got, expected);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,6 +35,7 @@ mod workdir;
 #[cfg(feature = "apply")]
 mod test_apply;
 mod test_behead;
+mod test_comments;
 mod test_cat;
 mod test_count;
 mod test_combos;


### PR DESCRIPTION
As discussed in #112. The QSV_COMMENTS variable will be used to set a comment character to ignore any lines that begin with this character.  If QSV_COMMENTS is not set then no lines will be ignored.

I created the option as an environmental variable per your initial suggestion.  Added Test and modified the readme.  Let me know if this is good. 

Still may add a top line skip option on the `input` sub command.  