### PR TITLE
add `--jobs` option to `schema` and `validate`

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -42,6 +42,9 @@ Schema options:
     --strict-dates             Enforce Internet Datetime format (RFC-3339)
                                for detected datetime columns
     --pattern-columns <args>   Select columns to add pattern constraints
+    -j, --jobs <arg>           The number of jobs to run in parallel.
+                               When not set, the number of jobs is set to the
+                               number of CPUs detected.
 
 Common options:
     -h, --help                 Display this message
@@ -58,6 +61,7 @@ struct Args {
     flag_enum_threshold: usize,
     flag_strict_dates: bool,
     flag_pattern_columns: SelectColumns,
+    flag_jobs: Option<usize>,
     flag_no_headers: bool,
     flag_delimiter: Option<Delimiter>,
     arg_input: Option<String>,
@@ -317,7 +321,7 @@ fn get_stats_records(args: &Args) -> CliResult<(ByteRecord, Vec<Stats>, AHashMap
         flag_nulls: false,
         flag_nullcount: true,
         flag_infer_dates: true,
-        flag_jobs: Some(util::max_jobs()),
+        flag_jobs: Some(util::njobs(args.flag_jobs)),
         flag_output: None,
         flag_no_headers: args.flag_no_headers,
         flag_delimiter: args.flag_delimiter,
@@ -406,7 +410,7 @@ fn get_unique_values(
         flag_limit: args.flag_enum_threshold,
         flag_asc: false,
         flag_no_nulls: true,
-        flag_jobs: Some(util::max_jobs()),
+        flag_jobs: Some(util::njobs(args.flag_jobs)),
         flag_output: None,
         flag_no_headers: args.flag_no_headers,
         flag_delimiter: args.flag_delimiter,

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -45,6 +45,9 @@ Validate options:
     --fail-fast                Stops on first error.
     --valid <suffix>           Valid record output file suffix. [default: valid]
     --invalid <suffix>         Invalid record output file suffix. [default: invalid]
+    -j, --jobs <arg>           The number of jobs to run in parallel.
+                               When not set, the number of jobs is set to the
+                               number of CPUs detected.
 
 
 Common options:
@@ -63,6 +66,7 @@ struct Args {
     flag_fail_fast: bool,
     flag_valid: Option<String>,
     flag_invalid: Option<String>,
+    flag_jobs: Option<usize>,
     flag_no_headers: bool,
     flag_delimiter: Option<Delimiter>,
     flag_quiet: bool,
@@ -78,6 +82,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .no_headers(args.flag_no_headers);
 
     let mut rdr = rconfig.reader()?;
+
+    // set RAYON_NUM_THREADS
+    util::njobs(args.flag_jobs);
 
     // if no json schema supplied, only let csv reader validate csv file
     if args.arg_json_schema.is_none() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,11 +50,11 @@ pub fn max_jobs() -> usize {
 }
 
 pub fn njobs(flag_jobs: Option<usize>) -> usize {
-    let num_cpus = num_cpus();
-    flag_jobs.map_or(num_cpus, |jobs| {
-        if jobs == 0 || jobs > num_cpus {
-            env::set_var("RAYON_NUM_THREADS", num_cpus.to_string());
-            num_cpus
+    let max_jobs = max_jobs();
+    flag_jobs.map_or(max_jobs, |jobs| {
+        if jobs == 0 || jobs > max_jobs {
+            env::set_var("RAYON_NUM_THREADS", max_jobs.to_string());
+            max_jobs
         } else {
             env::set_var("RAYON_NUM_THREADS", jobs.to_string());
             jobs


### PR DESCRIPTION
- so regardless of the multithreading implementation (threadpool or rayon), we have the same `--jobs` option to control number of threads.
- also corrected utils.rs so all multithreading implementations observe QSV_MAX_JOBS.