### PR TITLE
`fetch`: url template tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
@@ -2077,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c539a50b93a303167eded6e8dff5220cd39447409fb659f4cd24b1f72fe4f133"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -2489,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2",
 ]

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -183,7 +183,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         progress.set_draw_target(ProgressDrawTarget::hidden());
     }
 
-    let header_vec = util::safe_header_names(headers);
+    let header_vec = util::safe_header_names(headers, true);
 
     let mut record = csv::StringRecord::new();
     while rdr.read_record(&mut record)? {

--- a/src/util.rs
+++ b/src/util.rs
@@ -475,7 +475,7 @@ pub fn qsv_check_for_update(bin_name: &str) {
     };
 }
 
-pub fn safe_header_names(headers: csv::StringRecord) -> Vec<String> {
+pub fn safe_header_names(headers: csv::StringRecord, check_first_char: bool ) -> Vec<String> {
     // Create "safe" var/key names
     // Replace whitespace/invalid chars with _.
     // If name starts with a number, replace it with an _ as well
@@ -483,7 +483,7 @@ pub fn safe_header_names(headers: csv::StringRecord) -> Vec<String> {
     let mut header_vec: Vec<String> = Vec::with_capacity(headers.len());
     for (_i, h) in headers.iter().take(headers.len()).enumerate() {
         let mut python_var_name = re.replace_all(h, "_").to_string();
-        if python_var_name.as_bytes()[0].is_ascii_digit() {
+        if check_first_char && python_var_name.as_bytes()[0].is_ascii_digit() {
             python_var_name.replace_range(0..1, "_");
         }
         header_vec.push(python_var_name);

--- a/src/util.rs
+++ b/src/util.rs
@@ -475,7 +475,7 @@ pub fn qsv_check_for_update(bin_name: &str) {
     };
 }
 
-pub fn safe_header_names(headers: csv::StringRecord, check_first_char: bool ) -> Vec<String> {
+pub fn safe_header_names(headers: csv::StringRecord, check_first_char: bool) -> Vec<String> {
     // Create "safe" var/key names
     // Replace whitespace/invalid chars with _.
     // If name starts with a number, replace it with an _ as well


### PR DESCRIPTION
- when using the --url-template option, users can use a "safe" version of the column names (alphanumeric, everything else converted to underscore)
- url-template requires header column names. fail! if the --no-headers option is on
- expanded docopt usage text/examples
- updated util::safe_header_names fn to only check_first_digit_char for `py` command. 