### PR TITLE
`fetch`: expanded --url-template capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "fdbfe11fe19ff083c48923cf179540e8cd0535903dc35e178a1fdeeb59aef51f"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -820,10 +820,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -833,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -843,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -1018,6 +1019,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
+name = "dynfmt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c298552016db86f0d49e5de09818dd86c536f66095013cc415f4f85744033f"
+dependencies = [
+ "erased-serde",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1060,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
 dependencies = [
  "encoding_rs",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2293,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00e5e97bb258ac0fcea67da5e845aae5f7e6fb4f723ec94a503a6d0a541ccb7"
+checksum = "a378727d5fdcaafd15b5afe9842cff1c25fdc43f62a162ffda2263c57ad98703"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -2309,18 +2333,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61cb87bf5c9503fa0e7f38bcd311b31993328a5e29f3507dfbf763c8ccd37f4"
+checksum = "4fbb27a3e96edd34c13d97d0feefccc90a79270c577c66e19d95af8323823dfc"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd4b0b76ae07ca5a7b0527a75afc9f47744d14f4f3576bdf66a9a2420b5c54d"
+checksum = "7b719fff844bcf3f911132112ec06527eb195f6a98e0c42cf97e1118929fd4ea"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2328,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a845f73eda2aa27d35b3840e2c6f0c9447347cdb49954552f09ae7b1f432a3d9"
+checksum = "f795e52d3320abb349ca28b501a7112154a87f353fae1c811deecd58e99cfa9b"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2340,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e72ef79ca96c2dcb66d9b22f149400ac6c6b32ab468398ebbcb145d72f80c00"
+checksum = "39e03aa57a3bb7b96982958088df38302a139df4eef54671bc595f26556cb75b"
 dependencies = [
  "proc-macro2",
  "pyo3-build-config",
@@ -2368,6 +2392,7 @@ dependencies = [
  "csv-index",
  "dateparser",
  "docopt",
+ "dynfmt",
  "encoding_rs_io",
  "eudex",
  "filetime",
@@ -3068,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59d925cf59d8151f25a3bedf97c9c157597c9df7324d32d68991cc399ed08b"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ csv = "1.1"
 csv-index = "0.1"
 dateparser = "0.1"
 docopt = "1"
+dynfmt = { version = "0.1", features = ["curly"]}
 encoding_rs_io = "0.1"
 eudex = { version = "0.1", optional = true }
 filetime = "0.2"

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -8,8 +8,6 @@ use crate::util;
 use crate::CliError;
 use crate::CliResult;
 use indicatif::{ProgressBar, ProgressDrawTarget};
-use log::debug;
-use regex::Regex;
 use serde::Deserialize;
 
 const HELPERS: &str = r#"
@@ -185,19 +183,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         progress.set_draw_target(ProgressDrawTarget::hidden());
     }
 
-    // initialize valid local python variable names from header column names
-    // replace invalid chars with _. If name starts with a number,
-    // replace it with an _ as well
-    let re = Regex::new(r"[^A-Za-z0-9]").unwrap();
-    let mut header_vec: Vec<String> = Vec::with_capacity(headers_len);
-    for (_i, h) in headers.iter().take(headers_len).enumerate() {
-        let mut python_var_name = re.replace_all(h, "_").to_string();
-        if python_var_name.as_bytes()[0].is_ascii_digit() {
-            python_var_name.replace_range(0..1, "_");
-        }
-        header_vec.push(python_var_name);
-    }
-    debug!("python local var names: {header_vec:?}");
+    let header_vec = util::safe_header_names(headers);
 
     let mut record = csv::StringRecord::new();
     while rdr.read_record(&mut record)? {

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -55,7 +55,7 @@ fn fetch_url_template() {
     wrk.create(
         "data.csv",
         vec![
-            svec!["zipcode"],
+            svec!["zip code"],
             svec!["99999"],
             svec!["  90210   "],
             svec!["94105  "],
@@ -63,11 +63,11 @@ fn fetch_url_template() {
         ],
     );
     let mut cmd = wrk.command("fetch");
-    cmd.arg("zipcode")
+    cmd.arg("1")
         .arg("data.csv")
         .arg("--store-error")
         .arg("--url-template")
-        .arg("https://api.zippopotam.us/us/^");
+        .arg("https://api.zippopotam.us/us/{zip_code}");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -302,7 +302,7 @@ fn fetch_ratelimit() {
     // start webserver with rate limiting
     let (tx, rx) = mpsc::channel();
 
-    // println!("START Webserver ");
+    println!("START Webserver ");
     thread::spawn(move || {
         let server_future = run_webserver(tx);
         rt::System::new().block_on(server_future)
@@ -375,7 +375,6 @@ fn fetch_ratelimit() {
     assert_eq!(got, expected);
 
     // init stop webserver and wait until server gracefully exit
-    // println!("STOPPING Webserver");
-    // rt::System::new().block_on(srv.stop(true));
+    println!("STOPPING Webserver");
     rt::System::new().block_on(server_handle.stop(true));
 }


### PR DESCRIPTION
can now use replaceable parameters using multiple columns with format!-like capability. 

No longer limited to one column.