### PR TITLE
`sortcheck` improvements

### DIFF
--- a/tests/test_sort.rs
+++ b/tests/test_sort.rs
@@ -167,6 +167,101 @@ fn sortcheck_simple_unsorted() {
 }
 
 #[test]
+fn sortcheck_simple_all() {
+    let wrk = Workdir::new("sortcheck_simple_all");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col11", "col2"],
+            svec!["1", "d"],
+            svec!["5", "c"],
+            svec!["3", "b"],
+            svec!["4", "a"],
+            svec!["6", "a"],
+            svec!["2", "y"],
+            svec!["3", "z"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--all").arg("in.csv");
+
+    let got = wrk.output_stderr(&mut cmd);
+    assert!(got.ends_with(" 1"));
+}
+
+#[test]
+fn sortcheck_simple_all_json() {
+    let wrk = Workdir::new("sortcheck_simple_all_json");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col11", "col2"],
+            svec!["1", "d"],
+            svec!["5", "c"],
+            svec!["5", "c"],
+            svec!["3", "b"],
+            svec!["4", "a"],
+            svec!["6", "a"],
+            svec!["6", "a"],
+            svec!["2", "y"],
+            svec!["3", "z"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--all").arg("--json").arg("in.csv");
+
+    let output = cmd.output().unwrap();
+    let got_exitcode = output.status.to_string();
+    let got_stdout = std::str::from_utf8(&output.stdout).unwrap_or_default();
+
+    assert_eq!(
+        got_stdout,
+        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":2}
+"#
+    );
+    assert!(got_exitcode.ends_with(" 1"));
+}
+
+#[test]
+fn sortcheck_simple_all_json_progressbar() {
+    let wrk = Workdir::new("sortcheck_simple_all_json_progessbar");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col11", "col2"],
+            svec!["1", "d"],
+            svec!["5", "c"],
+            svec!["5", "c"],
+            svec!["3", "b"],
+            svec!["4", "a"],
+            svec!["6", "a"],
+            svec!["6", "a"],
+            svec!["2", "y"],
+            svec!["3", "z"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--all")
+        .arg("--json")
+        .arg("--progressbar")
+        .arg("in.csv");
+
+    let output = cmd.output().unwrap();
+    let got_exitcode = output.status.to_string();
+    let got_stdout = std::str::from_utf8(&output.stdout).unwrap_or_default();
+
+    assert_eq!(
+        got_stdout,
+        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":2}
+"#
+    );
+    assert!(got_exitcode.ends_with(" 1"));
+}
+
+#[test]
 fn sort_numeric() {
     let wrk = Workdir::new("sort_numeric");
     wrk.create(


### PR DESCRIPTION
- added --all option, to keep scanning even after the first sort break
- added --json and --pretty-json options to return results as json
- added additional sortcheck tests