### PR TITLE
`fetch`: add elapsed time to reports; add --max-retries

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 9

--- a/src/util.rs
+++ b/src/util.rs
@@ -212,9 +212,8 @@ macro_rules! update_cache_info {
                     let misses = cache.cache_misses().expect("Cache misses required");
                     let hit_ratio = (hits as f64 / (hits + misses) as f64) * 100.0;
                     $progress.set_message(format!(
-                        " of {} records. Cache hit ratio: {hit_ratio:.2}% - {} entries",
+                        " of {} records. Cache hit ratio: {hit_ratio:.2}%",
                         $progress.length().separate_with_commas(),
-                        cache_size.separate_with_commas(),
                     ));
                 }
             }


### PR DESCRIPTION
- change timeout default from 30 to 15
- removed GLOBAL atomic
- simplified docopt parameter parsing
- improved post-fetch messages