### PR TITLE
`QSV_SNIFF_DELIMITER` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Environment Variables
 ---------------------
 
 * `QSV_DEFAULT_DELIMITER` - single ascii character to use as delimiter.  Overrides `--delimeter` option. Defaults to "," (comma) for CSV files and "\t" (tab) for TSV files, when not set. Note that this will also set the delimiter for qsv's output to stdout. However, using the `--output` option, regardless of this environment variable, will automatically change the delimiter used in the generated file based on the file extension - i.e. comma for `.csv`, tab for `.tsv` and `.tab` files.
+* `QSV_SNIFF_DELIMITER` - when set, the delimiter is automatically detected. Overrides `--delimiter` and `QSV_DEFAULT_DELIMITER`. Note that delimiter sniffing currently
+does not work with piped files.
 * `QSV_NO_HEADERS` - when set, the first row will **NOT** be interpreted as headers. Supersedes `QSV_TOGGLE_HEADERS`.
 * `QSV_TOGGLE_HEADERS` - if set to `1`, toggles header setting - i.e. inverts qsv header behavior, with no headers being the default, and setting `--no-headers` will actually mean headers will not be ignored.
 * `QSV_MAX_JOBS` - number of jobs to use for multi-threaded commands (currently `frequency`, `split`, `schema` and `stats`). If not set, max_jobs is set

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -46,3 +46,56 @@ Types:
 
     assert_eq!(got, expected);
 }
+
+static EXPECTED_TABLE: &str = "\
+h1       h2   h3
+abcdefg  a    a
+a        abc  z\
+";
+
+fn data() -> Vec<Vec<String>> {
+    vec![
+        svec!["h1", "h2", "h3"],
+        svec!["abcdefg", "a", "a"],
+        svec!["a", "abc", "z"],
+    ]
+}
+
+#[test]
+fn qsv_sniff_pipe_delimiter_env() {
+    let wrk = Workdir::new("qsv_sniff_pipe_delimiter_env");
+    wrk.create_with_delim("in.file", data(), b'|');
+
+    let mut cmd = wrk.command("table");
+    cmd.env("QSV_SNIFF_DELIMITER", "1");
+    cmd.arg("in.file");
+
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(&*got, EXPECTED_TABLE)
+}
+
+#[test]
+fn qsv_sniff_semicolon_delimiter_env() {
+    let wrk = Workdir::new("qsv_sniff_semicolon_delimiter_env");
+    wrk.create_with_delim("in.file", data(), b';');
+
+    let mut cmd = wrk.command("table");
+    cmd.env("QSV_SNIFF_DELIMITER", "1");
+    cmd.arg("in.file");
+
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(&*got, EXPECTED_TABLE)
+}
+
+#[test]
+fn qsv_sniff_tab_delimiter_env() {
+    let wrk = Workdir::new("qsv_sniff_tab_delimiter_env");
+    wrk.create_with_delim("in.file", data(), b'\t');
+
+    let mut cmd = wrk.command("table");
+    cmd.env("QSV_SNIFF_DELIMITER", "1");
+    cmd.arg("in.file");
+
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(&*got, EXPECTED_TABLE)
+}


### PR DESCRIPTION
When set, auto-detects the delimiter used.

resolves #199 