### PR TITLE
Utf8 transcoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,6 +2674,7 @@ dependencies = [
  "csv-index",
  "dateparser",
  "docopt",
+ "encoding_rs_io",
  "eudex",
  "filetime",
  "flexi_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ csv = "1.1"
 csv-index = "0.1"
 dateparser = "0.1"
 docopt = "1"
+encoding_rs_io = "0.1"
 eudex = { version = "0.1", optional = true }
 filetime = "0.2"
 flexi_logger = { version = "0.22", features = ["compress"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::io::{self, Read};
 use std::ops::Deref;
 use std::path::PathBuf;
 
+use encoding_rs_io::DecodeReaderBytes;
 use serde::de::{Deserialize, Deserializer, Error};
 
 use crate::index::Indexed;
@@ -298,7 +299,10 @@ impl Config {
         Ok(match self.path {
             None => Box::new(io::stdin()),
             Some(ref p) => match fs::File::open(p) {
-                Ok(x) => Box::new(x),
+                Ok(x) => {
+                    let transcoded = DecodeReaderBytes::new(x);
+                    Box::new(transcoded)
+                }
                 Err(err) => {
                     let msg = format!("failed to open {}: {}", p.display(), err);
                     return Err(io::Error::new(io::ErrorKind::NotFound, msg));


### PR DESCRIPTION
Resolves #179.

We don't need to do the tab workaround, with encoding_rs_io, "it just works!"

That is, the input file is always transcoded to utf8 if requried.