### PR TITLE
`qsvdp`: add `validate` command

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -64,5 +64,4 @@ pub mod stats;
 pub mod table;
 #[cfg(any(feature = "full", feature = "lite"))]
 pub mod transpose;
-#[cfg(any(feature = "full", feature = "lite"))]
 pub mod validate;

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -4,6 +4,7 @@ use crate::CliError;
 use crate::CliResult;
 use anyhow::{anyhow, Result};
 use csv::ByteRecord;
+#[cfg(any(feature = "full", feature = "lite"))]
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use jsonschema::paths::PathChunk;
 use jsonschema::{output::BasicOutput, JSONSchema};
@@ -184,12 +185,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let headers = rdr.byte_headers()?.clone();
 
     // prep progress bar
+    #[cfg(any(feature = "full", feature = "lite"))]
     let progress = ProgressBar::new(0);
-    // for purpose of full file row count, prevent CSV reader to abort on incosistent column count
+
+    // for purpose of full file row count, prevent CSV reader to abort on inconsistent column count
     rconfig = rconfig.flexible(true);
     let record_count = util::count_rows(&rconfig);
     rconfig = rconfig.flexible(false);
 
+    #[cfg(any(feature = "full", feature = "lite"))]
     if !args.flag_quiet {
         util::prep_progress(&progress, record_count);
     } else {
@@ -268,6 +272,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             break;
         }
 
+        #[cfg(any(feature = "full", feature = "lite"))]
         let batch_size = batch.len();
 
         // do actual validation via Rayon parallel iterator
@@ -295,6 +300,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }
         }
 
+        #[cfg(any(feature = "full", feature = "lite"))]
         if !args.flag_quiet {
             progress.inc(batch_size as u64);
         }
@@ -305,6 +311,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
     } // end infinite loop
 
+    #[cfg(any(feature = "full", feature = "lite"))]
     if !args.flag_quiet {
         progress.set_message(format!(
             " validated {} records.",

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -57,6 +57,7 @@ macro_rules! command_list {
     slice       Slice records from CSV
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     stats       Infer data types and compute descriptive statistics
+    validate    Validate CSV data with JSON Schema
 
     sponsored by datHere - Data Infrastructure Engineering
 "
@@ -195,6 +196,7 @@ enum Command {
     Slice,
     Sort,
     Stats,
+    Validate,
 }
 
 impl Command {
@@ -231,6 +233,7 @@ impl Command {
             Command::Slice => cmd::slice::run(argv),
             Command::Sort => cmd::sort::run(argv),
             Command::Stats => cmd::stats::run(argv),
+            Command::Validate => cmd::validate::run(argv),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@ use crate::CliResult;
 use docopt::Docopt;
 #[cfg(any(feature = "full", feature = "lite"))]
 use indicatif::{ProgressBar, ProgressStyle};
+#[allow(unused_imports)]
 use log::{debug, error, info, log_enabled, Level};
 #[cfg(any(feature = "full", feature = "lite"))]
 use regex::Regex;


### PR DESCRIPTION
- so we can do extended CSV validation now in DP+, as well as jsonschema validation in  future DP+ versions