### PR TITLE
Correct multithreading jobs option

### DIFF
--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -45,8 +45,6 @@ frequency options:
                            an index already created. Note that a file handle
                            is opened for each job.
                            When set to '0', the number of jobs is set to the
-                           number of CPUs detected divided by 3.
-                           When set to '-1', the number of jobs is set to the
                            number of CPUs detected.
                            [default: 0]
 
@@ -201,8 +199,9 @@ impl Args {
     }
 
     fn njobs(&self) -> usize {
-        if self.flag_jobs == 0 {
-            util::num_cpus()
+        let num_cpus = util::num_cpus();
+        if self.flag_jobs == 0 || self.flag_jobs > num_cpus {
+            num_cpus
         } else {
             self.flag_jobs
         }

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -28,8 +28,6 @@ split options:
                            an index already created. Note that a file handle
                            is opened for each job.
                            When set to '0', the number of jobs is set to the
-                           number of CPUs detected divided by 3.
-                           When set to '-1', the number of jobs is set to the
                            number of CPUs detected.
                            [default: 0]
     --filename <filename>  A filename template to use when constructing
@@ -148,8 +146,9 @@ impl Args {
     }
 
     fn njobs(&self) -> usize {
-        if self.flag_jobs == 0 {
-            util::num_cpus()
+        let num_cpus = util::num_cpus();
+        if self.flag_jobs == 0 || self.flag_jobs > num_cpus {
+            num_cpus
         } else {
             self.flag_jobs
         }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -68,8 +68,6 @@ stats options:
                            This works only when the given CSV has an index.
                            Note that a file handle is opened for each job.
                            When set to '0', the number of jobs is set to the
-                           number of CPUs detected divided by 3.
-                           When set to '-1', the number of jobs is set to the
                            number of CPUs detected.
                            [default: 0]
 
@@ -224,8 +222,9 @@ impl Args {
     }
 
     fn njobs(&self) -> usize {
-        if self.flag_jobs == 0 {
-            util::num_cpus()
+        let num_cpus = util::num_cpus();
+        if self.flag_jobs == 0 || self.flag_jobs > num_cpus {
+            num_cpus
         } else {
             self.flag_jobs
         }


### PR DESCRIPTION
- correct `--jobs` helptext to reflect we're no longer doing the divided by 3 heuristic
- ensure only valid values are used with `--jobs`