### PR TITLE
`fetch` and `apply`: use lookup tables 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,9 +1372,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jql"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098b448343b135e22e81f4c262768e1e5912f61ff314940b7b315b0135fb34a2"
+checksum = "b0d3a1ed238ec121ef88a53f2b2c7d8c5ae8a9fe90b4a7964c3bd08f483e2f79"
 dependencies = [
  "anyhow",
  "pest",
@@ -2161,6 +2161,7 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
+ "serial_test",
  "strsim 0.10.0",
  "tabwriter",
  "test-data-generation",
@@ -2649,6 +2650,30 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.11.2",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -3499,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2a3b9c90b21734aaf4449cee7735305f559f28894123b57e0f700be8459418"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ actix-web = { version = "4.0", default-features = false, features = [
 assert-json-diff = "2.0"
 quickcheck = { version = "1", default-features = false }
 redis = { version = "0.21", default-features = false }
+serial_test = "0.6"
 
 [features]
 default = ["mimalloc"]

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,6 +12,14 @@ use regex::Regex;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer, Error};
 use thousands::Separable;
 
+#[macro_export]
+macro_rules! regex_once_cell {
+    ($re:literal $(,)?) => {{
+        static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
+        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+    }};
+}
+
 #[inline]
 pub fn num_cpus() -> usize {
     thread::available_parallelism().unwrap().get()
@@ -488,7 +496,7 @@ pub fn safe_header_names(headers: &csv::StringRecord, check_first_char: bool) ->
     // If name starts with a number, replace it with an _ as well
     let re = Regex::new(r"[^A-Za-z0-9]").unwrap();
     let mut header_vec: Vec<String> = Vec::with_capacity(headers.len());
-    for (_i, h) in headers.iter().take(headers.len()).enumerate() {
+    for h in headers.iter() {
         let mut python_var_name = re.replace_all(h, "_").to_string();
         if check_first_char && python_var_name.as_bytes()[0].is_ascii_digit() {
             python_var_name.replace_range(0..1, "_");

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -68,7 +68,7 @@ fn apply_dynfmt() {
     let mut cmd = wrk.command("apply");
     cmd.arg("dynfmt")
         .arg("--formatstr")
-        .arg("{qty_fruit_day} helpings of {1fruit} is good for you, even if it costs ${unit_cost_usd} each")
+        .arg("{qty_fruit_day} helpings of {1fruit} is good for you, even if it costs ${unit_cost_usd} each. {1fruit}, all {qty_fruit_day} - is just worth it!")
         .arg("--new-column")
         .arg("saying")
         .arg("data.csv");
@@ -89,7 +89,7 @@ fn apply_dynfmt() {
             "a",
             "5",
             "z",
-            "20.5 helpings of mangoes is good for you, even if it costs $5 each"
+            "20.5 helpings of mangoes is good for you, even if it costs $5 each. mangoes, all 20.5 - is just worth it!"
         ],
         svec![
             "10",
@@ -97,7 +97,7 @@ fn apply_dynfmt() {
             "b",
             "20",
             "y",
-            "10 helpings of bananas is good for you, even if it costs $20 each"
+            "10 helpings of bananas is good for you, even if it costs $20 each. bananas, all 10 - is just worth it!"
         ],
         svec![
             "3",
@@ -105,7 +105,7 @@ fn apply_dynfmt() {
             "c",
             "3.50",
             "x",
-            "3 helpings of strawberries is good for you, even if it costs $3.50 each"
+            "3 helpings of strawberries is good for you, even if it costs $3.50 each. strawberries, all 3 - is just worth it!"
         ],
     ];
     assert_eq!(got, expected);

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -1,4 +1,5 @@
 use crate::workdir::Workdir;
+use serial_test::serial;
 
 #[test]
 fn fetch_simple() {
@@ -360,6 +361,7 @@ async fn run_webserver(tx: mpsc::Sender<ServerHandle>) -> std::io::Result<()> {
 }
 
 #[test]
+#[serial]
 fn fetch_ratelimit() {
     // start webserver with rate limiting
     let (tx, rx) = mpsc::channel();
@@ -443,6 +445,95 @@ fn fetch_ratelimit() {
             "The quick brown fox jumped over the lazy dog by the zigzag quarry site Smurf"
         ],
     ];
+    assert_eq!(got, expected);
+
+    // init stop webserver and wait until server gracefully exit
+    println!("STOPPING Webserver");
+    rt::System::new().block_on(server_handle.stop(true));
+}
+
+#[test]
+#[serial]
+fn fetch_complex_url_template() {
+    // start webserver with rate limiting
+    let (tx, rx) = mpsc::channel();
+
+    println!("START Webserver ");
+    thread::spawn(move || {
+        let server_future = run_webserver(tx);
+        rt::System::new().block_on(server_future)
+    });
+
+    let server_handle = rx.recv().unwrap();
+
+    // proceed with usual unit test
+    let wrk = Workdir::new("fetch_complex_template");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["first name", "color"],
+            svec!["Smurfette", "blue"],
+            svec!["Papa", "blue"],
+            svec!["Clumsy", "blue"],
+            svec!["Brainy", "blue"],
+            svec!["Grouchy", "blue"],
+            svec!["Hefty", "blue"],
+            svec!["Greedy", "green"],
+            svec!["Jokey", "blue"],
+            svec!["Chef", "blue"],
+            svec!["Vanity", "blue"],
+            svec!["Handy", "blue"],
+            svec!["Scaredy", "black"],
+            svec!["Tracker", "blue"],
+            svec!["Sloppy", "blue"],
+            svec!["Harmony", "blue"],
+            svec!["Painter", "multicolor"],
+            svec!["Poet", "blue"],
+            svec!["Farmer", "blue"],
+            svec!["Natural", "blue"],
+            svec!["Snappy", "blue"],
+        ],
+    );
+    let mut cmd = wrk.command("fetch");
+    cmd.arg("--url-template")
+        .arg(concat!(
+            "http://",
+            test_server!(),
+            "/user/{first_name}%20{color}"
+        ))
+        .arg("--new-column")
+        .arg("Fullname")
+        .arg("--jql")
+        .arg(r#"."fullname""#)
+        .arg("--rate-limit")
+        .arg("4")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["first name", "color", "Fullname"],
+        svec!["Smurfette", "blue", "Smurfette blue Smurf"],
+        svec!["Papa", "blue", "Papa blue Smurf"],
+        svec!["Clumsy", "blue", "Clumsy blue Smurf"],
+        svec!["Brainy", "blue", "Brainy blue Smurf"],
+        svec!["Grouchy", "blue", "Grouchy blue Smurf"],
+        svec!["Hefty", "blue", "Hefty blue Smurf"],
+        svec!["Greedy", "green", "Greedy green Smurf"],
+        svec!["Jokey", "blue", "Jokey blue Smurf"],
+        svec!["Chef", "blue", "Chef blue Smurf"],
+        svec!["Vanity", "blue", "Vanity blue Smurf"],
+        svec!["Handy", "blue", "Handy blue Smurf"],
+        svec!["Scaredy", "black", "Scaredy black Smurf"],
+        svec!["Tracker", "blue", "Tracker blue Smurf"],
+        svec!["Sloppy", "blue", "Sloppy blue Smurf"],
+        svec!["Harmony", "blue", "Harmony blue Smurf"],
+        svec!["Painter", "multicolor", "Painter multicolor Smurf"],
+        svec!["Poet", "blue", "Poet blue Smurf"],
+        svec!["Farmer", "blue", "Farmer blue Smurf"],
+        svec!["Natural", "blue", "Natural blue Smurf"],
+        svec!["Snappy", "blue", "Snappy blue Smurf"],
+    ];
+
     assert_eq!(got, expected);
 
     // init stop webserver and wait until server gracefully exit


### PR DESCRIPTION
- to support `fetch --url-template` and `apply dynfmt` respectively
- vec backed lookup tables for dynamic formatting of these features are faster and cheaper 