### PR TITLE
Addl `validate` performance tweaks

### DIFF
--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -229,15 +229,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             " validated {} records.",
             progress.length().separate_with_commas()
         ));
-        util::prep_finish_progress(&progress);
+        util::finish_progress(&progress);
     }
 
     // only write out invalid/valid/errors output files if there are actually invalid records.
     // if 100% invalid, then valid file is not needed. but this is rare so live with creating empty file.
     if invalid_count > 0 {
-        if !args.flag_quiet {
-            progress.println("Writing invalid/valid/error files...");
-        }
+        let msg = "Writing invalid/valid/error files...";
+        info!("{msg}");
+        println!("{msg}");
+
         let input_path = args
             .arg_input
             .clone()
@@ -256,10 +257,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             &valid_suffix,
             &invalid_suffix,
         )?;
-    }
-
-    if !args.flag_quiet {
-        util::flush_progress(&progress);
     }
 
     // done with validation; print output

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -147,7 +147,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // reuse batch buffer
     let mut batch = Vec::with_capacity(BATCH_SIZE);
     let mut valid_flags: Vec<bool> = Vec::with_capacity(record_count as usize);
-    let mut validation_error_messages: Vec<String> = Vec::new();
+    let mut validation_error_messages: Vec<String> = Vec::with_capacity(50);
 
     // main loop to read CSV and construct batches for parallel processing.
     // each batch is processed via Rayon parallel iterator.
@@ -222,9 +222,22 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
     } // end infinite loop
 
+    use thousands::Separable;
+
+    if !args.flag_quiet {
+        progress.set_message(format!(
+            " validated {} records.",
+            progress.length().separate_with_commas()
+        ));
+        util::prep_finish_progress(&progress);
+    }
+
     // only write out invalid/valid/errors output files if there are actually invalid records.
     // if 100% invalid, then valid file is not needed. but this is rare so live with creating empty file.
     if invalid_count > 0 {
+        if !args.flag_quiet {
+            progress.println("Writing invalid/valid/error files...");
+        }
         let input_path = args
             .arg_input
             .clone()
@@ -245,14 +258,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         )?;
     }
 
-    use thousands::Separable;
-
     if !args.flag_quiet {
-        progress.set_message(format!(
-            " validated {} records.",
-            progress.length().separate_with_commas()
-        ));
-        util::finish_progress(&progress);
+        util::flush_progress(&progress);
     }
 
     // done with validation; print output
@@ -356,8 +363,9 @@ fn do_json_validation(
     schema_json: &Value,
     schema_compiled: &JSONSchema,
 ) -> CliResult<Option<String>> {
-    // row number was added as last column
-    let row_number_string = str::from_utf8(record.get(headers.len()).unwrap()).unwrap();
+    // row number was added as last column. We use unsafe from_utf8_unchecked to 
+    // skip UTF8 validation since we know its safe as we added it earlier
+    let row_number_string = unsafe { str::from_utf8_unchecked(record.get(headers.len()).unwrap()) };
     let row_number: usize = row_number_string.parse::<usize>().unwrap();
 
     let instance: Value = match to_json_instance(headers, record, schema_json) {
@@ -397,7 +405,8 @@ fn to_json_instance(headers: &ByteRecord, record: &ByteRecord, schema: &Value) -
         .expect("JSON Schema missing 'properties' object");
 
     // map holds individual CSV fields converted as serde_json::Value
-    let mut json_object_map: Map<String, Value> = Map::new();
+    // we use with_capacity to minimize allocs
+    let mut json_object_map: Map<String, Value> = Map::with_capacity(50);
 
     // iterate over each CSV field and convert to JSON type
     let headers_iter = headers.iter().enumerate();

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -363,7 +363,7 @@ fn do_json_validation(
     schema_json: &Value,
     schema_compiled: &JSONSchema,
 ) -> CliResult<Option<String>> {
-    // row number was added as last column. We use unsafe from_utf8_unchecked to 
+    // row number was added as last column. We use unsafe from_utf8_unchecked to
     // skip UTF8 validation since we know its safe as we added it earlier
     let row_number_string = unsafe { str::from_utf8_unchecked(record.get(headers.len()).unwrap()) };
     let row_number: usize = row_number_string.parse::<usize>().unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -161,30 +161,6 @@ pub fn finish_progress(progress: &ProgressBar) {
     }
 }
 
-pub fn prep_finish_progress(progress: &ProgressBar) {
-    let per_sec_rate = progress.per_sec();
-
-    let finish_template = format!(
-        "[{{elapsed_precise}}] [{{bar:20}} {{percent}}%{{msg}}] ({}/sec)",
-        per_sec_rate.separate_with_commas()
-    );
-
-    progress.set_style(
-        ProgressStyle::default_bar()
-            .template(&finish_template)
-            .progress_chars("=>-"),
-    );
-}
-
-pub fn flush_progress(progress: &ProgressBar) {
-    progress.abandon();
-
-    let per_sec_rate = progress.per_sec();
-    if log_enabled!(Level::Info) {
-        info!("Progress done... {per_sec_rate} records/sec");
-    }
-}
-
 macro_rules! update_cache_info {
     ($progress:expr, $cache_instance:expr) => {
         use cached::Cached;

--- a/src/util.rs
+++ b/src/util.rs
@@ -161,6 +161,30 @@ pub fn finish_progress(progress: &ProgressBar) {
     }
 }
 
+pub fn prep_finish_progress(progress: &ProgressBar) {
+    let per_sec_rate = progress.per_sec();
+
+    let finish_template = format!(
+        "[{{elapsed_precise}}] [{{bar:20}} {{percent}}%{{msg}}] ({}/sec)",
+        per_sec_rate.separate_with_commas()
+    );
+
+    progress.set_style(
+        ProgressStyle::default_bar()
+            .template(&finish_template)
+            .progress_chars("=>-"),
+    );
+}
+
+pub fn flush_progress(progress: &ProgressBar) {
+    progress.abandon();
+
+    let per_sec_rate = progress.per_sec();
+    if log_enabled!(Level::Info) {
+        info!("Progress done... {per_sec_rate} records/sec");
+    }
+}
+
 macro_rules! update_cache_info {
     ($progress:expr, $cache_instance:expr) => {
         use cached::Cached;


### PR DESCRIPTION
Hi @mhuang74 ,
I tweaked it a bit more and managed to squeeze a little more performance.

I also moved the progress bar preliminary finish message before writing the valid/invalid/error files as there was an appreciable delay before qsv exits if the validation job had errors.

I made it a PR as I wanted your input coz `validate` is your baby. :wink: 