### PR TITLE
Fetch: support custom http headers

### DIFF
--- a/docs/Fetch.md
+++ b/docs/Fetch.md
@@ -121,3 +121,31 @@ US,94105,http://api.zippopotam.us/us/94105,"-122.3892, 37.7864"
 US,92802,http://api.zippopotam.us/us/92802,"-117.9228, 33.8085"
 ```
 
+### Fetch using custom headers for api key
+
+```
+$ cat test5.csv
+URL
+http://httpbin.org/get
+
+$ qsv fetch URL test5.csv --jql '"headers"."X-Api-Key","headers"."X-Api-Secret"' --store-error --http-header "X-Api-Key:mykey" --http-header "X-Api-Secret  : nottelling"
+[00:00:00] [==================== 100% of 1 records. Cache hit ratio: 0.00% - 1 entries] (1,151/sec)
+"mykey, nottelling"
+
+$ qsv fetch URL test5.csv --store-error --http-header "X-Api-Key:mykey" --http-header "X-Api-Secret  : nottelling"
+[00:00:00] [==================== 100% of 1 records. Cache hit ratio: 0.00% - 1 entries] (1,105/sec)
+"{
+  ""args"": {}, 
+  ""headers"": {
+    ""Accept"": ""*/*"", 
+    ""Host"": ""httpbin.org"", 
+    ""User-Agent"": ""qsv/0.28.0 (https://github.com/jqnatividad/qsv)"", 
+    ""X-Amzn-Trace-Id"": ""Root=1-61d8d957-054da2374e304c7c7395cacc"", 
+    ""X-Api-Key"": ""mykey"", 
+    ""X-Api-Secret"": ""nottelling""
+  }, 
+  ""origin"": ""1.163.34.120"", 
+  ""url"": ""http://httpbin.org/get""
+}
+"
+```

--- a/docs/Fetch.md
+++ b/docs/Fetch.md
@@ -86,6 +86,28 @@ HTTP 404 - Not Found
 
 ```
 
+### Fetch with debug trace enabled to see problem with extra whitespace in URL column
+
+Note: if URL is quoted, then there cannot be extra whitespace before quotes
+
+```
+$ cat test4.csv 
+City,URL
+Beverley Hills, http://geodb-free-service.wirefreethought.com/v1/geo/locations/+34.0901-118.4065/nearbyCities
+San Francisco, "http://geodb-free-service.wirefreethought.com/v1/geo/locations/+37.7864-122.3892/nearbyCities"
+Anaheim," http://geodb-free-service.wirefreethought.com/v1/geo/locations/+33.8085-117.9228/nearbyCities"
+
+$ QSV_LOG_LEVEL=debug qsv fetch URL test4.csv  --store-error --jql '"data".[0]."name","data".[1]."name","data".[2]."name"' 
+[00:00:01] [==================== 100% of 3 records. Cache hit ratio: 0.00% - 3 entries] (7/sec)
+"Universal City, Hollywood, Sherman Oaks"
+builder error: relative URL without a base
+"Anaheim, Garden Grove, Fullerton"
+
+$ grep ERROR qsv_rCURRENT.log | tail -1
+[2022-01-06 20:55:49.814944 +08:00] ERROR [qsv::cmd::fetch] src/cmd/fetch.rs:238: Cannot fetch url: "\"http://geodb-free-service.wirefreethought.com/v1/geo/locations/+37.7864-122.3892/nearbyCities\"", error: reqwest::Error { kind: Builder, source: RelativeUrlWithoutBase }
+
+```
+
 ### Fetch with explicit rate limit, and pipe output to a new csv
 
 ```

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -168,7 +168,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
 
         let selected_col_value = record[column_index].to_owned();
-        let url = String::from_utf8_lossy(&selected_col_value).to_string();
+        let url = String::from_utf8_lossy(&selected_col_value).trim().to_string();
         debug!("Fetching URL: {:?}", &url);
 
         let final_value = get_cached_response(&url, &client, &limiter, &args.flag_jql, args.flag_store_error);

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -8,7 +8,7 @@ fn fetch_simple() {
         vec![
             svec!["URL"],
             svec!["https://api.zippopotam.us/us/99999"],
-            svec!["http://api.zippopotam.us/us/90210"],
+            svec!["  http://api.zippopotam.us/us/90210"],
             svec!["https://api.zippopotam.us/us/94105"],
             svec!["http://api.zippopotam.us/us/92802"],
             svec!["https://query.wikidata.org/sparql?query=SELECT%20?dob%20WHERE%20{wd:Q42%20wdt:P569%20?dob.}&format=json"],
@@ -109,6 +109,33 @@ fn fetch_jql_multiple() {
         svec!["http://api.zippopotam.us/us/90210", "Beverly Hills, CA"],
         svec!["http://api.zippopotam.us/us/94105", "San Francisco, CA"],
         svec!["https://api.zippopotam.us/us/92802", "Anaheim, CA"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn fetch_custom_header() {
+    let wrk = Workdir::new("fetch");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["URL"],
+            svec!["http://httpbin.org/get"],
+        ],
+    );
+    let mut cmd = wrk.command("fetch");
+    cmd.arg("URL")
+        .arg("--http-header")
+        .arg(" X-Api-Key :  DEMO_KEY")
+        .arg("--http-header")
+        .arg("X-Api-Secret :ABC123XYZ")
+        .arg("--jql")
+        .arg(r#""headers"."X-Api-Key","headers"."X-Api-Secret""#)
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["DEMO_KEY, ABC123XYZ"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
Support setting one or more custom http headers for fetch (#77):

* primary usecase is to set api keys. since each api requires different keys, it seems simpler to just set via args and not bother with config files for now
* to support config file, qsv should probably just have one single config file with command specific sections, and maybe even support profiles
* header format "key:value" uses ':' colon as separator
* integration test uses `http://httpbin.org/get` to confirm that custom headers are passed to server (thanks @jqnatividad for suggesting this)
* fixed bug with white space in URL column
