### PR TITLE
utf8 encoding check fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ qsv stats wcp.csv --output wcpstats.csv
 | `QSV_NO_UPDATE` | if set, prohibit self-update version check for the latest qsv release published on GitHub. |
 | `QSV_PREFER_DMY` | if set, date parsing will use DMY format. Otherwise, use MDY format (used with `apply datefmt`, `schema`, `sniff` & `stats` commands). |
 | `QSV_REGEX_UNICODE` | if set, makes `search`, `searchset` and `replace` commands unicode-aware. For increased performance, these commands are not unicode-aware and will ignore unicode values when matching and will panic when unicode characters are used in the regex. |
-| `QSV_SKIPUTF8_CHECK` | if set, skip UTF-8 encoding check. Otherwise, qsv scans the first 8k of files. For stdin, it scans the entire buffer. |
+| `QSV_SKIPUTF8_CHECK` | if set, skip UTF-8 encoding check. Otherwise, qsv scans the first 8k. |
 | `QSV_RDR_BUFFER_CAPACITY` | reader buffer size (default (bytes): 16384) |
 | `QSV_WTR_BUFFER_CAPACITY` | writer buffer size (default (bytes): 65536) |
 | `QSV_LOG_LEVEL` | desired level (default - off; `error`, `warn`, `info`, `trace`, `debug`). |

--- a/src/util.rs
+++ b/src/util.rs
@@ -253,6 +253,7 @@ pub fn many_configs(
             Config::new(&Some(p))
                 .delimiter(delim)
                 .no_headers(no_headers)
+                .checkutf8(false)
         })
         .collect::<Vec<_>>();
     errif_greater_one_stdin(&*confs)?;


### PR DESCRIPTION
To optimize performance, qsv makes extensive use of `from_utf8_unchecked` to eliminate the penalty, however small, of repetitive utf8 validation.
To do so, we pay the utf8 validation once per invocation by doing the validation up-front by scanning the first 8k of files, or the ENTIRE stdin buffer.

The problem here is if you have chain of piped qsv commands, you effectively get repetitive utf8 validation as the results are passed via stdin.

This PR fixes this as qsv now only does the utf8 encoding check for the first 8k of both files and stdin.

Also fixes #410, as we skip utf8 validation altogether for the `headers` and `cat` commands which  uses byterecords anyway and doesn't require utf8 input.