### PR TITLE
`sniff`: support non-utf8 files; flexible detection now works; rename --len to --sample

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,10 +669,10 @@ dependencies = [
 [[package]]
 name = "csv-sniffer"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e32aa93b952410d55c1ae03048cc22a6cc62a323711b8e9245ef4b5578051c"
+source = "git+https://github.com/jqnatividad/csv-sniffer?branch=non-utf8-bytecount#57c4e81151a0200c6c6873fbe61dfdebacb536d8"
 dependencies = [
  "bitflags",
+ "bytecount",
  "csv",
  "csv-core",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ crossbeam-channel = "0.5"
 csv = "1.1"
 csv-core = "0.1"
 csv-index = "0.1"
-csv-sniffer = "0.3"
+csv-sniffer = { version = "0.3", features = ["runtime-dispatch-simd"] }
 docopt = "1"
 dynfmt = { version = "0.1", default-features = false, features = [
     "curly",
@@ -157,6 +157,7 @@ calamine = { git = "https://github.com/jqnatividad/calamine", rev = "8023d886519
 csv = { git = "https://github.com/jqnatividad/rust-csv", branch = "perf-tweaks" }
 csv-core = { git = "https://github.com/jqnatividad/rust-csv", branch = "perf-tweaks" }
 csv-index = { git = "https://github.com/jqnatividad/rust-csv", branch = "perf-tweaks" }
+csv-sniffer = { git = "https://github.com/jqnatividad/csv-sniffer", branch = "non-utf8-bytecount" }
 docopt = { git = "https://github.com/jqnatividad/docopt.rs", branch = "perf-clippy-2021" }
 ext-sort = { git = "https://github.com/jqnatividad/ext-sort-rs", rev = "fd955e2462a65cae0de9c9e5113ea56d2904106a" }
 jsonschema = { git = "https://github.com/Stranger6667/jsonschema-rs", rev = "ead0da16db5a12a6d12cd54bc087d18ed6e62c08"}

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ qsv stats wcp.csv --output wcpstats.csv
 
 * `QSV_DEFAULT_DELIMITER` - single ascii character to use as delimiter.  Overrides `--delimeter` option. Defaults to "," (comma) for CSV files and "\t" (tab) for TSV files, when not set. Note that this will also set the delimiter for qsv's output to stdout. However, using the `--output` option, regardless of this environment variable, will automatically change the delimiter used in the generated file based on the file extension - i.e. comma for `.csv`, tab for `.tsv` and `.tab` files.
 * `QSV_SNIFF_DELIMITER` - when set, the delimiter is automatically detected. Overrides `QSV_DEFAULT_DELIMITER` and `--delimiter` option. Note that this does not work
-with stdin and requires UTF8-encoded files.
+with stdin.
 * `QSV_NO_HEADERS` - when set, the first row will **NOT** be interpreted as headers. Supersedes `QSV_TOGGLE_HEADERS`.
 * `QSV_TOGGLE_HEADERS` - if set to `1`, toggles header setting - i.e. inverts qsv header behavior, with no headers being the default, and setting `--no-headers` will actually mean headers will not be ignored.
 * `QSV_AUTOINDEX` - when set, automatically create an index when none is detected. Also automatically updates stale indices.

--- a/resources/test/snifftest-flexible.csv
+++ b/resources/test/snifftest-flexible.csv
@@ -1,0 +1,9 @@
+this is a preamble row
+another preamble row
+and yet another
+h1,h2,h3,h4
+abcdefg,1,a,3.14
+a,2,z,1.2020569
+c,42,x,1.0
+d,42,w
+e,88,q,32.5

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -137,7 +137,6 @@ fn sniff_flexible_json() {
     assert_eq!(got, expected);
 }
 
-
 #[test]
 fn sniff_pretty_json() {
     let wrk = Workdir::new("sniff_pretty_json");

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -119,9 +119,24 @@ fn sniff_json() {
 
     let got: String = wrk.stdout(&mut cmd);
 
-    let expected = r#"{"delimiter_char":",","header_row":true,"preamble_rows":3,"quote_char":"none","num_records":3,"num_fields":4,"types":["Text","Unsigned","Text","Float"]}"#;
+    let expected = r#"{"delimiter_char":",","header_row":true,"preamble_rows":3,"quote_char":"none","flexible":false,"num_records":3,"num_fields":4,"types":["Text","Unsigned","Text","Float"]}"#;
     assert_eq!(got, expected);
 }
+
+#[test]
+fn sniff_flexible_json() {
+    let wrk = Workdir::new("sniff_flexible_json");
+    let test_file = wrk.load_test_file("snifftest-flexible.csv");
+
+    let mut cmd = wrk.command("sniff");
+    cmd.arg("--json").arg(test_file);
+
+    let got: String = wrk.stdout(&mut cmd);
+
+    let expected = r#"{"delimiter_char":",","header_row":true,"preamble_rows":3,"quote_char":"none","flexible":true,"num_records":5,"num_fields":4,"types":["Text","Unsigned","Text","Float"]}"#;
+    assert_eq!(got, expected);
+}
+
 
 #[test]
 fn sniff_pretty_json() {
@@ -138,6 +153,7 @@ fn sniff_pretty_json() {
   "header_row": true,
   "preamble_rows": 3,
   "quote_char": "none",
+  "flexible": false,
   "num_records": 3,
   "num_fields": 4,
   "types": [


### PR DESCRIPTION
We used the csv-sniffer crate to enable the sniff command. It did not support non-utf8 files, and the flexible detection was not fully working.

Fixed those two issues on this PR (https://github.com/jblondin/csv-sniffer/pull/16).

To go ahead with the release, using our csv-sniffer fork.  Will switch back to the upstream csv-sniffer once the PR is merged. 