### PR TITLE
`apply`: dynfmt subcommand

### DIFF
--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -48,6 +48,70 @@ fn apply_ops_upper() {
 }
 
 #[test]
+fn apply_dynfmt() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec![
+                "qty-fruit/day",
+                "1fruit",
+                "another col",
+                "unit cost usd",
+                "and another one"
+            ],
+            svec!["20.5", "mangoes", "a", "5", "z"],
+            svec!["10", "bananas", "b", "20", "y"],
+            svec!["3", "strawberries", "c", "3.50", "x"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("dynfmt")
+        .arg("--formatstr")
+        .arg("{qty_fruit_day} helpings of {1fruit} is good for you, even if it costs ${unit_cost_usd} each")
+        .arg("--new-column")
+        .arg("saying")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![
+            "qty-fruit/day",
+            "1fruit",
+            "another col",
+            "unit cost usd",
+            "and another one",
+            "saying"
+        ],
+        svec![
+            "20.5",
+            "mangoes",
+            "a",
+            "5",
+            "z",
+            "20.5 helpings of mangoes is good for you, even if it costs $5 each"
+        ],
+        svec![
+            "10",
+            "bananas",
+            "b",
+            "20",
+            "y",
+            "10 helpings of bananas is good for you, even if it costs $20 each"
+        ],
+        svec![
+            "3",
+            "strawberries",
+            "c",
+            "3.50",
+            "x",
+            "3 helpings of strawberries is good for you, even if it costs $3.50 each"
+        ],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn apply_ops_empty_shortcircuit() {
     let wrk = Workdir::new("apply");
     wrk.create(


### PR DESCRIPTION
With `apply dynfmt`, users can now construct a new column using a template which can pull in other column values.

For example, create a new column 'mailing address' from 'house number', 'street', 'city' and 'zip-code' columns:

```bash
$ qsv apply dynfmt --formatstr '{house_number} {street}, {city} {zip_code} USA' -c 'mailing address' file.csv
```

Note how the template can contain additional arbitrary characters (the comma after street, and the USA suffix). 
To insert a column value, enclose the column name in curly braces, replacing all non-alphanumeric characters with underscores.

