### PR TITLE
`sniff`: can now sniff date and datetime data types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,13 +889,11 @@ checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -1245,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
@@ -1913,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b305cc4569dd4e8765bab46261f67ef5d4d11a4b6e745100ee5dad8948b46c"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -2152,16 +2150,16 @@ dependencies = [
 
 [[package]]
 name = "qsv-sniffer"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f88555486a4988c43aec6d906b7a81c6158274aa5f2936ae06f7b7e30fbc860"
+checksum = "64828e2cf67cea165ec10b9e8820677f6faa6baa2bb066366220ff5d4d51e749"
 dependencies = [
  "bitflags",
  "bytecount",
  "csv",
  "csv-core",
  "memchr",
- "once_cell",
+ "qsv-dateparser",
  "regex",
  "tabwriter",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ pyo3 = { version = "0.16", features = [
 qsv-dateparser = "0.4"
 qsv-stats = "0.3"
 qsv_currency = { version = "0.5", optional = true }
-qsv-sniffer = { version = "0.4", features = ["runtime-dispatch-simd"] }
+qsv-sniffer = { version = "0.5", features = ["runtime-dispatch-simd"] }
 rand = "0.8"
 rayon = "1.5"
 regex = "1"

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -232,7 +232,7 @@ fn sniff_sample() {
     "GeoAreaLabel"
   ],
   "types": [
-    "Text",
+    "DateTime",
     "Text",
     "Text",
     "Text",


### PR DESCRIPTION
and the user can specify if they prefer to parse dates in dmy format with the `--prefer-dmy` option