### PR TITLE
Build lite properly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,42 +35,48 @@ jobs:
             architecture: x86_64
             artifact_name: qsv*
             use-cross: false
-            addl-build-args: --all-features          
+            addl-build-args: --features=apply,generate,lua,fetch,foreach,python,notlite
+            default-features:
           - os: ubuntu-latest
             os-name: linux
             target: i686-unknown-linux-gnu
             architecture: i686
             artifact_name: qsv*
             use-cross: true
-            addl-build-args: --features=apply,generate,lua,fetch,foreach
+            addl-build-args: --features=apply,generate,lua,fetch,foreach,notlite
+            default-features:
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-msvc
             architecture: x86_64
             artifact_name: qsv*.exe
             use-cross: false
-            addl-build-args: --features=apply,generate,lua,fetch,python
+            addl-build-args: --features=apply,generate,lua,fetch,python,notlite
+            default-features:
           - os: windows-latest
             os-name: windows
             target: i686-pc-windows-msvc
             architecture: i686
             artifact_name: qsv*.exe
             use-cross: true
-            addl-build-args: --features=apply,generate,lua,fetch
+            addl-build-args: --features=apply,generate,lua,fetch,notlite
+            default-features:
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-gnu
             architecture: x86_64
             artifact_name: qsv*.exe
             use-cross: false
-            addl-build-args: --no-default-features --features=apply,generate,lua,fetch,python
+            addl-build-args: --features=apply,generate,lua,fetch,python,notlite
+            default-features:
           - os: macos-latest
             os-name: macos
             target: x86_64-apple-darwin
             architecture: x86_64
             artifact_name: qsv*
             use-cross: false
-            addl-build-args: --all-features
+            addl-build-args: --features=apply,generate,lua,fetch,foreach,python,notlite
+            default-features: --no-default-features 
           - os: macos-latest
             os-name: macos
             target: aarch64-apple-darwin
@@ -78,28 +84,32 @@ jobs:
             artifact_name: qsv*
             build-prep: true
             use-cross: true
-            addl-build-args: --features=apply,generate,lua,fetch,foreach
+            addl-build-args: --features=apply,generate,lua,fetch,foreach,notlite
+            default-features: --no-default-features
           - os: ubuntu-latest
             os-name: linux
             target: aarch64-unknown-linux-gnu
             architecture: aarch64
             artifact_name: qsv*
             use-cross: true
-            addl-build-args: --features=apply,generate,lua,fetch,foreach
+            addl-build-args: --features=apply,generate,lua,fetch,foreach,notlite
+            default-features:
           - os: ubuntu-latest
             os-name: linux
             target: arm-unknown-linux-gnueabihf
             architecture: arm
             artifact_name: qsv*
             use-cross: true
-            addl-build-args: --no-default-features --features=apply,generate,lua,fetch,foreach
+            addl-build-args: --features=apply,generate,lua,fetch,foreach,notlite
+            default-features: --no-default-features
           - os: ubuntu-latest
             os-name: linux
             target: arm-unknown-linux-musleabihf
             architecture: arm
             artifact_name: qsv*
             use-cross: true
-            addl-build-args: --no-default-features --features=apply,generate,lua,fetch,foreach
+            addl-build-args: --features=apply,generate,lua,fetch,foreach,notlite
+            default-features: --no-default-features
 
     steps:
     - name: Installing Rust toolchain
@@ -122,13 +132,20 @@ jobs:
       run: |
         sudo xcode-select -s "/Applications/Xcode_12.5.1.app"
         sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
-    - name: Cargo build
+    - name: Build qsv
       uses: actions-rs/cargo@v1
       with:
         command: build
         use-cross: ${{ matrix.job.use-cross }}
         toolchain: ${{ matrix.rust }}
-        args: --release --locked --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }}
+        args: --release --locked --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }} ${{ matrix.job.default-features }}
+    - name: Build qsvlite
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        use-cross: ${{ matrix.job.use-cross }}
+        toolchain: ${{ matrix.rust }}
+        args: --release --locked --target ${{ matrix.job.target }} features=lite
     - name: Copy binaries to working dir
       shell: bash
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,21 @@ autobins      = false
 include       = ["src/**/*", "LICENSE-MIT", "README.md", "CHANGELOG.md"]
 
 [[bin]]
-name    = "qsv"
-test    = false
-bench   = false
-doctest = false
-path    = "src/main.rs"
+name              = "qsv"
+test              = false
+bench             = false
+doctest           = false
+path              = "src/main.rs"
+required-features = ["notlite"]
+
 
 [[bin]]
-name    = "qsvlite"
-test    = false
-bench   = false
-doctest = false
-path    = "src/mainlite.rs"
+name              = "qsvlite"
+test              = false
+bench             = false
+doctest           = false
+path              = "src/mainlite.rs"
+required-features = ["lite"]
 
 [[test]]
 name = "tests"
@@ -142,5 +145,7 @@ apply = [
 fetch = ["cached", "dynfmt", "governor", "jql", "jsonxf"]
 foreach = []
 generate = ["test-data-generation"]
+lite = []
+notlite = []
 lua = ["mlua"]
 python = ["pyo3"]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "apply")]
+#[cfg(all(feature = "apply",  feature="notlite"))]
 pub mod apply;
 pub mod behead;
 pub mod cat;
@@ -7,27 +7,27 @@ pub mod dedup;
 pub mod enumerate;
 pub mod exclude;
 pub mod explode;
-#[cfg(feature = "fetch")]
+#[cfg(all(feature = "fetch",  feature="notlite"))]
 pub mod fetch;
 pub mod fill;
 pub mod fixlengths;
 pub mod flatten;
 pub mod fmt;
-#[cfg(feature = "foreach")]
+#[cfg(all(feature = "foreach",  feature="notlite"))]
 pub mod foreach;
 pub mod frequency;
-#[cfg(feature = "generate")]
+#[cfg(all(feature = "generate",  feature="notlite"))]
 pub mod generate;
 pub mod headers;
 pub mod index;
 pub mod input;
 pub mod join;
 pub mod jsonl;
-#[cfg(feature = "lua")]
+#[cfg(all(feature = "lua",  feature="notlite"))]
 pub mod lua;
 pub mod partition;
 pub mod pseudo;
-#[cfg(feature = "python")]
+#[cfg(all(feature = "python",  feature="notlite"))]
 pub mod python;
 pub mod rename;
 pub mod replace;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "apply",  feature="notlite"))]
+#[cfg(all(feature = "apply", feature = "notlite"))]
 pub mod apply;
 pub mod behead;
 pub mod cat;
@@ -7,27 +7,27 @@ pub mod dedup;
 pub mod enumerate;
 pub mod exclude;
 pub mod explode;
-#[cfg(all(feature = "fetch",  feature="notlite"))]
+#[cfg(all(feature = "fetch", feature = "notlite"))]
 pub mod fetch;
 pub mod fill;
 pub mod fixlengths;
 pub mod flatten;
 pub mod fmt;
-#[cfg(all(feature = "foreach",  feature="notlite"))]
+#[cfg(all(feature = "foreach", feature = "notlite"))]
 pub mod foreach;
 pub mod frequency;
-#[cfg(all(feature = "generate",  feature="notlite"))]
+#[cfg(all(feature = "generate", feature = "notlite"))]
 pub mod generate;
 pub mod headers;
 pub mod index;
 pub mod input;
 pub mod join;
 pub mod jsonl;
-#[cfg(all(feature = "lua",  feature="notlite"))]
+#[cfg(all(feature = "lua", feature = "notlite"))]
 pub mod lua;
 pub mod partition;
 pub mod pseudo;
-#[cfg(all(feature = "python",  feature="notlite"))]
+#[cfg(all(feature = "python", feature = "notlite"))]
 pub mod python;
 pub mod rename;
 pub mod replace;

--- a/src/util.rs
+++ b/src/util.rs
@@ -39,24 +39,21 @@ pub fn max_jobs() -> usize {
 
 pub fn version() -> String {
     let mut enabled_features = "".to_string();
-    if let Some(qsv_type) = option_env!("CARGO_BIN_NAME") {
-        if qsv_type != "qsvlite" {
-            #[cfg(feature = "apply")]
-            enabled_features.push_str("apply;");
-            #[cfg(feature = "fetch")]
-            enabled_features.push_str("fetch;");
-            #[cfg(feature = "foreach")]
-            enabled_features.push_str("foreach;");
-            #[cfg(feature = "generate")]
-            enabled_features.push_str("generate;");
-            #[cfg(feature = "lua")]
-            enabled_features.push_str("lua;");
-            #[cfg(feature = "python")]
-            enabled_features.push_str("python;");
 
-            enabled_features.push('-');
-        }
-    }
+    #[cfg(all(feature = "apply", feature = "notlite"))]
+    enabled_features.push_str("apply;");
+    #[cfg(all(feature = "fetch", feature = "notlite"))]
+    enabled_features.push_str("fetch;");
+    #[cfg(all(feature = "foreach", feature = "notlite"))]
+    enabled_features.push_str("foreach;");
+    #[cfg(all(feature = "generate", feature = "notlite"))]
+    enabled_features.push_str("generate;");
+    #[cfg(all(feature = "lua", feature = "notlite"))]
+    enabled_features.push_str("lua;");
+    #[cfg(all(feature = "python", feature = "notlite"))]
+    enabled_features.push_str("python;");
+
+    enabled_features.push('-');
 
     #[cfg(feature = "mimalloc")]
     let malloc_kind = "mimalloc".to_string();


### PR DESCRIPTION
Previously, qsvlite disabled all features, but the code was still being linked in, though they were not available.

Now, qsvlite does not link in disabled features, making for a much smaller  binary.