### PR TITLE
Custom exit codes; --exitcode option for search & searchset

### DIFF
--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -52,6 +52,8 @@ Common options:
                            column named <column>. For each found row, <column>
                            is set to the row number of the row, followed by a
                            semicolon, then a list of the matching regexes.
+    -e, --exitcode         Return exit code 0 if there's a match.
+                           Return exit code 1 if no match is found.
 ";
 
 #[derive(Deserialize)]
@@ -66,6 +68,7 @@ struct Args {
     flag_unicode: bool,
     flag_ignore_case: bool,
     flag_flag: Option<String>,
+    flag_exitcode: bool,
 }
 
 fn read_regexset(filename: impl AsRef<Path>) -> io::Result<Vec<String>> {
@@ -116,6 +119,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut record = csv::ByteRecord::new();
     let mut flag_rowi: u64 = 1;
+    let mut match_found = false;
+
     // to save allocs
     #[allow(unused_assignments)]
     let mut matched_rows = String::with_capacity(20);
@@ -133,6 +138,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }
             matched
         });
+        if !match_found && m {
+            match_found = true;
+        }
         if args.flag_invert_match {
             m = !m;
         }
@@ -155,5 +163,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             wtr.write_byte_record(&record)?;
         }
     }
-    Ok(wtr.flush()?)
+    wtr.flush()?;
+
+    if args.flag_exitcode {
+        if match_found {
+            std::process::exit(0);
+        } else {
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
 }

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -5,7 +5,7 @@ use std::borrow::ToOwned;
 use std::env;
 use std::fmt;
 use std::io;
-use std::process;
+use std::process::{ExitCode, Termination};
 use std::time::Instant;
 
 use docopt::Docopt;
@@ -94,6 +94,19 @@ Options:
 "
 );
 
+pub enum QsvExitCode {
+    Good = 0,
+    Bad = 1,
+    IncorrectUsage = 2,
+    Abort = 255,
+}
+
+impl Termination for QsvExitCode {
+    fn report(self) -> ExitCode {
+        ExitCode::from(self as u8)
+    }
+}
+
 #[derive(Deserialize)]
 struct Args {
     arg_command: Option<Command>,
@@ -101,7 +114,7 @@ struct Args {
     flag_envlist: bool,
 }
 
-fn main() {
+fn main() -> QsvExitCode {
     util::init_logger();
 
     let now = Instant::now();
@@ -122,11 +135,11 @@ fn main() {
     if args.flag_list {
         wout!(concat!("Installed commands:", command_list!()));
         log_end(qsv_args, now);
-        return;
+        return QsvExitCode::Good;
     } else if args.flag_envlist {
         util::show_env_vars();
         log_end(qsv_args, now);
-        return;
+        return QsvExitCode::Good;
     }
     match args.arg_command {
         None => {
@@ -136,32 +149,36 @@ fn main() {
 Please choose one of the following commands:",
                 command_list!()
             ));
-            ::std::process::exit(0);
+            return QsvExitCode::Good;
         }
         Some(cmd) => match cmd.run() {
             Ok(()) => {
                 log_end(qsv_args, now);
-                process::exit(0);
+                QsvExitCode::Good
             }
-            Err(CliError::Flag(err)) => err.exit(),
+            Err(CliError::Flag(err)) => {
+                werr!("{err}");
+                log_end(qsv_args, now);
+                QsvExitCode::IncorrectUsage
+            }
             Err(CliError::Csv(err)) => {
                 werr!("{err}");
                 log_end(qsv_args, now);
-                process::exit(1);
+                QsvExitCode::Bad
             }
             Err(CliError::Io(ref err)) if err.kind() == io::ErrorKind::BrokenPipe => {
                 log_end(qsv_args, now);
-                process::exit(0);
+                QsvExitCode::Good
             }
             Err(CliError::Io(err)) => {
                 werr!("{err}");
                 log_end(qsv_args, now);
-                process::exit(1);
+                QsvExitCode::Bad
             }
             Err(CliError::Other(msg)) => {
                 werr!("{msg}");
                 log_end(qsv_args, now);
-                process::exit(1);
+                QsvExitCode::IncorrectUsage
             }
         },
     }
@@ -308,6 +325,6 @@ impl<'a> From<&'a str> for CliError {
 
 impl From<regex::Error> for CliError {
     fn from(err: regex::Error) -> CliError {
-        CliError::Other(format!("{err:?}"))
+        CliError::Other(format!("Regex error: {err:?}"))
     }
 }

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -5,7 +5,7 @@ use std::borrow::ToOwned;
 use std::env;
 use std::fmt;
 use std::io;
-use std::process;
+use std::process::{ExitCode, Termination};
 use std::time::Instant;
 
 use docopt::Docopt;
@@ -113,6 +113,19 @@ Options:
 "
 );
 
+pub enum QsvExitCode {
+    Good = 0,
+    Bad = 1,
+    IncorrectUsage = 2,
+    Abort = 255,
+}
+
+impl Termination for QsvExitCode {
+    fn report(self) -> ExitCode {
+        ExitCode::from(self as u8)
+    }
+}
+
 #[derive(Deserialize)]
 struct Args {
     arg_command: Option<Command>,
@@ -121,7 +134,7 @@ struct Args {
     flag_update: bool,
 }
 
-fn main() {
+fn main() -> QsvExitCode {
     util::init_logger();
 
     let now = Instant::now();
@@ -142,16 +155,16 @@ fn main() {
     if args.flag_list {
         wout!(concat!("Installed commands:", command_list!()));
         log_end(qsv_args, now);
-        return;
+        return QsvExitCode::Good;
     } else if args.flag_envlist {
         util::show_env_vars();
         log_end(qsv_args, now);
-        return;
+        return QsvExitCode::Good;
     }
     if args.flag_update {
         util::qsv_check_for_update();
         log_end(qsv_args, now);
-        return;
+        return QsvExitCode::Good;
     }
     match args.arg_command {
         None => {
@@ -163,32 +176,36 @@ Please choose one of the following commands:",
             ));
             util::qsv_check_for_update();
             log_end(qsv_args, now);
-            ::std::process::exit(0);
+            return QsvExitCode::Good;
         }
         Some(cmd) => match cmd.run() {
             Ok(()) => {
                 log_end(qsv_args, now);
-                process::exit(0);
+                QsvExitCode::Good
             }
-            Err(CliError::Flag(err)) => err.exit(),
+            Err(CliError::Flag(err)) => {
+                werr!("{err}");
+                log_end(qsv_args, now);
+                QsvExitCode::IncorrectUsage
+            }
             Err(CliError::Csv(err)) => {
                 werr!("{err}");
                 log_end(qsv_args, now);
-                process::exit(1);
+                QsvExitCode::Bad
             }
             Err(CliError::Io(ref err)) if err.kind() == io::ErrorKind::BrokenPipe => {
                 log_end(qsv_args, now);
-                process::exit(0);
+                QsvExitCode::Good
             }
             Err(CliError::Io(err)) => {
                 werr!("{err}");
                 log_end(qsv_args, now);
-                process::exit(1);
+                QsvExitCode::Bad
             }
             Err(CliError::Other(msg)) => {
                 werr!("{msg}");
                 log_end(qsv_args, now);
-                process::exit(1);
+                QsvExitCode::IncorrectUsage
             }
         },
     }
@@ -372,6 +389,6 @@ impl<'a> From<&'a str> for CliError {
 
 impl From<regex::Error> for CliError {
     fn from(err: regex::Error) -> CliError {
-        CliError::Other(format!("{err:?}"))
+        CliError::Other(format!("Regex error: {err:?}"))
     }
 }


### PR DESCRIPTION
Take advantage of custom exit codes introduced in Rust 1.61
https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html#whats-in-1610-stable

Also add --exitcode option to `search` and `searchset`

Resolves #435 