### PR TITLE
Embrace from_utf8_unchecked

### DIFF
--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -1,5 +1,4 @@
 use std::cmp;
-use std::str::from_utf8;
 
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
@@ -122,11 +121,12 @@ where
     }
 }
 
+#[inline]
 fn next_no_case<'a, X>(xs: &mut X) -> Option<String>
 where
     X: Iterator<Item = &'a [u8]>,
 {
     xs.next()
-        .and_then(|bytes| from_utf8(bytes).ok())
+        .and_then(|bytes| unsafe { Some(std::str::from_utf8_unchecked(bytes)) })
         .map(str::to_lowercase)
 }

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -127,6 +127,6 @@ where
     X: Iterator<Item = &'a [u8]>,
 {
     xs.next()
-        .and_then(|bytes| unsafe { Some(std::str::from_utf8_unchecked(bytes)) })
+        .map(|bytes| unsafe { std::str::from_utf8_unchecked(bytes) })
         .map(str::to_lowercase)
 }

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -246,24 +246,22 @@ impl<R> fmt::Debug for ValueIndex<R> {
     }
 }
 
+#[inline]
 fn get_row_key(sel: &Selection, row: &csv::ByteRecord, casei: bool) -> Vec<ByteString> {
     sel.select(row).map(|v| transform(v, casei)).collect()
 }
 
+#[inline]
 fn transform(bs: &[u8], casei: bool) -> ByteString {
-    match str::from_utf8(bs) {
-        Err(_) => bs.to_vec(),
-        Ok(s) => {
-            if !casei {
-                s.trim().as_bytes().to_vec()
-            } else {
-                let norm: String = s
-                    .trim()
-                    .chars()
-                    .map(|c| c.to_lowercase().next().unwrap())
-                    .collect();
-                norm.into_bytes()
-            }
-        }
+    let s = unsafe { str::from_utf8_unchecked(bs) };
+    if casei {
+        let norm: String = s
+            .trim()
+            .chars()
+            .map(|c| c.to_lowercase().next().unwrap())
+            .collect();
+        norm.into_bytes()
+    } else {
+        s.trim().as_bytes().to_vec()
     }
 }

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -198,9 +198,8 @@ impl Args {
     }
 }
 
+#[inline]
 fn trim(bs: ByteString) -> ByteString {
-    match String::from_utf8(bs) {
-        Ok(s) => s.trim().as_bytes().to_vec(),
-        Err(bs) => bs.into_bytes(),
-    }
+    let s = unsafe { String::from_utf8_unchecked(bs) };
+    s.trim().as_bytes().to_vec()
 }

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -461,24 +461,22 @@ impl<R> fmt::Debug for ValueIndex<R> {
     }
 }
 
+#[inline]
 fn get_row_key(sel: &Selection, row: &csv::ByteRecord, casei: bool) -> Vec<ByteString> {
     sel.select(row).map(|v| transform(v, casei)).collect()
 }
 
+#[inline]
 fn transform(bs: &[u8], casei: bool) -> ByteString {
-    match str::from_utf8(bs) {
-        Err(_) => bs.to_vec(),
-        Ok(s) => {
-            if casei {
-                let norm: String = s
-                    .trim()
-                    .chars()
-                    .map(|c| c.to_lowercase().next().unwrap())
-                    .collect();
-                norm.into_bytes()
-            } else {
-                s.trim().as_bytes().to_vec()
-            }
-        }
+    let s = unsafe { str::from_utf8_unchecked(bs) };
+    if casei {
+        let norm: String = s
+            .trim()
+            .chars()
+            .map(|c| c.to_lowercase().next().unwrap())
+            .collect();
+        norm.into_bytes()
+    } else {
+        s.trim().as_bytes().to_vec()
     }
 }

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -1,14 +1,12 @@
 use std::cmp;
 
+use self::Number::{Float, Int};
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use serde::Deserialize;
-use std::str::from_utf8;
-
-use self::Number::{Float, Int};
 
 static USAGE: &str = "
 Sorts CSV data lexicographically.
@@ -192,7 +190,7 @@ where
     X: Iterator<Item = &'a [u8]>,
 {
     xs.next()
-        .and_then(|bytes| from_utf8(bytes).ok())
+        .and_then(|bytes| unsafe { Some(std::str::from_utf8_unchecked(bytes)) })
         .and_then(|s| {
             if let Ok(i) = s.parse::<i64>() {
                 Some(Number::Int(i))

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -190,7 +190,7 @@ where
     X: Iterator<Item = &'a [u8]>,
 {
     xs.next()
-        .and_then(|bytes| unsafe { Some(std::str::from_utf8_unchecked(bytes)) })
+        .map(|bytes| unsafe { std::str::from_utf8_unchecked(bytes) })
         .and_then(|s| {
             if let Ok(i) = s.parse::<i64>() {
                 Some(Number::Int(i))


### PR DESCRIPTION
- since we now say qsv only works with utf8 encoded files, use from_utf8_unchecked
where it makes sense (hot loops)