### PR TITLE
`sniff` display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "csv-sniffer"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5f6cb5cd8188758d302117c0450c836cb22a0d3799c766817a1c6773392c5a"
+checksum = "a1e32aa93b952410d55c1ae03048cc22a6cc62a323711b8e9245ef4b5578051c"
 dependencies = [
  "bitflags",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ chrono = { version = "0.4", optional = true }
 crossbeam-channel = "0.5"
 csv = "1.1"
 csv-index = "0.1"
-csv-sniffer = "0.2"
+csv-sniffer = "0.3"
 dateparser = "0.1"
 docopt = "1"
 dynfmt = { version = "0.1", default-features = false, features = [

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -33,7 +33,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .sniff_path(path)
         {
             Ok(metadata) => {
-                println!("{metadata}");
+                let full_metadata = format!("{}", metadata);
+                // show otherwise invisible tab character as "tab"
+                let mut disp = full_metadata.replace("\tDelimiter: \t", "\tDelimiter: tab");
+                // remove Dialect header
+                disp = disp.replace("Dialect:\n", "");
+                println!("{disp}");
             }
             Err(e) => {
                 return fail!(format!("sniff error: {e}"));

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -1,64 +1,71 @@
 use crate::workdir::Workdir;
 
-#[test]
-fn sniff() {
-    let wrk = Workdir::new("sniff");
-    wrk.create(
-        "in.csv",
-        vec![
-            svec!["id", "timestamp", "h3"],
-            svec!["1", "2021-04-26 00:02:18", "a"],
-            svec!["2", "2021-04-26 19:22:26", "b"],
-            svec!["30", "2021-04-26 11:44:13", "c"],
-            svec!["4", "2021-04-26 14:37:03", "d"],
-            svec!["2", "2021-04-26 20:22:26", "e"],
-            svec!["5", "2021-04-26 19:29:26", "f"],
-            svec!["60", "2021-04-26 04:52:46", "g"],
-            svec!["2", "2021-04-26 19:12:26", "h"],
-            svec!["30", "2021-04-26 10:44:13", "i"],
-            svec!["30", "2021-04-26 09:44:13", "j"],
-            svec!["1", "2021-04-26 01:02:18", "k"],
-        ],
-    );
-
-    let mut cmd = wrk.command("sniff");
-    cmd.arg("in.csv");
-
-    let got: String = wrk.stdout(&mut cmd);
-
-    let expected = r#"Metadata
-========
-Dialect:
-	Delimiter: ,
-	Has header row?: true
-	Number of preamble rows: 0
-	Quote character: none
-	Double-quote escapes?: true
-	Escape character: none
-	Comment character: none
-	Flexible: false
-
-Number of fields: 3
-Types:
-	0: Unsigned
-	1: Text
-	2: Text"#;
-
-    assert_eq!(got, expected);
-}
-
 static EXPECTED_TABLE: &str = "\
-h1       h2   h3
-abcdefg  a    a
-a        abc  z\
+h1       h2  h3
+abcdefg  1   a
+a        2   z\
 ";
 
 fn data() -> Vec<Vec<String>> {
     vec![
         svec!["h1", "h2", "h3"],
-        svec!["abcdefg", "a", "a"],
-        svec!["a", "abc", "z"],
+        svec!["abcdefg", "1", "a"],
+        svec!["a", "2", "z"],
     ]
+}
+
+#[test]
+fn sniff() {
+    let wrk = Workdir::new("sniff");
+    wrk.create_with_delim("in.file", data(), b',');
+
+    let mut cmd = wrk.command("sniff");
+    cmd.arg("in.file");
+
+    let got: String = wrk.stdout(&mut cmd);
+
+    let expected = r#"Metadata
+========
+	Delimiter: ,
+	Has header row?: true
+	Number of preamble rows: 0
+	Quote character: none
+	Flexible: false
+
+Number of fields: 3
+Types:
+	0: Text
+	1: Unsigned
+	2: Text"#;
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn sniff_tab() {
+    let wrk = Workdir::new("sniff_tab");
+    wrk.create_with_delim("in.file", data(), b'\t');
+
+    let mut cmd = wrk.command("sniff");
+    cmd.arg("in.file");
+
+    let got: String = wrk.stdout(&mut cmd);
+
+    let expected = r#"Metadata
+========
+	Delimiter: tab
+	Has header row?: true
+	Number of preamble rows: 0
+	Quote character: none
+	Flexible: false
+
+Number of fields: 3
+Types:
+	0: Text
+	1: Unsigned
+	2: Text"#;
+
+    assert_eq!(got, expected);
 }
 
 #[test]


### PR DESCRIPTION
- reformat the `sniff` metadata display
- improved sniff tests
- bumped csv-sniffer to 0.3.1