### PR TITLE
Only do input utf8-encoding check for commands that need it

### DIFF
--- a/src/cmd/behead.rs
+++ b/src/cmd/behead.rs
@@ -26,6 +26,7 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let conf = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(false);
 

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -35,6 +35,7 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let conf = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -72,6 +72,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let mut rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
+        .checkutf8(false)
         .no_headers(args.flag_no_headers);
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -96,6 +96,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let num_sheets = sheet_names.len();
 
     let mut wtr = Config::new(&args.flag_output)
+        .checkutf8(false)
         .flexible(args.flag_flexible)
         .writer()?;
     let mut record = csv::StringRecord::new();

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -84,6 +84,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
+        .checkutf8(false)
         .select(args.arg_selection);
 
     let wconfig = Config::new(&args.flag_output);

--- a/src/cmd/fixlengths.rs
+++ b/src/cmd/fixlengths.rs
@@ -43,6 +43,7 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let config = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(true)
         .flexible(true);

--- a/src/cmd/flatten.rs
+++ b/src/cmd/flatten.rs
@@ -52,6 +52,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
+        .checkutf8(false)
         .no_headers(args.flag_no_headers);
     let mut rdr = rconfig.reader()?;
     let headers = rdr.byte_headers()?.clone();

--- a/src/cmd/fmt.rs
+++ b/src/cmd/fmt.rs
@@ -51,6 +51,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
     let rconfig = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(true);
     let mut wconfig = Config::new(&args.flag_output)

--- a/src/cmd/foreach.rs
+++ b/src/cmd/foreach.rs
@@ -65,6 +65,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
+        .checkutf8(false)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/generate.rs
+++ b/src/cmd/generate.rs
@@ -71,7 +71,9 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let conf = Config::new(&args.arg_input).delimiter(args.flag_delimiter);
+    let conf = Config::new(&args.arg_input)
+        .checkutf8(false)
+        .delimiter(args.flag_delimiter);
 
     let tdir = temp_dir();
     let mut dsp = DataSampleParser::new();

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -54,7 +54,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         Some(p) => PathBuf::from(&p),
     };
 
-    let rconfig = Config::new(&Some(args.arg_input)).delimiter(args.flag_delimiter);
+    let rconfig = Config::new(&Some(args.arg_input))
+        .checkutf8(false)
+        .delimiter(args.flag_delimiter);
     let mut rdr = rconfig.reader_file()?;
     let mut wtr = io::BufWriter::new(fs::File::create(&pidx)?);
     RandomAccessSimple::create(&mut rdr, &mut wtr)?;

--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -73,11 +73,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         std::env::set_var("QSV_SNIFF_PREAMBLE", "1");
     }
     let mut rconfig = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(true)
         .quote(args.flag_quote.as_byte())
-        .trim(trim_setting)
-        .checkutf8(false);
+        .trim(trim_setting);
     if args.flag_auto_skip {
         std::env::remove_var("QSV_SNIFF_PREAMBLE");
     }

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -72,6 +72,7 @@ impl Args {
         Config::new(&self.arg_input)
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
+            .checkutf8(false)
             .select(self.arg_column.clone())
     }
 

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -40,6 +40,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
     let rconfig = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -78,6 +78,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
+        .checkutf8(false)
         .select(args.flag_select);
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/reverse.rs
+++ b/src/cmd/reverse.rs
@@ -36,6 +36,7 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let rconfig = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -59,6 +59,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
+        .checkutf8(false)
         .no_headers(args.flag_no_headers);
     let mut sample_size = args.arg_sample_size;
 

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -552,6 +552,7 @@ fn generate_string_patterns(
     // standard boiler-plate for reading CSV
 
     let rconfig = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_pattern_columns.clone());

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -70,6 +70,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
+        .checkutf8(false)
         .select(args.flag_select);
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -92,6 +92,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .unicode(regex_unicode)
         .build()?;
     let rconfig = Config::new(&args.arg_input)
+        .checkutf8(false)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_select);

--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -66,6 +66,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
+        .checkutf8(false)
         .select(args.arg_selection);
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -108,6 +108,7 @@ impl Args {
 
     fn rconfig(&self) -> Config {
         Config::new(&self.arg_input)
+            .checkutf8(false)
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
     }

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -141,6 +141,7 @@ impl Args {
 
     fn rconfig(&self) -> Config {
         Config::new(&self.arg_input)
+            .checkutf8(false)
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
     }

--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -73,6 +73,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(true)
+        .checkutf8(false)
         .flexible(true);
     let wconfig = Config::new(&args.flag_output).delimiter(Some(Delimiter(b'\t')));
 

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -93,6 +93,7 @@ impl Args {
 
     fn rconfig(&self) -> Config {
         Config::new(&self.arg_input)
+            .checkutf8(false)
             .delimiter(self.flag_delimiter)
             .no_headers(true)
     }


### PR DESCRIPTION
this is a follow-up to #410 .

We turned on utf8-encoding check by default, and it was applied too aggressively.

Only do so for commands that use `from_utf8_unchecked`.

This should also result in a nice performance boost for commands that don't require the check.