### PR TITLE
`sniff`: intelligent sampling

### DIFF
--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -10,9 +10,9 @@ static USAGE: &str = r#"
 Quickly sniff CSV metadata (delimiter, header row, preamble rows, quote character, 
 flexible, is_utf8, number of records, number of fields, field names & data types).
 
-NOTE: This command "sniffs" a CSV's schema by sampling the first n rows of a file
-(use --sample to adjust), and its inferences are sometimes wrong if the sample is
-not large enough.
+NOTE: This command "sniffs" a CSV's schema by sampling the first n rows of a file.
+Its inferences are sometimes wrong if the sample is not large enough (use --sample 
+to adjust). 
 
 If you want more robust, guaranteed schemata, use the "schema" or "stats" commands
 instead as they scan the entire file.
@@ -85,10 +85,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // is really not precise - see https://floating-point-gui.de/errors/comparison/
         sample_all = true;
     }
-    // sample_size is at least 10
-    if sample_size < 10.0 {
-        sample_size = 10.0;
-    }
 
     let rdr = conf.reader_file_stdin()?;
 
@@ -98,7 +94,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .sample_size(SampleSize::All)
             .sniff_reader(rdr.into_inner())
     } else {
-        let sniff_size = sample_size as usize;
+        let mut sniff_size = sample_size as usize;
+        // sample_size is at least 10
+        if sniff_size < 10 {
+            sniff_size = 10;
+        }
         log::info!("Sniffing {sniff_size} of {n_rows} rows...");
         Sniffer::new()
             .sample_size(SampleSize::Records(sniff_size))

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -56,7 +56,7 @@ struct SniffStruct {
     types: Vec<String>,
 }
 
-fn rowcount(metadata: &csv_sniffer::metadata::Metadata, rowcount:u64 ) -> u64 {
+fn rowcount(metadata: &csv_sniffer::metadata::Metadata, rowcount: u64) -> u64 {
     let has_header_row = metadata.dialect.header.has_header_row;
     let num_preamble_rows = metadata.dialect.header.num_preamble_rows;
     let mut final_rowcount = rowcount;

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -174,3 +174,96 @@ fn sniff_pretty_json() {
 
     assert_eq!(got, expected);
 }
+
+
+#[test]
+fn sniff_sample() {
+    let wrk = Workdir::new("sniff_sample");
+    let test_file = wrk.load_test_file("adur-public-toilets.csv");
+
+    let mut cmd = wrk.command("sniff");
+    cmd.arg("--pretty-json").arg("--sample").arg("0.25").arg(test_file);
+
+    let got: String = wrk.stdout(&mut cmd);
+
+    let expected = r#"{
+  "delimiter_char": ",",
+  "header_row": true,
+  "preamble_rows": 0,
+  "quote_char": "none",
+  "flexible": false,
+  "is_utf8": true,
+  "num_records": 15,
+  "num_fields": 32,
+  "fields": [
+    "ExtractDate",
+    "OrganisationURI",
+    "OrganisationLabel",
+    "ServiceTypeURI",
+    "ServiceTypeLabel",
+    "LocationText",
+    "CoordinateReferenceSystem",
+    "GeoX",
+    "GeoY",
+    "GeoPointLicensingURL",
+    "Category",
+    "AccessibleCategory",
+    "RADARKeyNeeded",
+    "BabyChange",
+    "FamilyToilet",
+    "ChangingPlace",
+    "AutomaticPublicConvenience",
+    "FullTimeStaffing",
+    "PartOfCommunityScheme",
+    "CommunitySchemeName",
+    "ChargeAmount",
+    "InfoURL",
+    "OpeningHours",
+    "ManagedBy",
+    "ReportEmail",
+    "ReportTel",
+    "Notes",
+    "UPRN",
+    "Postcode",
+    "StreetAddress",
+    "GeoAreaURI",
+    "GeoAreaLabel"
+  ],
+  "types": [
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Unsigned",
+    "Unsigned",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Boolean",
+    "Boolean",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Text",
+    "Unsigned",
+    "Boolean",
+    "Text",
+    "Boolean",
+    "Boolean"
+  ]
+}"#;
+
+    assert_eq!(got, expected);
+}

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -175,14 +175,16 @@ fn sniff_pretty_json() {
     assert_eq!(got, expected);
 }
 
-
 #[test]
 fn sniff_sample() {
     let wrk = Workdir::new("sniff_sample");
     let test_file = wrk.load_test_file("adur-public-toilets.csv");
 
     let mut cmd = wrk.command("sniff");
-    cmd.arg("--pretty-json").arg("--sample").arg("0.25").arg(test_file);
+    cmd.arg("--pretty-json")
+        .arg("--sample")
+        .arg("0.25")
+        .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
 


### PR DESCRIPTION
the sample size can be:
- an integer (first n rows to sample)
- a percentage if between 0 and 1 exclusive (e.g. 0.20 is 20 percent, first 20 percent of total rows)
- zero (sample the whole file)

The default sample size is 100 rows.