### PR TITLE
`fetch`: perf tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [FAQ](https://github.com/jqnatividad/qsv/wiki/FAQ) for more details.
 | [exclude](/src/cmd/exclude.rs#L18)[^2] | Removes a set of CSV data from another set based on the specified columns.  |
 | [explode](/src/cmd/explode.rs#L8-L9) | Explode rows into multiple ones by splitting a column value based on the given separator.  |
 | [extsort](/src/cmd/extsort.rs#L12)[^5] | Sort an arbitrarily large CSV/text file using a multithreaded [external merge sort](https://en.wikipedia.org/wiki/External_sorting) algorithm. |
-| [fetch](/src/cmd/fetch.rs#L20-L21) | Fetches HTML/data from web pages or web services for every row in a URL column. Comes with [jql](https://github.com/yamafaktory/jql#%EF%B8%8F-usage) JSON query language support, dynamic throttling & optional [Redis](https://redis.io/) response caching. |
+| [fetch](/src/cmd/fetch.rs#L24) | Fetches HTML/data from web pages or web services for every row. Comes with [jql](https://github.com/yamafaktory/jql#%EF%B8%8F-usage) JSON query language support, dynamic throttling ([RateLimit](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html)) & caching with optional [Redis](https://redis.io/) support for persistent caching. |
 | [fill](/src/cmd/fill.rs#L13) | Fill empty values.  |
 | [fixlengths](/src/cmd/fixlengths.rs#L9-L11) | Force a CSV to have same-length records by either padding or truncating them. |
 | [flatten](/src/cmd/flatten.rs#L12-L15) | A flattened view of CSV records. Useful for viewing one record at a time.<br />e.g. `qsv slice -i 5 data.csv \| qsv flatten`. |

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 // NOTE: when using the examples with jql, DO NOT USE the example here as rendered in
 // source code, use the example as rendered by "qsv fetch --help".
-// the source code below has addl escape characters for the jql examples, 
+// the source code below has addl escape characters for the jql examples,
 // so cutting and pasting it into the command line will not work.
 static USAGE: &str = "
 Fetches HTML/data from web pages or web services for every row.


### PR DESCRIPTION
- minimize use of mutable variables
- minimize use of intermediate assignments, assign to vars directly when possible
- raise qps limit to 25
- add more comments
- expand usage text with more info on caching; sync up fetch description in README; link to RateLimit