### PR TITLE
`stats`: more perf tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ governor = { version = "0.4", optional = true }
 grex = "1.3"
 indicatif = "0.16"
 itertools = "0.10"
+itoa = "1"
 jsonschema = { version = "0.15", features = [
     "resolve-file",
     "resolve-http",
@@ -99,6 +100,7 @@ reqwest = { version = "0.11", features = [
     "rustls-tls",
 ], default-features = false }
 reverse_geocoder = { version = "3", optional = true }
+ryu = "1"
 self_update = { version = "0.29", features = [
     "archive-zip",
     "compression-zip-deflate",

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -422,13 +422,13 @@ stats_tests!(
     stats_quartiles,
     "quartiles",
     &["1", "2", "3"],
-    "-2,1,2,3,2,4"
+    "-2.0,1.0,2.0,3.0,2.0,4.0"
 );
 stats_tests!(
     stats_quartiles_null,
     "quartiles",
     &["", "1", "2", "3"],
-    "-2,1,2,3,2,4"
+    "-2.0,1.0,2.0,3.0,2.0,4.0"
 );
 stats_tests!(
     stats_quartiles_even,


### PR DESCRIPTION
- remove Unknown field type, as we will never get it, given that all input is utf8
- remove unnecessary match arms from FieldType Commute
- remove unnecessary tempvar for checking field len to see if its DateTime (>17 len) or Date
- use from_utf8_unchecked to skip utf8 validation
- use faster mul_add fn instead of manual mul, then add for calculating upper fence
- do collect instead of from_iter
- removed unnecessary closures
- use itoa and ryu instead of to_string() for faster int/float to string conversion