### PR TITLE
`fetch`: faster defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ cached = { version = "0.37", default-features = false, features = [
 ], optional = true }
 calamine = { version = "0.18", features = ["dates"] }
 censor = { version = "0.2", optional = true }
+console = { version = "0.15", optional = true }
 crossbeam-channel = "0.5"
 csv = "1.1"
 csv-core = "0.1"
@@ -89,7 +90,7 @@ flexi_logger = { version = "0.22", features = [
 ], default-features = false }
 governor = { version = "0.4", optional = true }
 grex = { version = "1.3", default-features = false }
-indexmap = {version = "1.9.1", features = ["serde-1"]}
+indexmap = { version = "1.9", features = ["serde-1"] }
 indicatif = "0.16"
 itertools = "0.10"
 itoa = "1"
@@ -185,7 +186,16 @@ apply = [
     "vader_sentiment",
     "whatlang",
 ]
-fetch = ["cached", "dynfmt", "governor", "jql", "jsonxf", "redis", "url"]
+fetch = [
+    "cached",
+    "console",
+    "dynfmt",
+    "governor",
+    "jql",
+    "jsonxf",
+    "redis",
+    "url",
+]
 foreach = []
 generate = ["test-data-generation"]
 lua = ["mlua"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [FAQ](https://github.com/jqnatividad/qsv/wiki/FAQ) for more details.
 | [exclude](/src/cmd/exclude.rs#L18)[^2] | Removes a set of CSV data from another set based on the specified columns.  |
 | [explode](/src/cmd/explode.rs#L8-L9) | Explode rows into multiple ones by splitting a column value based on the given separator.  |
 | [extsort](/src/cmd/extsort.rs#L12)[^5] | Sort an arbitrarily large CSV/text file using a multithreaded [external merge sort](https://en.wikipedia.org/wiki/External_sorting) algorithm. |
-| [fetch](/src/cmd/fetch.rs#L31) | Fetches HTML/data from web pages or web services for every row. Comes with [jql](https://github.com/yamafaktory/jql#%EF%B8%8F-usage) JSON query language support, dynamic throttling ([RateLimit](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html)) & caching with optional [Redis](https://redis.io/) support for persistent caching. |
+| [fetch](/src/cmd/fetch.rs#L33) | Fetches HTML/data from web pages or web services for every row. Comes with [jql](https://github.com/yamafaktory/jql#%EF%B8%8F-usage) JSON query language support, dynamic throttling ([RateLimit](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html)) & caching with optional [Redis](https://redis.io/) support for persistent caching. |
 | [fill](/src/cmd/fill.rs#L13) | Fill empty values.  |
 | [fixlengths](/src/cmd/fixlengths.rs#L9-L11) | Force a CSV to have same-length records by either padding or truncating them. |
 | [flatten](/src/cmd/flatten.rs#L12-L15) | A flattened view of CSV records. Useful for viewing one record at a time.<br />e.g. `qsv slice -i 5 data.csv \| qsv flatten`. |

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -6,11 +6,12 @@ use crate::CliResult;
 use crate::{regex_once_cell, util};
 use cached::proc_macro::{cached, io_cached};
 use cached::{RedisCache, Return};
+use console::set_colors_enabled;
 use dynfmt::Format;
 use governor::{
     clock::DefaultClock, middleware::NoOpMiddleware, state::direct::NotKeyed, state::InMemoryState,
 };
-use indicatif::{ProgressBar, ProgressDrawTarget};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget};
 use log::{debug, error, info, log_enabled};
 use once_cell::sync::{Lazy, OnceCell};
 use rand::Rng;
@@ -21,6 +22,7 @@ use serde_json::json;
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{thread, time};
+use thousands::Separable;
 use url::Url;
 
 // NOTE: when using the examples with jql, DO NOT USE the example here as rendered in
@@ -124,14 +126,14 @@ Fetch options:
                                down-throttling as required.
                                CAUTION: Only use zero for APIs that use RateLimit headers,
                                otherwise your fetch job may look like a Denial Of Service attack.
-                               [default: 25]
+                               [default: 0 ]
     --timeout <seconds>        Timeout for each URL GET. [default: 30 ]
     --http-header <key:value>  Append custom header(s) to the HTTP header. Pass multiple key-value pairs
                                by adding this option multiple times, once for each pair. The key and value 
                                should be separated by a colon.
     --max-errors <count>       Maximum number of errors before aborting.
                                Set to zero (0) to continue despite errors.
-                               [default: 0 ]
+                               [default: 100 ]
     --store-error              On error, store error code/message instead of blank value.
     --cookies                  Allow cookies.
     --redis                    Use Redis to cache responses. It connects to "redis://127.0.0.1:6379"
@@ -220,6 +222,8 @@ static JQL_GROUPS: once_cell::sync::OnceCell<Vec<jql::Group>> = OnceCell::new();
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
+
+    set_colors_enabled(true);
 
     if args.flag_redis {
         // check if redis connection is valid
@@ -370,15 +374,35 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         false
     };
 
-    // prep progress bar
-    let progress = ProgressBar::new(0);
+    // prep progress bars
+    let multi_progress = MultiProgress::new();
+    let progress = multi_progress.add(ProgressBar::new(0));
     let mut record_count = 0;
+
+    let error_progress = multi_progress.add(ProgressBar::new(args.flag_max_errors as u64));
+    if args.flag_max_errors > 0 {
+        error_progress.set_style(
+            indicatif::ProgressStyle::default_bar()
+                .template("{bar:37.red/white} {percent}%{msg} ({per_sec})")
+                .progress_chars("##-"),
+        );
+        error_progress.set_message(format!(
+            " of {} max errors",
+            args.flag_max_errors.separate_with_commas()
+        ));
+    } else {
+        error_progress.set_draw_target(ProgressDrawTarget::hidden());
+    }
     if args.flag_quiet {
         progress.set_draw_target(ProgressDrawTarget::hidden());
+        error_progress.set_draw_target(ProgressDrawTarget::hidden());
     } else {
         record_count = util::count_rows(&rconfig)?;
         util::prep_progress(&progress, record_count);
     }
+
+    let multi_progress = thread::spawn(move || multi_progress.join());
+
     // do a progress update every 3 seconds
     // for very large jobs, so the job doesn't look frozen
     if record_count > 100_000 {
@@ -416,6 +440,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut final_value = String::with_capacity(150);
     #[allow(unused_assignments)]
     let mut str_value = String::with_capacity(100);
+    let mut running_error_count = 0_usize;
 
     while rdr.read_byte_record(&mut record)? {
         if not_quiet {
@@ -483,13 +508,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             wtr.write_byte_record(&output_record)?;
         }
 
-        if args.flag_max_errors > 0
-            && GLOBAL_ERROR_COUNT.load(Ordering::Relaxed) >= args.flag_max_errors
-        {
-            let abort_msg = format!("{} max errors. Fetch aborted.", args.flag_max_errors);
-            info!("{abort_msg}");
-            eprintln!("{abort_msg}");
-            break;
+        if args.flag_max_errors > 0 {
+            let error_count = GLOBAL_ERROR_COUNT.load(Ordering::SeqCst);
+            if error_count > running_error_count {
+                error_progress.inc(1);
+                running_error_count += 1;
+            }
+            if error_count >= args.flag_max_errors {
+                break;
+            };
         }
     }
 
@@ -500,6 +527,22 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             util::update_cache_info!(progress, GET_CACHED_RESPONSE);
         }
         util::finish_progress(&progress);
+        if running_error_count == 0 {
+            error_progress.finish_and_clear();
+        } else {
+            error_progress.finish();
+
+            // sleep so we can dependably write eprintln without messing up progress bars
+            thread::sleep(time::Duration::from_nanos(10));
+
+            let abort_msg = format!(
+                "{} max errors. Fetch aborted.",
+                args.flag_max_errors.separate_with_commas()
+            );
+            info!("{abort_msg}");
+            eprintln!("{abort_msg}");
+        }
+        let _ = multi_progress.join().unwrap();
     }
 
     Ok(wtr.flush()?)
@@ -633,7 +676,11 @@ fn get_response(
     let resp: reqwest::blocking::Response = match client.get(&valid_url).send() {
         Ok(response) => response,
         Err(error) => {
-            error!("Cannot fetch url: {valid_url:?}, error: {error:?}");
+            GLOBAL_ERROR_COUNT.fetch_add(1, Ordering::SeqCst);
+            error!(
+                "Cannot fetch url: {valid_url:?}, err_count: {}, error: {error:?}",
+                GLOBAL_ERROR_COUNT.load(Ordering::SeqCst)
+            );
             if flag_store_error {
                 return error.to_string();
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -181,7 +181,7 @@ pub fn finish_progress(progress: &ProgressBar) {
     let per_sec_rate = progress.per_sec();
 
     let finish_template = format!(
-        "[{{elapsed_precise}}] [{{bar:20}} {{percent}}%{{msg}}] ({}/sec)",
+        "[{{elapsed_precise}}] [{{bar:25}} {{percent}}%{{msg}}] ({}/sec)",
         per_sec_rate.separate_with_commas()
     );
 


### PR DESCRIPTION
- rate-limit is zero by default. so fetch will go as fast as possible, with max-errors of 100 instead of zero
- we now display a separate progress bar for errors