### PR TITLE
Fetch: enable cookies and storing error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
  "bitflags",
  "brotli2",
  "bytes 0.5.6",
- "cookie",
+ "cookie 0.14.4",
  "copyless",
  "derive_more",
  "either",
@@ -773,6 +773,33 @@ dependencies = [
  "percent-encoding",
  "time 0.2.27",
  "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.27",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3f7034c0932dc36f5bd8ec37368d971346809435824f277cb3b8299fc56167c"
+dependencies = [
+ "cookie 0.15.1",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.2.27",
+ "url",
 ]
 
 [[package]]
@@ -2231,6 +2258,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8eda7c62d9ecaafdf8b62374c006de0adf61666ae96a96ba74a37134aa4e470"
+
+[[package]]
+name = "publicsuffix"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292972edad6bbecc137ab84c5e36421a4a6c979ea31d3cc73540dd04315b33e1"
+dependencies = [
+ "byteorder",
+ "hashbrown 0.11.2",
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,6 +2329,7 @@ version = "0.28.0"
 dependencies = [
  "actix-governor",
  "actix-web",
+ "anyhow",
  "byteorder",
  "cached",
  "censor",
@@ -2568,6 +2614,8 @@ checksum = "7c4e0a76dc12a116108933f6301b95e83634e0c47b0afbed6abbaa0601e99258"
 dependencies = [
  "base64",
  "bytes 1.1.0",
+ "cookie 0.15.1",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2582,6 +2630,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite 0.2.8",
+ "proc-macro-hack",
  "rustls",
  "rustls-pemfile",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ vader_sentiment = { version = "0.1", optional = true }
 whatlang = { version = "0.12", optional = true }
 reqwest = { version = "0.11", features = [
     "blocking",
-    "json",
     "rustls-tls",
+    "cookies"
 ], default-features = false }
 jql = { version = "3", default-features = false }
 pyo3 = { version = "0.15", features = [
@@ -95,6 +95,7 @@ pyo3 = { version = "0.15", features = [
     "abi3-py37",
 ], optional = true }
 governor = "0.4"
+anyhow = "1.0"
 
 [dev-dependencies]
 quickcheck     = { version = "1", default-features = false }

--- a/docs/Fetch.md
+++ b/docs/Fetch.md
@@ -6,8 +6,8 @@ Fetch is integrated with [`jql`](https://github.com/yamafaktory/jql), with some 
 
 * Primary usecase is to retrieve simple values from API JSON response, hence selectors must result in: Number, String, Bool, or Array of such.
 * Arrays of Number, String, and Bool are concatenated into String with comma separator
-* Output may contain jql error messages
-* JSON Null becomes "null" string
+* On jql error, output is blank. To see jql error message please enable `--store-error` flag
+* JSON Null becomes `"null"` string
 * Processing aborts if jql output is still a JSON
 
 
@@ -17,51 +17,81 @@ __test.csv__
 
 ```
 Country,ZipCode,URL
+US,99999,http://api.zippopotam.us/us/99999
 US,90210,http://api.zippopotam.us/us/90210
 US,94105,http://api.zippopotam.us/us/94105
 US,92802,http://api.zippopotam.us/us/92802
 ```
 
 
-### Fetch url from 3rd column of `test.csv`, apply JQL selector, and print results
+### Fetch data via 3rd column of `test.csv`, apply JQL selector, and print results
+
+Notice that first row is blank due to api error (bad url).
 
 ```
-$ qsv fetch  3 --jql '."places"[0]."place name"' test.csv
+$ qsv fetch 3 test.csv --jql '"places"[0]."place name"'
+[00:00:00] [==================== 100% of 4 records. Cache hit ratio: 0.00% - 4 entries] (6/sec)
+""
 Beverly Hills
 San Francisco
 Anaheim
 ```
 
-### Fetch url from `URL` column of `test.csv`, apply JQL selector, and put results into new column named City
+### Fetch data via `URL` column of `test.csv`, apply JQL selector, and put results into new column named City
+
+Notice that on error, instead of blank values, error messages can be stored via `--store-error` flag.
 
 ```
-$ qsv fetch URL --new-column City --jql '."places"[0]."place name"' test.csv
-Country,ZipCode,URL,City
-US,90210,http://api.zippopotam.us/us/90210,Beverly Hills
-US,94105,http://api.zippopotam.us/us/94105,San Francisco
-US,92802,http://api.zippopotam.us/us/92802,Anaheim
+$ qsv fetch URL test.csv --jql '"places"[0]."place name"' --store-error
+[00:00:01] [==================== 100% of 4 records. Cache hit ratio: 0.00% - 4 entries] (6/sec)
+HTTP 404 - Not Found
+Beverly Hills
+San Francisco
+Anaheim
+
 ```
 
-### Fetch url from `URL` column of `test.csv`, use JQL to select multiple values, and put them into new column
+### Fetch data via `URL` column of `test.csv`, use JQL to select multiple values, and put them into new column
 
 Please note, multiple values get concatenated into a single quoted string with comma as separator.
 
 ```
 $ qsv fetch URL --new-column CityState --jql '"places"[0]."place name","places"[0]."state abbreviation"' test.csv
-[00:00:00] [==================== 100% of 3 records. Cache hit ratio: 0.00% - 3 entries] (7/sec)
+[00:00:00] [==================== 100% of 4 records. Cache hit ratio: 0.00% - 4 entries] (7/sec)
 Country,ZipCode,URL,CityState
+US,99999,http://api.zippopotam.us/us/99999,
 US,90210,http://api.zippopotam.us/us/90210,"Beverly Hills, CA"
 US,94105,http://api.zippopotam.us/us/94105,"San Francisco, CA"
 US,92802,http://api.zippopotam.us/us/92802,"Anaheim, CA"
+```
+
+### Fetch data via `URL` column of `test.csv`, with invalid jql selector
+
+```
+$ qsv fetch URL test.csv --jql '"place"[0]."place name"' 
+[00:00:01] [==================== 100% of 4 records. Cache hit ratio: 0.00% - 4 entries] (4/sec)
+""
+""
+""
+""
+
+$ qsv fetch URL test.csv --jql '"place"[0]."place name"' --store-error
+[00:00:01] [==================== 100% of 4 records. Cache hit ratio: 0.00% - 4 entries] (6/sec)
+HTTP 404 - Not Found
+"Node ""place"" not found on the parent element"
+"Node ""place"" not found on the parent element"
+"Node ""place"" not found on the parent element"
+
 ```
 
 ### Fetch with explicit rate limit set, and pipe output to a new csv
 
 ```
 $ qsv fetch URL test.csv --rate-limit 3 --jql '"places"[0]."longitude","places"[0]."latitude"' -c Coordinates > new.csv
-[00:00:01] [==================== 100% of 3 records. Cache hit ratio: 0.00% - 3 entries] (5/sec)
+[00:00:01] [==================== 100% of 4 records. Cache hit ratio: 0.00% - 4 entries] (4/sec)
 $ cat new.csv
 Country,ZipCode,URL,Coordinates
+US,99999,http://api.zippopotam.us/us/99999,
 US,90210,http://api.zippopotam.us/us/90210,"-118.4065, 34.0901"
 US,94105,http://api.zippopotam.us/us/94105,"-122.3892, 37.7864"
 US,92802,http://api.zippopotam.us/us/92802,"-117.9228, 33.8085"

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -26,10 +26,9 @@ fetch options:
     -c, --new-column <name>    Put the fetched values in a new column instead.
     --jql <selector>           Apply jql selector to API returned JSON value.
     --rate-limit <qps>         Rate Limit in Queries Per Second. [default: 5]
-    -j, --jobs <value>         Number of concurrent requests.
     --header <file>            File containing additional HTTP Request Headers. Useful for setting Authorization or overriding User Agent.
-    --store-error              On error, store HTTP error instead of blank value.
-    --cookies                  Automatically store and send cookies. Useful for authenticated sessions.
+    --store-error              On error, store error code/message instead of blank value.
+    --cookies                  Allow cookies.
 
 Common options:
     -h, --help                 Display this message
@@ -47,7 +46,6 @@ Common options:
 struct Args {
     flag_new_column: Option<String>,
     flag_jql: Option<String>,
-    flag_jobs: Option<u8>,
     flag_rate_limit: Option<u32>,
     flag_header: Option<String>,
     flag_store_error: bool,
@@ -75,11 +73,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             input: {:?}, 
             new column: {:?}, 
             jql: {:?},
-            threads: {:?},
             rate limit: {:?},
             http header file: {:?},
             store error: {:?},
-            store cookie: {:?},
+            cookies: {:?},
             output: {:?}, 
             no_header: {:?}, 
             delimiter: {:?}, 
@@ -88,7 +85,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         (&args.arg_input).clone().unwrap(),
         &args.flag_new_column,
         &args.flag_jql,
-        &args.flag_jobs,
         &args.flag_rate_limit,
         &args.flag_header,
         &args.flag_store_error,
@@ -99,16 +95,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         &args.flag_quiet
     );
 
-    if let Some(_jobs) = args.flag_jobs {
-        panic!("Param not yet supported: jobs")
-    }
-
-    if let Some(_header) = args.flag_header {
+    if let Some(_header) = &args.flag_header {
         panic!("Param not yet supported: header")
-    }
-
-    if args.flag_cookies {
-        panic!("Param not yet supported: cookies")
     }
 
     let rconfig = Config::new(&args.arg_input)
@@ -143,6 +131,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     use reqwest::blocking::Client;
     let client = Client::builder()
         .user_agent(DEFAULT_USER_AGENT)
+        .cookie_store(args.flag_cookies)
         .build()
         .unwrap();
 
@@ -152,7 +141,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut include_existing_columns = false;
 
-    if let Some(name) = &args.flag_new_column {
+    if let Some(name) = args.flag_new_column {
         include_existing_columns = true;
 
         // write header with new column
@@ -182,7 +171,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let url = String::from_utf8_lossy(&selected_col_value).to_string();
         debug!("Fetching URL: {:?}", &url);
 
-        let final_value = get_cached_response(&url, &client, &limiter, &args.flag_jql);
+        let final_value = get_cached_response(&url, &client, &limiter, &args.flag_jql, args.flag_store_error);
 
         if include_existing_columns {
             record.push_field(final_value.as_bytes());
@@ -231,6 +220,7 @@ fn get_cached_response(
     client: &reqwest::blocking::Client,
     limiter: &governor::RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>,
     flag_jql: &Option<String>,
+    flag_store_error: bool,
 ) -> String {
 
     // wait until RateLimiter gives Okay
@@ -238,22 +228,60 @@ fn get_cached_response(
         thread::sleep(time::Duration::from_millis(10));
     };
 
-    let resp = client.get(url).send().unwrap();
-    debug!("response: {:?}", &resp);
-    let api_value = resp.text().unwrap();
-    debug!("api value: {:?}", &api_value);
+    let resp: reqwest::blocking::Response;
 
-    let final_value;
-
-    // apply JQL selector if provided
-    if let Some(selectors) = flag_jql {
-        final_value = apply_jql(&api_value, selectors);
-        
-    } else {
-        final_value = api_value;
+    match client.get(url).send() {
+        Ok(response) => {
+            resp = response;
+        },
+        Err(error) => {
+            error!("Cannot fetch url: {:?}, error: {:?}", url, error);
+            if flag_store_error {
+                return error.to_string();
+            } else {
+                return String::default();
+            }
+        }
     }
-    
-    debug!("final value: {:?}", &final_value);
+    debug!("response: {:?}", &resp);
+
+
+    let api_status = resp.status();
+    let api_value: String = resp.text().unwrap().to_string();
+    debug!("api value: {}", &api_value);
+
+    let final_value: String;
+
+    if api_status.is_client_error() || api_status.is_server_error() {
+        if flag_store_error {
+            final_value = format!("HTTP {} - {}", 
+                                    api_status.as_str(), 
+                                    api_status.canonical_reason().unwrap_or("unknown error")
+                                );
+        } else {
+            final_value = String::default();
+        }
+    } else {
+        // apply JQL selector if provided
+        if let Some(selectors) = flag_jql {
+            match apply_jql(&api_value, selectors) {
+                Ok(s) => {
+                    final_value = s;
+                },
+                Err(e) => {
+                    if flag_store_error {
+                        final_value = e.to_string();
+                    } else {
+                        final_value = String::default();
+                    }
+                }
+            }
+        } else {
+            final_value = api_value;
+        }
+    }
+
+    debug!("final value: {}", &final_value);
 
     final_value
 }
@@ -261,20 +289,23 @@ fn get_cached_response(
 use jql::walker;
 use serde_json::{Deserializer, Value};
 
-fn apply_jql(json: &str, selectors: &str) -> String {
-    let mut return_val: String = String::default();
+use anyhow::{Result,anyhow};
 
-    // panic here since api did not return valid JSON and cannot apply JQL selector
+fn apply_jql(json: &str, selectors: &str) -> Result<String> {
+
+    // check if api returned valid JSON before applying JQL selector
     if let Err(error) = serde_json::from_str::<Value>(json) {
-        error!("API response is not valid JSON, cannot apply jql selector. error={:?}, api response={:?}.", &error, json);
-        panic!("API response is not valid JSON, cannot apply jql selector. error={:?}, api response={:?}.", &error, json);
+        warn!("API response is not valid JSON, cannot apply jql selector. error={:?}, api response={:?}.", &error, json);
+        return Err(anyhow!("Cannot apply jql to invalid json"));
     }
+
+    let mut result: Result<String> = Ok(String::default());
 
     Deserializer::from_str(json)
         .into_iter::<Value>()
         .for_each(|value| match value {
             Ok(valid_json) => {
-                
+
                 // Walk through the JSON content with the provided selectors as
                 // input.
                 match walker(&valid_json, Some(selectors)) {
@@ -299,7 +330,6 @@ fn apply_jql(json: &str, selectors: &str) -> String {
                         }
 
                         match &selection {
-
                             Value::Array(array) => {
                                 let mut concat_string = String::new();
 
@@ -316,30 +346,42 @@ fn apply_jql(json: &str, selectors: &str) -> String {
                                     concat_string.push_str(&str_val);
                                 }
 
-                                return_val = concat_string;
+                                result = Ok(concat_string);
                             },
                             Value::Object(object) => {
-                                panic!("Unsupported jql result type: OBJECT {:?}", object);
+                                warn!("Unsupported jql result type: OBJECT {:?}", object);
+                                result = Err(anyhow!("Unsupported jql result type: OBJECT"));
                             },
                             _ => {
-                                return_val = get_value_string(&selection);
+                                result = Ok(get_value_string(&selection));
                             }
                         }
 
                     }
                     Err(error) => {
                         warn!("JQL error: {}", &error);
-                        return_val = error;
+                        result = Err(anyhow!(error));
                     }
                 }
             },
             Err(error) => {
-                error!("API response is not valid JSON, cannot apply jql selector. error={:?}, api response={:?}.", &error, &json);
-                panic!("API response is not valid JSON, cannot apply jql selector. error={:?}, api response={:?}.", &error, &json);
+                // shouldn't happen, but do same thing earlier when checking for invalid json
+                warn!("API response is not valid JSON, cannot apply jql selector. error={:?}, api response={:?}.", &error, json);
+                result = Err(anyhow!("Cannot apply jql to invalid json"));
             }
         });
 
-    return_val
+    result
+}
+
+#[test]
+fn test_apply_jql_invalid_json() {
+    let json = r#"<!doctype html><html lang="en"><meta charset=utf-8><title>shortest html5</title>"#;
+    let selectors = r#"."places"[0]."place name""#;
+
+    let value: String = apply_jql(json, selectors).unwrap_err().to_string();
+
+    assert_eq!("Cannot apply jql to invalid json", value);
 }
 
 #[test]
@@ -347,7 +389,7 @@ fn test_apply_jql_string() {
     let json = r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#;
     let selectors = r#"."places"[0]."place name""#;
 
-    let value: String = apply_jql(json, selectors);
+    let value: String = apply_jql(json, selectors).unwrap();
 
     assert_eq!("Beverly Hills", value);
 }
@@ -357,7 +399,7 @@ fn test_apply_jql_number() {
     let json = r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": -118.4065, "state": "California", "state abbreviation": "CA", "latitude": 34.0901}]}"#;
     let selectors = r#"."places"[0]."longitude""#;
 
-    let value: String = apply_jql(json, selectors);
+    let value: String = apply_jql(json, selectors).unwrap();
 
     assert_eq!("-118.4065", value);
 }
@@ -367,7 +409,7 @@ fn test_apply_jql_bool() {
     let json = r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": -118.4065, "state": "California", "state abbreviation": "CA", "latitude": 34.0901, "expensive": true}]}"#;
     let selectors = r#"."places"[0]."expensive""#;
 
-    let value: String = apply_jql(json, selectors);
+    let value: String = apply_jql(json, selectors).unwrap();
 
     assert_eq!(true.to_string(), value);
 }
@@ -377,7 +419,7 @@ fn test_apply_jql_null() {
     let json = r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": -118.4065, "state": "California", "state abbreviation": "CA", "latitude": 34.0901, "university":null}]}"#;
     let selectors = r#"."places"[0]."university""#;
 
-    let value: String = apply_jql(json, selectors);
+    let value: String = apply_jql(json, selectors).unwrap();
 
     assert_eq!("null".to_string(), value);
 }
@@ -387,7 +429,7 @@ fn test_apply_jql_array() {
     let json = r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": -118.4065, "state": "California", "state abbreviation": "CA", "latitude": 34.0901}]}"#;
     let selectors = r#"."places"[0]."longitude",."places"[0]."latitude""#;
 
-    let value: String = apply_jql(json, selectors);
+    let value: String = apply_jql(json, selectors).unwrap();
 
     assert_eq!("-118.4065, 34.0901".to_string(), value);
 }

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -385,6 +385,16 @@ fn test_apply_jql_invalid_json() {
 }
 
 #[test]
+fn test_apply_jql_invalid_selector() {
+    let json = r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#;
+    let selectors = r#"."place"[0]."place name""#;
+
+    let value = apply_jql(json, selectors).unwrap_err().to_string();
+
+    assert_eq!("Node \"place\" not found on the parent element", value);
+}
+
+#[test]
 fn test_apply_jql_string() {
     let json = r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#;
     let selectors = r#"."places"[0]."place name""#;

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -124,7 +124,7 @@ async fn index() -> impl Responder {
 }
 
 /// handler with path parameters like `/user/{name}/`
-/// returns Smurf fullname
+/// returns Smurf fullname in JSON format
 async fn get_fullname(
     req: HttpRequest,
     web::Path((name,)): web::Path<(String,)>,
@@ -145,9 +145,9 @@ fn run_webserver(tx: mpsc::Sender<Server>) -> std::io::Result<()> {
     use actix_governor::{Governor, GovernorConfig, GovernorConfigBuilder};
 
     // Allow bursts with up to five requests per IP address
-    // and replenishes one element every 500 ms (2 qps)
+    // and replenishes one element every 250 ms (4 qps)
     let governor_conf: GovernorConfig = GovernorConfigBuilder::default()
-        .per_millisecond(500)
+        .per_millisecond(250)
         .burst_size(5)
         .finish()
         .unwrap();
@@ -218,7 +218,7 @@ fn fetch_ratelimit() {
         .arg("--jql")
         .arg(r#"."fullname""#)
         .arg("--rate-limit")
-        .arg("2")
+        .arg("4")
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -7,6 +7,7 @@ fn fetch_simple() {
         "data.csv",
         vec![
             svec!["URL"],
+            svec!["https://api.zippopotam.us/us/99999"],
             svec!["http://api.zippopotam.us/us/90210"],
             svec!["https://api.zippopotam.us/us/94105"],
             svec!["http://api.zippopotam.us/us/92802"],
@@ -14,10 +15,15 @@ fn fetch_simple() {
         ],
     );
     let mut cmd = wrk.command("fetch");
-    cmd.arg("URL").arg("data.csv");
+    cmd.arg("URL")
+        .arg("data.csv")
+        .arg("--store-error");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
+        svec![
+            r#"HTTP 404 - Not Found"#
+        ],
         svec![
             r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#
         ],


### PR DESCRIPTION
* Add implementation, tests, and docs for `--store-error` flag.
* Support `--cookies` flag.
* Remove `--jobs` param since single-thread may be fast enough for most usecases.
* Update examples in Fetch.md


