### PR TITLE
Fetch: improve jql integration

### DIFF
--- a/docs/Fetch.md
+++ b/docs/Fetch.md
@@ -1,0 +1,69 @@
+# Fetch command
+
+## jql ##
+
+Fetch is integrated with [`jql`](https://github.com/yamafaktory/jql), with some limitations:
+
+* Primary usecase is to retrieve simple values from API JSON response, hence selectors must result in: Number, String, Bool, or Array of such.
+* Arrays of Number, String, and Bool are concatenated into String with comma separator
+* Output may contain jql error messages
+* JSON Null becomes "null" string
+* Processing aborts if jql output is still a JSON
+
+
+## Usage Examples
+
+__test.csv__
+
+```
+Country,ZipCode,URL
+US,90210,http://api.zippopotam.us/us/90210
+US,94105,http://api.zippopotam.us/us/94105
+US,92802,http://api.zippopotam.us/us/92802
+```
+
+
+### Fetch url from 3rd column of `test.csv`, apply JQL selector, and print results
+
+```
+$ qsv fetch  3 --jql '."places"[0]."place name"' test.csv
+Beverly Hills
+San Francisco
+Anaheim
+```
+
+### Fetch url from `URL` column of `test.csv`, apply JQL selector, and put results into new column named City
+
+```
+$ qsv fetch URL --new-column City --jql '."places"[0]."place name"' test.csv
+Country,ZipCode,URL,City
+US,90210,http://api.zippopotam.us/us/90210,Beverly Hills
+US,94105,http://api.zippopotam.us/us/94105,San Francisco
+US,92802,http://api.zippopotam.us/us/92802,Anaheim
+```
+
+### Fetch url from `URL` column of `test.csv`, use JQL to select multiple values, and put them into new column
+
+Please note, multiple values get concatenated into a single quoted string with comma as separator.
+
+```
+$ qsv fetch URL --new-column CityState --jql '"places"[0]."place name","places"[0]."state abbreviation"' test.csv
+[00:00:00] [==================== 100% of 3 records. Cache hit ratio: 0.00% - 3 entries] (7/sec)
+Country,ZipCode,URL,CityState
+US,90210,http://api.zippopotam.us/us/90210,"Beverly Hills, CA"
+US,94105,http://api.zippopotam.us/us/94105,"San Francisco, CA"
+US,92802,http://api.zippopotam.us/us/92802,"Anaheim, CA"
+```
+
+### Fetch with explicit rate limit set, and pipe output to a new csv
+
+```
+$ qsv fetch URL test.csv --rate-limit 3 --jql '"places"[0]."longitude","places"[0]."latitude"' -c Coordinates > new.csv
+[00:00:01] [==================== 100% of 3 records. Cache hit ratio: 0.00% - 3 entries] (5/sec)
+$ cat new.csv
+Country,ZipCode,URL,Coordinates
+US,90210,http://api.zippopotam.us/us/90210,"-118.4065, 34.0901"
+US,94105,http://api.zippopotam.us/us/94105,"-122.3892, 37.7864"
+US,92802,http://api.zippopotam.us/us/92802,"-117.9228, 33.8085"
+```
+

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -48,7 +48,7 @@ fn fetch_simple() {
 }
 
 #[test]
-fn fetch_jql() {
+fn fetch_jql_single() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
@@ -73,6 +73,36 @@ fn fetch_jql() {
         svec!["http://api.zippopotam.us/us/90210", "Beverly Hills"],
         svec!["http://api.zippopotam.us/us/94105", "San Francisco"],
         svec!["https://api.zippopotam.us/us/92802", "Anaheim"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn fetch_jql_multiple() {
+    let wrk = Workdir::new("fetch");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["URL"],
+            svec!["http://api.zippopotam.us/us/90210"],
+            svec!["http://api.zippopotam.us/us/94105"],
+            svec!["https://api.zippopotam.us/us/92802"],
+        ],
+    );
+    let mut cmd = wrk.command("fetch");
+    cmd.arg("URL")
+        .arg("--new-column")
+        .arg("CityState")
+        .arg("--jql")
+        .arg(r#""places"[0]."place name","places"[0]."state abbreviation""#)
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["URL", "CityState"],
+        svec!["http://api.zippopotam.us/us/90210", "\"Beverly Hills, CA\""],
+        svec!["http://api.zippopotam.us/us/94105", "\"San Francisco, CA\""],
+        svec!["https://api.zippopotam.us/us/92802", "\"Anaheim, CA\""],
     ];
     assert_eq!(got, expected);
 }

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -100,9 +100,9 @@ fn fetch_jql_multiple() {
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["URL", "CityState"],
-        svec!["http://api.zippopotam.us/us/90210", "\"Beverly Hills, CA\""],
-        svec!["http://api.zippopotam.us/us/94105", "\"San Francisco, CA\""],
-        svec!["https://api.zippopotam.us/us/92802", "\"Anaheim, CA\""],
+        svec!["http://api.zippopotam.us/us/90210", "Beverly Hills, CA"],
+        svec!["http://api.zippopotam.us/us/94105", "San Francisco, CA"],
+        svec!["https://api.zippopotam.us/us/92802", "Anaheim, CA"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
Improve JQL integration for Fetch (#77)

* added better error messaging for jql errors
* added support for multi-value selectors by concatenating them into comma separated string (e.g. "Anaheim, CA")
* added support for JSON Number types properly
* added usage examples in Fetch.md
* refactored and added unit tests for jql integration
* added integration test for multi-value jql selector
* added errors for unsupported CLI params

```
mhuang@twisted-linen:~/Projects/rust/qsv (fetch-fix-jql)$ cargo test fetch
    Finished test [optimized + debuginfo] target(s) in 0.29s
     Running unittests (target/debug/deps/qsv-018ebfd29fc3825d)

running 5 tests
test cmd::fetch::test_apply_jql_null ... ok
test cmd::fetch::test_apply_jql_bool ... ok
test cmd::fetch::test_apply_jql_array ... ok
test cmd::fetch::test_apply_jql_number ... ok
test cmd::fetch::test_apply_jql_string ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/qsvlite-51c40fd03267f4fc)

running 5 tests
test cmd::fetch::test_apply_jql_null ... ok
test cmd::fetch::test_apply_jql_bool ... ok
test cmd::fetch::test_apply_jql_number ... ok
test cmd::fetch::test_apply_jql_array ... ok
test cmd::fetch::test_apply_jql_string ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/tests.rs (target/debug/deps/tests-df10d0df673cea23)

running 4 tests
test test_fetch::fetch_jql_single ... ok
test test_fetch::fetch_jql_multiple ... ok
test test_fetch::fetch_simple ... ok
test test_fetch::fetch_ratelimit ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 616 filtered out; finished in 9.03s

```
