### PR TITLE
`fetch`: add `--url-template` and `--redis` options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cached"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d512eceb8e40aeb03ac59aa242f652572e935d66fce998aedb6699c127adffb2"
+checksum = "a8c2f17f7be6adf37bd51e543537b0a9e51d865e94c11a421a5a3c8aafac41af"
 dependencies = [
  "async-mutex",
  "async-rwlock",
@@ -817,11 +817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
 dependencies = [
  "bytes 1.1.0",
- "futures-core",
  "memchr",
- "pin-project-lite 0.2.8",
- "tokio 1.17.0",
- "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -2712,6 +2708,7 @@ dependencies = [
  "strsim 0.10.0",
  "tabwriter",
  "test-data-generation",
+ "thiserror",
  "thousands",
  "threadpool",
  "titlecase",
@@ -2927,17 +2924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
 dependencies = [
  "async-trait",
- "bytes 1.1.0",
  "combine",
  "dtoa",
- "futures-util",
  "itoa 0.4.8",
  "percent-encoding",
- "pin-project-lite 0.2.8",
  "r2d2",
  "sha1",
- "tokio 1.17.0",
- "tokio-util 0.6.9",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ dependencies = [
  "quickcheck",
  "rand 0.8.5",
  "rayon",
+ "redis",
  "regex",
  "reqwest",
  "reverse_geocoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cached"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4dfac631a8e77b2f327f7852bb6172771f5279c4512efe79fad6067b37be3d"
+checksum = "d512eceb8e40aeb03ac59aa242f652572e935d66fce998aedb6699c127adffb2"
 dependencies = [
  "async-mutex",
  "async-rwlock",
@@ -729,13 +729,19 @@ dependencies = [
  "cached_proc_macro_types",
  "hashbrown 0.11.2",
  "once_cell",
+ "r2d2",
+ "redis",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio 1.17.0",
 ]
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725f434d6da2814b989bd905c62ca28a9383feff7440210dc279665fbbbc9511"
+checksum = "dc8de7b947777686ee8f3c11f4c3e58c296d6bc598d9b2286a80a9404a538ff8"
 dependencies = [
  "cached_proc_macro_types",
  "darling",
@@ -802,6 +808,20 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "memchr",
+ "pin-project-lite 0.2.8",
+ "tokio 1.17.0",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -1118,6 +1138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1553,6 +1579,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -2767,6 +2799,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot 0.11.2",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +2918,27 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "redis"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
+dependencies = [
+ "async-trait",
+ "bytes 1.1.0",
+ "combine",
+ "dtoa",
+ "futures-util",
+ "itoa 0.4.8",
+ "percent-encoding",
+ "pin-project-lite 0.2.8",
+ "r2d2",
+ "sha1",
+ "tokio 1.17.0",
+ "tokio-util 0.6.9",
+ "url",
 ]
 
 [[package]]
@@ -3053,6 +3117,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot 0.11.2",
+]
 
 [[package]]
 name = "scopeguard"
@@ -3368,7 +3441,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3608,7 +3681,19 @@ dependencies = [
  "num_cpus",
  "pin-project-lite 0.2.8",
  "socket2 0.4.4",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ jsonschema = { version = "0.15", features = [
 jql = { version = "3.1", default-features = false }
 log = "0.4"
 mimalloc = { version = "0.1", default-features = false, optional = true }
-once_cell = { version = "1.9", optional = true }
+once_cell = "1.9"
 pyo3 = { version = "0.15", features = [
     "abi3-py38",
     "auto-initialize",
@@ -109,6 +109,7 @@ actix-governor   = "0.2"
 actix-web        = "3.3"
 assert-json-diff = "2.0"
 quickcheck       = { version = "1", default-features = false }
+redis            = "0.21"
 
 [features]
 default = ["mimalloc"]
@@ -116,7 +117,6 @@ apply = [
     "censor",
     "chrono",
     "eudex",
-    "once_cell",
     "qsv_currency",
     "reverse_geocoder",
     "strsim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ serde_json = "1.0"
 strsim = { version = "0.10", optional = true }
 tabwriter = "1.2"
 test-data-generation = { version = "0.3", optional = true }
+thiserror = "1.0"
 thousands = "0.2"
 threadpool = "1.8"
 titlecase = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,7 @@ opt-level = 3
 [dependencies]
 anyhow = "1.0"
 byteorder = "1.4"
-cached = { version = "0.30", default-features = false, features = [
-    "proc_macro",
-] }
+cached = { version = "0.32", features = ["redis_store"] }
 censor = { version = "0.2", optional = true }
 chrono = { version = "0.4", optional = true }
 crossbeam-channel = "0.5"

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -3,9 +3,11 @@ use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
 use cached::proc_macro::{cached, io_cached};
+use cached::RedisCache;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use log::{debug, error};
 use serde::Deserialize;
+use thiserror::Error;
 
 static USAGE: &str = "
 Fetch data via a URL column, and optionally store them in a new column.

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -50,6 +50,100 @@ fn fetch_simple() {
 }
 
 #[test]
+fn fetch_url_template() {
+    let wrk = Workdir::new("fetch");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["zipcode"],
+            svec!["99999"],
+            svec!["  90210   "],
+            svec!["94105  "],
+            svec!["92802"],
+        ],
+    );
+    let mut cmd = wrk.command("fetch");
+    cmd.arg("zipcode")
+        .arg("data.csv")
+        .arg("--store-error")
+        .arg("--url-template")
+        .arg("https://api.zippopotam.us/us/^");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![r#"HTTP 404 - Not Found"#],
+        svec![
+            r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#
+        ],
+        svec![
+            r#"{"post code": "94105", "country": "United States", "country abbreviation": "US", "places": [{"place name": "San Francisco", "longitude": "-122.3892", "state": "California", "state abbreviation": "CA", "latitude": "37.7864"}]}"#
+        ],
+        svec![
+            r#"{"post code": "92802", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Anaheim", "longitude": "-117.9228", "state": "California", "state abbreviation": "CA", "latitude": "33.8085"}]}"#
+        ],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn fetch_simple_redis() {
+    // if there is no local redis server, skip fetch_simple_redis test
+    let redis_client = redis::Client::open("redis://127.0.0.1:6379").unwrap();
+    if let Err(_) = redis_client.get_connection() {
+        return;
+    }
+
+    let wrk = Workdir::new("fetch");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["URL"],
+            svec!["https://api.zippopotam.us/us/99999"],
+            svec!["  http://api.zippopotam.us/us/90210"],
+            svec!["https://api.zippopotam.us/us/94105"],
+            svec!["http://api.zippopotam.us/us/92802"],
+            svec!["https://query.wikidata.org/sparql?query=SELECT%20?dob%20WHERE%20{wd:Q42%20wdt:P569%20?dob.}&format=json"],
+        ],
+    );
+    let mut cmd = wrk.command("fetch");
+    cmd.arg("URL")
+        .arg("data.csv")
+        .arg("--store-error")
+        .arg("--redis");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![r#"HTTP 404 - Not Found"#],
+        svec![
+            r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#
+        ],
+        svec![
+            r#"{"post code": "94105", "country": "United States", "country abbreviation": "US", "places": [{"place name": "San Francisco", "longitude": "-122.3892", "state": "California", "state abbreviation": "CA", "latitude": "37.7864"}]}"#
+        ],
+        svec![
+            r#"{"post code": "92802", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Anaheim", "longitude": "-117.9228", "state": "California", "state abbreviation": "CA", "latitude": "33.8085"}]}"#
+        ],
+        svec![
+            r#"{
+  "head" : {
+    "vars" : [ "dob" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "dob" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1952-03-11T00:00:00Z"
+      }
+    } ]
+  }
+}"#
+        ],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn fetch_jql_single() {
     let wrk = Workdir::new("fetch");
     wrk.create(


### PR DESCRIPTION
- `url-template` allows users to construct the URL to use with fetch dynamically
- allow the use of redis as a persistent cache store