### PR TITLE
Fetch: upgrade to jql 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,9 +1746,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jql"
-version = "3.0.9"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94221fde71dcfdbc3a78d55245fceb0c5ee1f3ccf07094d13949f19df1fe986"
+checksum = "d91f570ea5803860cb47a216bae6c22fc1451fcd5376a11ab65c9cfc9d146239"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ jsonschema = { version = "0.15", features = [
     "resolve-file",
     "resolve-http",
 ], default-features = false }
-jql = { version = "~3.0.9", default-features = false }
+jql = { version = "3.1", default-features = false }
 log = "0.4"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 num_cpus = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ jsonschema = { version = "0.15", features = [
     "resolve-file",
     "resolve-http",
 ], default-features = false }
-jql = { version = "3.1", default-features = false }
+jql = { version = "~3.1.0", default-features = false }
 log = "0.4"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 num_cpus = "1"

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -304,7 +304,7 @@ fn apply_jql(json: &str, selectors: &str) -> Result<String> {
             Ok(valid_json) => {
                 // Walk through the JSON content with the provided selectors as
                 // input.
-                match walker(&valid_json, Some(selectors)) {
+                match walker(&valid_json, selectors) {
                     Ok(selection) => {
                         fn get_value_string(v: &Value) -> String {
                             if v.is_null() {


### PR DESCRIPTION
walk() now takes &str instead of Option<&str>

