### PR TITLE
`sniff` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv-sniffer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5f6cb5cd8188758d302117c0450c836cb22a0d3799c766817a1c6773392c5a"
+dependencies = [
+ "bitflags",
+ "csv",
+ "csv-core",
+ "memchr",
+ "regex",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2421,7 @@ dependencies = [
  "crossbeam-channel",
  "csv",
  "csv-index",
+ "csv-sniffer",
  "dateparser",
  "docopt",
  "dynfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ chrono = { version = "0.4", optional = true }
 crossbeam-channel = "0.5"
 csv = "1.1"
 csv-index = "0.1"
+csv-sniffer = "0.2"
 dateparser = "0.1"
 docopt = "1"
 dynfmt = { version = "0.1", default-features = false, features = [

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -38,6 +38,7 @@ pub mod search;
 pub mod searchset;
 pub mod select;
 pub mod slice;
+pub mod sniff;
 pub mod sort;
 pub mod split;
 pub mod stats;

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -1,0 +1,45 @@
+use crate::util;
+use crate::CliResult;
+use csv_sniffer::{SampleSize, Sniffer};
+use serde::Deserialize;
+
+static USAGE: &str = "
+Quickly sniff CSV details (delimiter, quote character, number of fields, data types,
+header row, preamble rows).
+
+Usage:
+    qsv sniff [options] [<input>]
+
+sniff options:
+    -l, --len <arg>        How many rows to sample to sniff out the details.
+                           [default: 100]
+
+Common options:
+    -h, --help             Display this message
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input: Option<String>,
+    flag_len: usize,
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    if let Some(path) = args.arg_input {
+        match Sniffer::new()
+            .sample_size(SampleSize::Records(args.flag_len))
+            .sniff_path(path)
+        {
+            Ok(metadata) => {
+                println!("{metadata}");
+            }
+            Err(e) => {
+                return fail!(format!("sniff error: {e}"));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,7 @@ macro_rules! command_list {
     searchset   Search CSV data with a regex set
     select      Select, re-order, duplicate or drop columns
     slice       Slice records from CSV
+    sniff       Quickly sniff CSV metadata
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     split       Split CSV data into many files
     stats       Infer data types and compute descriptive statistics
@@ -258,6 +259,7 @@ enum Command {
     SearchSet,
     Select,
     Slice,
+    Sniff,
     Sort,
     Split,
     Stats,
@@ -322,6 +324,7 @@ impl Command {
             Command::SearchSet => cmd::searchset::run(argv),
             Command::Select => cmd::select::run(argv),
             Command::Slice => cmd::slice::run(argv),
+            Command::Sniff => cmd::sniff::run(argv),
             Command::Sort => cmd::sort::run(argv),
             Command::Split => cmd::split::run(argv),
             Command::Stats => cmd::stats::run(argv),

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -68,6 +68,7 @@ macro_rules! command_list {
     searchset   Search CSV data with a regex set
     select      Select, re-order, duplicate or drop columns
     slice       Slice records from CSV
+    sniff       Quickly sniff CSV metadata
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     split       Split CSV data into many files
     stats       Infer data types and compute descriptive statistics
@@ -221,6 +222,7 @@ enum Command {
     SearchSet,
     Select,
     Slice,
+    Sniff,
     Sort,
     Split,
     Stats,
@@ -275,6 +277,7 @@ impl Command {
             Command::SearchSet => cmd::searchset::run(argv),
             Command::Select => cmd::select::run(argv),
             Command::Slice => cmd::slice::run(argv),
+            Command::Sniff => cmd::sniff::run(argv),
             Command::Sort => cmd::sort::run(argv),
             Command::Split => cmd::split::run(argv),
             Command::Stats => cmd::stats::run(argv),

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -1,0 +1,48 @@
+use crate::workdir::Workdir;
+
+#[test]
+fn sniff() {
+    let wrk = Workdir::new("sniff");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["id", "timestamp", "h3"],
+            svec!["1", "2021-04-26 00:02:18", "a"],
+            svec!["2", "2021-04-26 19:22:26", "b"],
+            svec!["30", "2021-04-26 11:44:13", "c"],
+            svec!["4", "2021-04-26 14:37:03", "d"],
+            svec!["2", "2021-04-26 20:22:26", "e"],
+            svec!["5", "2021-04-26 19:29:26", "f"],
+            svec!["60", "2021-04-26 04:52:46", "g"],
+            svec!["2", "2021-04-26 19:12:26", "h"],
+            svec!["30", "2021-04-26 10:44:13", "i"],
+            svec!["30", "2021-04-26 09:44:13", "j"],
+            svec!["1", "2021-04-26 01:02:18", "k"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sniff");
+    cmd.arg("in.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+
+    let expected = r#"Metadata
+========
+Dialect:
+	Delimiter: ,
+	Has header row?: true
+	Number of preamble rows: 0
+	Quote character: none
+	Double-quote escapes?: true
+	Escape character: none
+	Comment character: none
+	Flexible: false
+
+Number of fields: 3
+Types:
+	0: Unsigned
+	1: Text
+	2: Text"#;
+
+    assert_eq!(got, expected);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -72,6 +72,7 @@ mod test_search;
 mod test_searchset;
 mod test_select;
 mod test_slice;
+mod test_sniff;
 mod test_sort;
 mod test_split;
 mod test_stats;
@@ -199,7 +200,7 @@ impl Arbitrary for CsvData {
         // If the CSV data starts with a BOM, strip it, because it wreaks havoc
         // with tests that weren't designed to handle it.
         if !d.data.is_empty() && !d.data[0].is_empty() {
-            if let Some(stripped) = d.data[0][0].strip_prefix("\u{FEFF}") {
+            if let Some(stripped) = d.data[0][0].strip_prefix('\u{FEFF}') {
                 d.data[0][0] = stripped.to_string();
             }
         }


### PR DESCRIPTION
adds `sniff` command which uses the `csv-sniffer` crate to quickly get CSV metadata.

This complements the `stats` command which is more exhaustive and can possibly take a relatively long time.  `sniff` just scans 100 rows by default to infer CSV metadata.