### PR TITLE
`py`: convert spaces to underscores for valid python variable names

### DIFF
--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -43,7 +43,8 @@ Create a new column, filter rows or compute aggregations by evaluating a python
 expression on every row of a CSV file.
 
 The executed Python has 4 ways to reference cell values (as strings):
-  1. Directly by using column name (e.g. amount) as a local variable
+  1. Directly by using column name (e.g. amount) as a local variable. If a column
+     name has spaces, they are replaced with underscores (e.g. "unit cost" -> unit_cost)
   2. Indexing cell value by column name as an attribute: row.amount
   3. Indexing cell value by column name as a key: row["amount"]
   4. Indexing cell value by column position: row[0]
@@ -58,9 +59,9 @@ Some usage examples:
   $ qsv py map c "int(col.a) + int(col['b'])"
   $ qsv py map c "int(col[0]) + int(col[1])"
 
-  Use Python f-strings to calculate using multiple columns (qty, fruit & unitcost) 
+  Use Python f-strings to calculate using multiple columns (qty, fruit & "unit cost") 
     and format into a new column 'formatted'
-  $ qsv py map formatted "f'{qty} {fruit} cost ${(float(unitcost) * float(qty)):.2f}'"
+  $ qsv py map formatted "f'{qty} {fruit} cost ${(float(unit_cost) * float(qty)):.2f}'"
 
   Strip and prefix cell values
   $ qsv py map prefixed "'clean_' + a.strip()"
@@ -194,7 +195,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         for (i, h) in headers.iter().take(headers_len).enumerate() {
             let cell_value = record.get(i).unwrap();
-            locals.set_item(h, cell_value)?;
+            locals.set_item(h.replace(" ", "_"), cell_value)?;
             row_data.push(cell_value);
         }
 

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -377,3 +377,31 @@ fn py_format() {
     ];
     assert_eq!(got, expected);
 }
+
+#[test]
+fn py_format_header_with_spaces() {
+    let wrk = Workdir::new("py");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["qty", "fruit", "unit cost usd"],
+            svec!["20.5", "mangoes", "5"],
+            svec!["10", "bananas", "20"],
+            svec!["3", "strawberries", "3.50"],
+        ],
+    );
+    let mut cmd = wrk.command("py");
+    cmd.arg("map")
+        .arg("formatted")
+        .arg("f'{qty} {fruit} cost ${(float(unit_cost_usd) * float(qty)):.2f}'")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["qty", "fruit", "unit cost usd", "formatted"],
+        svec!["20.5", "mangoes", "5", "20.5 mangoes cost $102.50"],
+        svec!["10", "bananas", "20", "10 bananas cost $200.00"],
+        svec!["3", "strawberries", "3.50", "3 strawberries cost $10.50"],
+    ];
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
fixes #182