### PR TITLE
`--envlist` enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,18 @@ commands are not unicode-aware and will ignore unicode values when matching and 
 * `QSV_COMMENT_CHAR` - set to a comment character which will ignore any lines (including the header) that start with this character (default: comments disabled).
 * `QSV_LOG_LEVEL` - set to desired level (default - off, error, warn, info, trace, debug).
 * `QSV_LOG_DIR` - when logging is enabled, the directory where the log files will be stored. If the specified directory does not exist, qsv will attempt to create it. If not set, the log files are created in the directory where qsv was started. See [Logging](docs/Logging.md#logging) for more info.
-* `QSV_NO_UPDATE` - prohibit self-update version check of the latest qsv release published on GitHub.
+* `QSV_NO_UPDATE` - prohibit self-update version check for the latest qsv release published on GitHub.
 
-> **NOTE:** To get a list of all environment variables with the `QSV_` prefix, run `qsv --envlist`.
+Several dependencies also have environment variables that influence qsv's performance & behavior:
+
+* Memory Management ([mimalloc](https://docs.rs/mimalloc/latest/mimalloc/))   
+  When incorporating qsv into a data pipeline that runs in batch mode, particularly with very large CSV files using qsv commands that load entire CSV files into memory, you can 
+  [fine-tune Mimalloc's behavior using its environment variables](https://github.com/microsoft/mimalloc#environment-options).
+* Network Access ([reqwest](https://docs.rs/reqwest/latest/reqwest/))   
+  qsv uses reqwest for its `fetch` and `--update` functions and will honor [proxy settings](https://docs.rs/reqwest/latest/reqwest/index.html#proxies) set through `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.
+  
+
+> **NOTE:** To get a list of all qsv-relevant environment variables, run `qsv --envlist`.
 
 Feature Flags
 -------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ Usage:
 
 Options:
     --list               List all commands available.
-    --envlist            List all environment variables with the QSV_ prefix.
+    --envlist            List all qsv-relevant environment variables.
     -u, --update         Update qsv to the latest release from GitHub.
     --skip-update-check  Skip automatic update check.
     -h, --help           Display this message

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -94,7 +94,7 @@ Usage:
 
 Options:
     --list               List all commands available.
-    --envlist            List all environment variables with the QSV_ prefix.
+    --envlist            List all qsv-relevant environment variables.
     -u, --update         Update qsv to the latest release from GitHub.
     --skip-update-check  Skip automatic update check.
     -h, --help           Display this message

--- a/src/util.rs
+++ b/src/util.rs
@@ -100,17 +100,22 @@ pub fn version() -> String {
     }
 }
 
+const OTHER_ENV_VARS: &[&str] = &["no_proxy", "http_proxy", "https_proxy"];
+
 pub fn show_env_vars() {
     let mut env_var_set = false;
     for (n, v) in env::vars_os() {
         let env_var = n.into_string().unwrap();
-        if env_var.starts_with("QSV_") {
+        if env_var.starts_with("QSV_")
+            || env_var.starts_with("MIMALLOC_")
+            || OTHER_ENV_VARS.contains(&env_var.to_lowercase().as_str())
+        {
             env_var_set = true;
             println!("{}: {}", env_var, v.into_string().unwrap());
         }
     }
     if !env_var_set {
-        println!("No QSV_ environment variables set.");
+        println!("No qsv-relevant environment variables set.");
     }
 }
 

--- a/tests/test_comments.rs
+++ b/tests/test_comments.rs
@@ -140,3 +140,23 @@ fn comments_headers() {
 2   column2";
     assert_eq!(got, expected);
 }
+
+#[test]
+fn envlist() {
+    let wrk = Workdir::new("comments");
+    let mut cmd = wrk.command("");
+    cmd.env("QSV_ENVVAR", "#");
+    cmd.env("MIMALLOC_ENVVAR", "1");
+    cmd.arg("--envlist");
+
+    let got_envlist: String = wrk.stdout(&mut cmd);
+    assert_eq!(
+        got_envlist,
+        r#"MIMALLOC_ENVVAR: 1
+QSV_ENVVAR: #"#
+    );
+    // unset it so we don't have side effects outside tests
+    // as these env vars persists
+    cmd.env("QSV_ENVVAR", "");
+    cmd.env("MIMALLOC_ENVVAR", "");
+}

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -102,7 +102,11 @@ impl Workdir {
 
     pub fn command(&self, sub_command: &str) -> process::Command {
         let mut cmd = process::Command::new(&self.qsv_bin());
-        cmd.current_dir(&self.dir).arg(sub_command);
+        if sub_command.is_empty() {
+            cmd.current_dir(&self.dir);
+        } else {
+            cmd.current_dir(&self.dir).arg(sub_command);
+        }
         cmd
     }
 


### PR DESCRIPTION
Previously, the `--envlist` option only showed environment variables with a `QSV_` prefix.

It now also shows envvars with a `MIMALLOC_` prefix and `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` env vars if they are set. 