### PR TITLE
`fetch`: prettify minify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,6 +1318,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1672,16 @@ dependencies = [
  "time 0.3.7",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "jsonxf"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6889ea54a6add10ed8a757719ec88293201265fa7fe56e09ae66b6df038a6"
+dependencies = [
+ "getopts",
+ "memchr",
 ]
 
 [[package]]
@@ -2403,6 +2422,7 @@ dependencies = [
  "itertools",
  "jql",
  "jsonschema",
+ "jsonxf",
  "log",
  "mimalloc",
  "mlua",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ jsonschema = { version = "0.15", features = [
     "resolve-file",
     "resolve-http",
 ], default-features = false }
+jsonxf = "1"
 jql = { version = "3.1", default-features = false }
 log = "0.4"
 mimalloc = { version = "0.1", default-features = false, optional = true }

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -21,36 +21,23 @@ fn fetch_simple() {
     let expected = vec![
         svec![r#"HTTP 404 - Not Found"#],
         svec![
-            r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#
+            r#"{"post code":"90210","country":"United States","country abbreviation":"US","places":[{"place name":"Beverly Hills","longitude":"-118.4065","state":"California","state abbreviation":"CA","latitude":"34.0901"}]}"#
         ],
         svec![
-            r#"{"post code": "94105", "country": "United States", "country abbreviation": "US", "places": [{"place name": "San Francisco", "longitude": "-122.3892", "state": "California", "state abbreviation": "CA", "latitude": "37.7864"}]}"#
+            r#"{"post code":"94105","country":"United States","country abbreviation":"US","places":[{"place name":"San Francisco","longitude":"-122.3892","state":"California","state abbreviation":"CA","latitude":"37.7864"}]}"#
         ],
         svec![
-            r#"{"post code": "92802", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Anaheim", "longitude": "-117.9228", "state": "California", "state abbreviation": "CA", "latitude": "33.8085"}]}"#
+            r#"{"post code":"92802","country":"United States","country abbreviation":"US","places":[{"place name":"Anaheim","longitude":"-117.9228","state":"California","state abbreviation":"CA","latitude":"33.8085"}]}"#
         ],
         svec![
-            r#"{
-  "head" : {
-    "vars" : [ "dob" ]
-  },
-  "results" : {
-    "bindings" : [ {
-      "dob" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "1952-03-11T00:00:00Z"
-      }
-    } ]
-  }
-}"#
+            r#"{"head":{"vars":["dob"]},"results":{"bindings":[{"dob":{"datatype":"http://www.w3.org/2001/XMLSchema#dateTime","type":"literal","value":"1952-03-11T00:00:00Z"}}]}}"#
         ],
     ];
     assert_eq!(got, expected);
 }
 
 #[test]
-fn fetch_url_template() {
+fn fetch_simple_url_template() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
@@ -73,13 +60,13 @@ fn fetch_url_template() {
     let expected = vec![
         svec![r#"HTTP 404 - Not Found"#],
         svec![
-            r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#
+            r#"{"post code":"90210","country":"United States","country abbreviation":"US","places":[{"place name":"Beverly Hills","longitude":"-118.4065","state":"California","state abbreviation":"CA","latitude":"34.0901"}]}"#
         ],
         svec![
-            r#"{"post code": "94105", "country": "United States", "country abbreviation": "US", "places": [{"place name": "San Francisco", "longitude": "-122.3892", "state": "California", "state abbreviation": "CA", "latitude": "37.7864"}]}"#
+            r#"{"post code":"94105","country":"United States","country abbreviation":"US","places":[{"place name":"San Francisco","longitude":"-122.3892","state":"California","state abbreviation":"CA","latitude":"37.7864"}]}"#
         ],
         svec![
-            r#"{"post code": "92802", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Anaheim", "longitude": "-117.9228", "state": "California", "state abbreviation": "CA", "latitude": "33.8085"}]}"#
+            r#"{"post code":"92802","country":"United States","country abbreviation":"US","places":[{"place name":"Anaheim","longitude":"-117.9228","state":"California","state abbreviation":"CA","latitude":"33.8085"}]}"#
         ],
     ];
     assert_eq!(got, expected);
@@ -115,29 +102,16 @@ fn fetch_simple_redis() {
     let expected = vec![
         svec![r#"HTTP 404 - Not Found"#],
         svec![
-            r#"{"post code": "90210", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Beverly Hills", "longitude": "-118.4065", "state": "California", "state abbreviation": "CA", "latitude": "34.0901"}]}"#
+            r#"{"post code":"90210","country":"United States","country abbreviation":"US","places":[{"place name":"Beverly Hills","longitude":"-118.4065","state":"California","state abbreviation":"CA","latitude":"34.0901"}]}"#
         ],
         svec![
-            r#"{"post code": "94105", "country": "United States", "country abbreviation": "US", "places": [{"place name": "San Francisco", "longitude": "-122.3892", "state": "California", "state abbreviation": "CA", "latitude": "37.7864"}]}"#
+            r#"{"post code":"94105","country":"United States","country abbreviation":"US","places":[{"place name":"San Francisco","longitude":"-122.3892","state":"California","state abbreviation":"CA","latitude":"37.7864"}]}"#
         ],
         svec![
-            r#"{"post code": "92802", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Anaheim", "longitude": "-117.9228", "state": "California", "state abbreviation": "CA", "latitude": "33.8085"}]}"#
+            r#"{"post code":"92802","country":"United States","country abbreviation":"US","places":[{"place name":"Anaheim","longitude":"-117.9228","state":"California","state abbreviation":"CA","latitude":"33.8085"}]}"#
         ],
         svec![
-            r#"{
-  "head" : {
-    "vars" : [ "dob" ]
-  },
-  "results" : {
-    "bindings" : [ {
-      "dob" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "1952-03-11T00:00:00Z"
-      }
-    } ]
-  }
-}"#
+            r#"{"head":{"vars":["dob"]},"results":{"bindings":[{"dob":{"datatype":"http://www.w3.org/2001/XMLSchema#dateTime","type":"literal","value":"1952-03-11T00:00:00Z"}}]}}"#
         ],
     ];
     assert_eq!(got, expected);


### PR DESCRIPTION
`fetch` now automatically minifies JSON responses.

If the user wants pretty-printed JSON, the --pretty option is now available.

If the response is not in JSON format, its passed through.