### PR TITLE
`stats`: refactor for performance 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,7 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
+ "smartstring",
  "strsim 0.10.0",
  "tabwriter",
  "test-data-generation",
@@ -2941,6 +2942,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "smartstring"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea958ad90cacc8ece7f238fde3671e1b350ee1741964edf2a22fd16f60224163"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +2974,12 @@ checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ self_update = { version = "0.28", features = [
 ], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+smartstring = "1"
 strsim = { version = "0.10", optional = true }
 tabwriter = "1.2"
 test-data-generation = { version = "0.3", optional = true }


### PR DESCRIPTION
- skip utf8 validation as we automatically transcode to utf8 all input
- use smartstring
- short-circuit computing quartiles and median if not applicable to field type
- expand docopt usage text to indicate which stats are expensive