### PR TITLE
`dedup`: `--sorted` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [FAQ](https://github.com/jqnatividad/qsv/wiki/FAQ) for more details.
 | [behead](/src/cmd/behead.rs#L7) | Drop headers from a CSV.  |
 | [cat](/src/cmd/cat.rs#L7) | Concatenate CSV files by row or by column. |
 | [count](/src/cmd/count.rs#L8)[^2] | Count the rows in a CSV file. (Instantaneous with an index.) |
-| [dedup](/src/cmd/dedup.rs#L13)[^3][^5] | Remove redundant rows.  |
+| [dedup](/src/cmd/dedup.rs#L14)[^3][^5] | Remove redundant rows.  |
 | [enum](/src/cmd/enumerate.rs#L10-L12) | Add a new column enumerating rows by adding a column of incremental or uuid identifiers. Can also be used to copy a column or fill a new column with a constant value.  |
 | [excel](/src/cmd/excel.rs#L11) | Exports a specified Excel/ODS sheet to a CSV file. |
 | [exclude](/src/cmd/exclude.rs#L18)[^2] | Removes a set of CSV data from another set based on the specified columns.  |
@@ -71,7 +71,7 @@ See [FAQ](https://github.com/jqnatividad/qsv/wiki/FAQ) for more details.
 
 [^1]: enabled by optional feature flag. Not available on `qsvlite`.   
 [^2]: uses an index when available.   
-[^3]: loads the entire CSV into memory. Note that `stats` & `transpose` have modes that do not load the entire CSV into memory.   
+[^3]: loads the entire CSV into memory. Note that `dedup`, `stats` & `transpose` have modes that do not load the entire CSV into memory.   
 [^4]: multithreaded when an index is available.   
 [^5]: multithreaded even without an index.
 

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -4,6 +4,7 @@ use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
+use csv::ByteRecord;
 use rayon::prelude::*;
 use serde::Deserialize;
 
@@ -12,7 +13,12 @@ use crate::cmd::sort::iter_cmp;
 static USAGE: &str = r#"
 Dedups CSV rows. 
 
-Note that this requires reading all of the CSV data into memory, because the rows need to be sorted first.
+Note that this requires reading all of the CSV data into memory because because the 
+rows need to be sorted first. That is, unless the --sorted option is used to indicate
+the CSV is already sorted (typically, with the extsort command).
+
+An extsort/dedup --sorted combination is typically done when deduping extremely
+large CSV files that will not fit into memory.
 
 A duplicate count will be sent to <stderr>.
 
@@ -24,18 +30,24 @@ sort options:
                                Note that the outputs will remain at the full width
                                of the CSV.
                                See 'qsv select --help' for the format details.
-    -C, --no-case              Compare strings disregarding case
+    -C, --no-case              Compare strings disregarding case 
+    --sorted                   The input is already sorted. Do not load the CSV into
+                               memory to sort it first. Meant to be used in tandem and
+                               after an extsort.
     -D, --dupes-output <file>  Write duplicates to <file>.
     -H, --human-readable       Comma separate duplicate count.
-    -j, --jobs <arg>           The number of jobs to run in parallel.
+    -j, --jobs <arg>           The number of jobs to run in parallel when sorting
+                               an unsorted CSV, before deduping.
                                When not set, the number of jobs is set to the
                                number of CPUs detected.
+                               Does not work with --sorted option as its not
+                               multithreaded.
 
 Common options:
     -h, --help                 Display this message
     -o, --output <file>        Write output to <file> instead of stdout.
     -n, --no-headers           When set, the first row will not be interpreted
-                               as headers. Namely, it will be sorted with the rest
+                               as headers. That is, it will be sorted with the rest
                                of the rows. Otherwise, the first row will always
                                appear as the header row in the output.
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
@@ -47,6 +59,7 @@ struct Args {
     arg_input: Option<String>,
     flag_select: SelectColumns,
     flag_no_case: bool,
+    flag_sorted: bool,
     flag_dupes_output: Option<String>,
     flag_output: Option<String>,
     flag_no_headers: bool,
@@ -74,38 +87,76 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
     let sel = rconfig.selection(&headers)?;
 
-    util::njobs(args.flag_jobs);
-
-    let mut all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;
-    all.par_sort_unstable_by(|r1, r2| {
-        let a = sel.select(r1);
-        let b = sel.select(r2);
-        iter_cmp(a, b)
-    });
-
     rconfig.write_headers(&mut rdr, &mut wtr)?;
     let mut dupe_count = 0_usize;
-    {
+
+    if args.flag_sorted {
+        let mut record = ByteRecord::new();
+        let mut next_record = ByteRecord::new();
+
+        rdr.read_byte_record(&mut record)?;
+        loop {
+            let more_records = rdr.read_byte_record(&mut next_record)?;
+            if !more_records {
+                wtr.write_byte_record(&record)?;
+                break;
+            };
+            let a = sel.select(&record);
+            let b = sel.select(&next_record);
+            let comparison = if no_case {
+                iter_cmp_no_case(a, b)
+            } else {
+                iter_cmp(a, b)
+            };
+            match comparison {
+                cmp::Ordering::Equal => {
+                    dupe_count += 1;
+                    if dupes_output {
+                        dupewtr.write_byte_record(&record)?;
+                    }
+                }
+                cmp::Ordering::Less => {
+                    wtr.write_byte_record(&record)?;
+                    record.clone_from(&next_record);
+                }
+                cmp::Ordering::Greater => {
+                    let fail_msg = format!(
+                        "Aborting! Input not sorted! {record:?} is greater than {next_record:?}"
+                    );
+                    return fail!(fail_msg);
+                }
+            }
+        }
+    } else {
+        util::njobs(args.flag_jobs);
+
+        let mut all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;
+        all.par_sort_unstable_by(|r1, r2| {
+            let a = sel.select(r1);
+            let b = sel.select(r2);
+            iter_cmp(a, b)
+        });
+
         let mut current = 0;
         while current + 1 < all.len() {
             let a = sel.select(&all[current]);
             let b = sel.select(&all[current + 1]);
             if no_case {
-                if iter_cmp_no_case(a, b) != cmp::Ordering::Equal {
-                    wtr.write_byte_record(&all[current])?;
-                } else {
+                if iter_cmp_no_case(a, b) == cmp::Ordering::Equal {
                     dupe_count += 1;
                     if dupes_output {
                         dupewtr.write_byte_record(&all[current])?;
                     }
+                } else {
+                    wtr.write_byte_record(&all[current])?;
                 }
-            } else if iter_cmp(a, b) != cmp::Ordering::Equal {
-                wtr.write_byte_record(&all[current])?;
-            } else {
+            } else if iter_cmp(a, b) == cmp::Ordering::Equal {
                 dupe_count += 1;
                 if dupes_output {
                     dupewtr.write_byte_record(&all[current])?;
                 }
+            } else {
+                wtr.write_byte_record(&all[current])?;
             }
             current += 1;
         }

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -11,16 +11,18 @@ use serde::Deserialize;
 use crate::cmd::sort::iter_cmp;
 
 static USAGE: &str = r#"
-Dedups CSV rows. 
+Deduplicates CSV rows. 
 
 Note that this requires reading all of the CSV data into memory because because the 
-rows need to be sorted first. That is, unless the --sorted option is used to indicate
-the CSV is already sorted (typically, with the extsort command).
+rows need to be sorted first. 
 
-An extsort/dedup --sorted combination is typically done when deduping extremely
-large CSV files that will not fit into memory.
+That is, unless the --sorted option is used to indicate the CSV is already sorted
+(typically, with the extsort command). This will make dedup run in streaming mode 
+with constant memory.
 
-A duplicate count will be sent to <stderr>.
+Either way, the output will not only be deduplicated, it will also be sorted.
+
+A duplicate count will also be sent to <stderr>.
 
 Usage:
     qsv dedup [options] [<input>]

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -70,3 +70,152 @@ fn dedup_select() {
     let expected = vec![svec!["N", "S"], svec!["10", "a"], svec!["2", "B"]];
     assert_eq!(got, expected);
 }
+
+#[test]
+fn dedup_sorted() {
+    let wrk = Workdir::new("dedup_sorted");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["N", "S"],
+            svec!["10", "a"],
+            svec!["10", "a"],
+            svec!["10", "b"],
+            svec!["20", "B"],
+            svec!["20", "b"],
+            svec!["3", "c"],
+            svec!["4", "d"],
+        ],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--sorted").arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["N", "S"],
+        svec!["10", "a"],
+        svec!["10", "b"],
+        svec!["20", "B"],
+        svec!["20", "b"],
+        svec!["3", "c"],
+        svec!["4", "d"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn dedup_sorted_nocase() {
+    let wrk = Workdir::new("dedup_sorted_nocase");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["N", "S"],
+            svec!["10", "a"],
+            svec!["10", "A"],
+            svec!["10", "a"],
+            svec!["10", "A"],
+            svec!["11", "c"],
+            svec!["20", "b"],
+            svec!["20", "b"],
+            svec!["20", "B"],
+            svec!["20", "B"],
+            svec!["3", "c"],
+            svec!["4", "d"],
+        ],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--sorted").arg("--no-case").arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["N", "S"],
+        svec!["10", "a"],
+        svec!["11", "c"],
+        svec!["20", "b"],
+        svec!["3", "c"],
+        svec!["4", "d"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn dedup_alreadysorted_nocase() {
+    let wrk = Workdir::new("dedup_alreadysorted_nocase");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["N", "S"],
+            svec!["10", "a"],
+            svec!["10", "a"],
+            svec!["10", "a"],
+            svec!["100", "a"],
+            svec!["100", "a"],
+            svec!["20", "b"],
+            svec!["20", "b"],
+            svec!["20", "B"],
+            svec!["20", "B"],
+            svec!["3", "c"],
+            svec!["4", "d"],
+        ],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--no-case").arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["N", "S"],
+        svec!["10", "a"],
+        svec!["100", "a"],
+        svec!["20", "b"],
+        svec!["3", "c"],
+        svec!["4", "d"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn dedup_not_sorted() {
+    let wrk = Workdir::new("dedup__not_sorted");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["N", "S"],
+            svec!["30", "c"],
+            svec!["10", "a"],
+            svec!["10", "a"],
+            svec!["20", "b"],
+            svec!["20", "B"],
+        ],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--sorted").arg("in.csv");
+
+    let got: String = wrk.output_stderr(&mut cmd);
+    assert!(got.contains("Aborting! Input not sorted!"));
+}
+
+#[test]
+fn dedup_not_sorted2() {
+    let wrk = Workdir::new("dedup__not_sorted2");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["N", "S"],
+            svec!["10", "a"],
+            svec!["10", "a"],
+            svec!["20", "b"],
+            svec!["20", "B"],
+            svec!["1", "c"],
+        ],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--sorted").arg("in.csv");
+
+    let got: String = wrk.output_stderr(&mut cmd);
+    assert!(got.contains("Aborting! Input not sorted!"));
+}


### PR DESCRIPTION
- added `--sorted` option to deduplicate an already sorted CSV file. This will allow `dedup` to run in streaming mode with constant memory, as it no longer needs to load the entire CSV into memory to sort it first.
- together with `extsort` command, this enables qsv to dedup arbitrarily large CSV files that will not fit into memory.