### PR TITLE
`sniff`: preamble and rowcount fixes

### DIFF
--- a/resources/test/snifftest.csv
+++ b/resources/test/snifftest.csv
@@ -1,0 +1,7 @@
+this is a preamble row
+another preamble row
+and yet another
+h1,h2,h3,h4
+abcdefg,1,a,3.14
+a,2,z,1.2020569
+c,42,x,1.0

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -47,17 +47,29 @@ struct SniffStruct {
     types: Vec<String>,
 }
 
+fn rowcount(conf: &Config, metadata: &csv_sniffer::metadata::Metadata) -> u64 {
+    let has_header_row = metadata.dialect.header.has_header_row;
+    let num_preamble_rows = metadata.dialect.header.num_preamble_rows;
+    let prelim_count = util::count_rows(conf);
+    let mut final_rowcount = prelim_count;
+
+    if !has_header_row {
+        final_rowcount += 1;
+    }
+    
+    final_rowcount = final_rowcount - num_preamble_rows as u64;
+    final_rowcount
+}
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    let conf = Config::new(&args.arg_input);
+    let conf = Config::new(&args.arg_input).flexible(true);
     let rdr = conf.reader_file_stdin()?;
 
     let sniff_results = Sniffer::new()
         .sample_size(SampleSize::Records(args.flag_len))
         .sniff_reader(rdr.into_inner());
-
-    let num_rows = util::count_rows(&conf);
 
     if args.flag_json || args.flag_pretty_json {
         match sniff_results {
@@ -75,7 +87,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         csv_sniffer::metadata::Quote::Some(chr) => format!("{}", char::from(chr)),
                         csv_sniffer::metadata::Quote::None => "none".into(),
                     },
-                    num_records: num_rows,
+                    num_records: rowcount(&conf, &metadata),
                     num_fields: metadata.num_fields,
                     types: sniffedtypes,
                 };
@@ -100,6 +112,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 // remove Dialect header
                 disp = disp.replace("Dialect:\n", "");
                 // add number of records if not stdin, where we can count rows
+                let num_rows = rowcount(&conf, &metadata);
                 if num_rows > 0 {
                     let rows_str = format!(
                         "\nNumber of records: {}\nNumber of fields:",

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -112,39 +112,39 @@ fn qsv_sniff_tab_delimiter_env() {
 #[test]
 fn sniff_json() {
     let wrk = Workdir::new("sniff_json");
-    wrk.create_with_delim("in.file", data(), b',');
+    let test_file = wrk.load_test_file("snifftest.csv");
 
     let mut cmd = wrk.command("sniff");
-    cmd.arg("--json").arg("in.file");
+    cmd.arg("--json").arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
 
-    let expected = r#"{"delimiter_char":",","header_row":true,"preamble_rows":0,"quote_char":"none","num_records":2,"num_fields":3,"types":["Text","Unsigned","Text"]}"#;
-
+    let expected = r#"{"delimiter_char":",","header_row":true,"preamble_rows":3,"quote_char":"none","num_records":3,"num_fields":4,"types":["Text","Unsigned","Text","Float"]}"#;
     assert_eq!(got, expected);
 }
 
 #[test]
 fn sniff_pretty_json() {
     let wrk = Workdir::new("sniff_pretty_json");
-    wrk.create_with_delim("in.file", data(), b',');
+    let test_file = wrk.load_test_file("snifftest.csv");
 
     let mut cmd = wrk.command("sniff");
-    cmd.arg("--pretty-json").arg("in.file");
+    cmd.arg("--pretty-json").arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
 
     let expected = r#"{
   "delimiter_char": ",",
   "header_row": true,
-  "preamble_rows": 0,
+  "preamble_rows": 3,
   "quote_char": "none",
-  "num_records": 2,
-  "num_fields": 3,
+  "num_records": 3,
+  "num_fields": 4,
   "types": [
     "Text",
     "Unsigned",
-    "Text"
+    "Text",
+    "Float"
   ]
 }"#;
 


### PR DESCRIPTION
- now works properly with CSVs with preamble rows by setting flexible = true
- rowcounts take preamble rows and header row into account