### PR TITLE
`fetch`: better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec23e6762830658d2b3d385a75aa212af2f67a4586d4442907144f3bb6a1ca8"
 dependencies = [
  "matrixmultiply",
- "num-complex 0.4.1",
+ "num-complex 0.4.2",
  "num-integer",
  "num-traits",
  "rawpointer",
@@ -1651,7 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-bigint 0.4.3",
- "num-complex 0.4.1",
+ "num-complex 0.4.2",
  "num-integer",
  "num-iter",
  "num-rational 0.4.0",
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
 ]
@@ -2129,7 +2129,6 @@ dependencies = [
  "sysinfo",
  "tabwriter",
  "test-data-generation",
- "thiserror",
  "thousands",
  "threadpool",
  "titlecase",
@@ -2724,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c481baae55ea597122229896b67df9af4b941678bf2eab6228139331e66fb0"
+checksum = "7d80929a3b477bce3a64360ca82bfb361eacce1dcb7b1fb31e8e5e181e37c212"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2943,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ strsim = { version = "0.10", optional = true }
 sysinfo = "0.24"
 tabwriter = "1.2"
 test-data-generation = { version = "0.3", optional = true }
-thiserror = { version = "1.0", optional = true }
 thousands = "0.2"
 threadpool = "1.8"
 titlecase = { version = "2", optional = true }
@@ -182,7 +181,7 @@ apply = [
     "vader_sentiment",
     "whatlang",
 ]
-fetch = ["cached", "dynfmt", "governor", "jql", "jsonxf", "thiserror", "url"]
+fetch = ["cached", "dynfmt", "governor", "jql", "jsonxf", "url"]
 foreach = []
 generate = ["test-data-generation"]
 lua = ["mlua"]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::{env, fs, io, str, thread, time};
@@ -96,17 +95,18 @@ pub fn version() -> String {
     match (qsvtype, maj, min, pat, pre) {
         (Some(qsvtype), Some(maj), Some(min), Some(pat), Some(pre)) => {
             if pre.is_empty() {
-                return format!(
+                format!(
                     "{qsvtype} {maj}.{min}.{pat}-{malloc_kind}-{enabled_features}{maxjobs}-{numcpus}",
                     maxjobs = max_jobs(),
                     numcpus = num_cpus()
-                );
-            }
-            format!(
+                )
+            } else {
+                format!(
                     "{qsvtype} {maj}.{min}.{pat}-{pre}-{malloc_kind}-{enabled_features}{maxjobs}-{numcpus}",
                     maxjobs = max_jobs(),
                     numcpus = num_cpus(),
                 )
+            }
         }
         _ => "".to_owned(),
     }


### PR DESCRIPTION
use our crate::CliError instead of thiserror to handle Redis/reqwest::ClientBuilder errors
- this makes it cleaner as we can bubble up the error to main, instead of doing an unwrap
- turn on adaptive flow control in case we're using HTTP2 for improved network performance/throughput
- added more comments