### PR TITLE
progressbars are now off by default, and are disabled with stdin input

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ qsv stats wcp.csv --output wcpstats.csv
 | `QSV_WTR_BUFFER_CAPACITY` | writer buffer size (default (bytes): 65536) |
 | `QSV_LOG_LEVEL` | desired level (default - off; `error`, `warn`, `info`, `trace`, `debug`). |
 | `QSV_LOG_DIR` | when logging is enabled, the directory where the log files will be stored. If the specified directory does not exist, qsv will attempt to create it. If not set, the log files are created in the directory where qsv was started. See [Logging](docs/Logging.md#logging) for more info. |
+| `QSV_PROGRESSBAR` | if set, enable the --progressbar option on the `apply`, `fetch`, `fetchpost`, `foreach`, `lua`, `py` and `validate` commands.  |
 | `QSV_REDIS_CONNSTR` | the `fetch` command can use [Redis](https://redis.io/) to cache responses. Set to connect to the desired Redis instance. (default: `redis:127.0.0.1:6379/1`). For more info on valid Redis connection string formats, see https://docs.rs/redis/latest/redis/#connection-parameters. |
 | `QSV_FP_REDIS_CONNSTR` | the `fetchpost` command can also use Redis to cache responses (default: `redis:127.0.0.1:6379/2`). Note that `fetchpost` connects to database 2, as opposed to `fetch` which connects to database 1. |
 | `QSV_REDIS_MAX_POOL_SIZE` | the maximum Redis connection pool size. (default: 20). |

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -172,7 +172,7 @@ Common options:
                                appear as the header row in the output.
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character. (default: ,)
-    -q, --quiet                Don't show progress bars.
+    -p, --progressbar          Show progress bars. Not valid for stdin.
 "#;
 
 #[derive(Deserialize, Debug)]
@@ -196,7 +196,7 @@ struct Args {
     flag_output: Option<String>,
     flag_no_headers: bool,
     flag_delimiter: Option<Delimiter>,
-    flag_quiet: bool,
+    flag_progressbar: bool,
     arg_url_column: SelectColumns,
     arg_input: Option<String>,
 }
@@ -414,14 +414,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         RateLimiter::direct(Quota::per_second(rate_limit).allow_burst(NonZeroU32::new(5).unwrap()));
 
     // prep progress bars
-    set_colors_enabled(true); // as error progress bar is red
-                              // create multi_progress to stderr with a maximum refresh of 5 per second
+    let show_progress =
+        (args.flag_progressbar || std::env::var("QSV_PROGRESSBAR").is_ok()) && !rconfig.is_stdin();
+
+    // create multi_progress to stderr with a maximum refresh of 5 per second
     let multi_progress = MultiProgress::with_draw_target(ProgressDrawTarget::stderr_with_hz(5));
     let progress = multi_progress.add(ProgressBar::new(0));
     let mut record_count = 0;
 
     let error_progress = multi_progress.add(ProgressBar::new(args.flag_max_errors as u64));
-    if args.flag_max_errors > 0 {
+    if args.flag_max_errors > 0 && show_progress {
+        set_colors_enabled(true); // as error progress bar is red
         error_progress.set_style(
             indicatif::ProgressStyle::default_bar()
                 .template("{bar:37.red/white} {percent}%{msg} ({per_sec:7})")
@@ -435,8 +438,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         error_progress.set_draw_target(ProgressDrawTarget::hidden());
     }
 
-    let not_quiet = !args.flag_quiet; // minimize negations
-    if not_quiet {
+    if show_progress {
         record_count = util::count_rows(&rconfig)?;
         util::prep_progress(&progress, record_count);
     } else {
@@ -550,7 +552,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut now = Instant::now();
 
     while rdr.read_byte_record(&mut record)? {
-        if not_quiet {
+        if show_progress {
             progress.inc(1);
         }
 
@@ -681,7 +683,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     report_wtr.flush()?;
 
-    if not_quiet {
+    if show_progress {
         if args.flag_redis {
             util::update_cache_info!(progress, redis_cache_hits, record_count);
         } else {
@@ -704,35 +706,35 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         } else {
             error_progress.abandon();
         }
-
-        let mut end_msg = format!(
-            "{} records successfully fetched as {}. {} errors.",
-            HumanCount(running_success_count),
-            if include_existing_columns {
-                "CSV"
-            } else {
-                "JSONL"
-            },
-            HumanCount(running_error_count)
-        );
-        if report != ReportKind::None {
-            use std::fmt::Write;
-
-            write!(
-                &mut end_msg,
-                " {} report created: \"{}{FETCH_REPORT_SUFFIX}\"",
-                if report == ReportKind::Detailed {
-                    "Detailed"
-                } else {
-                    "Short"
-                },
-                report_path
-            )
-            .unwrap();
-        }
-        info!("{end_msg}");
-        eprintln!("{end_msg}");
     }
+
+    let mut end_msg = format!(
+        "{} records successfully fetched as {}. {} errors.",
+        HumanCount(running_success_count),
+        if include_existing_columns {
+            "CSV"
+        } else {
+            "JSONL"
+        },
+        HumanCount(running_error_count)
+    );
+    if report != ReportKind::None {
+        use std::fmt::Write;
+
+        write!(
+            &mut end_msg,
+            " {} report created: \"{}{FETCH_REPORT_SUFFIX}\"",
+            if report == ReportKind::Detailed {
+                "Detailed"
+            } else {
+                "Short"
+            },
+            report_path
+        )
+        .unwrap();
+    }
+    info!("{end_msg}");
+    eprintln!("{end_msg}");
 
     Ok(wtr.flush()?)
 }


### PR DESCRIPTION
Progress bars are now off by default, and are enabled with the --progress option, replacing the --quiet option.

As it turns out, progress bars where also the cause of the panic with stdin input, as progressbars need a record count, and doing so with stdin consumed it, preventing the command from running.

Now, if using stdin, progressbars are disabled.

This was not caught in the CI tests as we don't have stdin tests that tested progressbars.

Resolves #437 