### PR TITLE
`fetch` & `fetchpost`: better --report option handling

### DIFF
--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -171,6 +171,7 @@ Fetch options:
                                fetch_url - URL used, fetch_status - HTTP code, fetch_cache_hit - cache hit flag,
                                fetch_retries - retry attempts, fetch_elapsed - elapsed time & fetch_response.
                                The short report only has the six columns without the "qsv_fetch_" prefix.
+                               [default: none]
     --redis                    Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/1"
                                with a connection pool size of 20, with a TTL of 28 days, and a cache hit 
                                NOT renewing an entry's TTL.
@@ -206,7 +207,7 @@ struct Args {
     flag_store_error: bool,
     flag_cache_error: bool,
     flag_cookies: bool,
-    flag_report: Option<String>,
+    flag_report: String,
     flag_redis: bool,
     flag_flushdb: bool,
     flag_output: Option<String>,
@@ -475,14 +476,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     // prepare report
-    let report = if let Some(reportkind) = args.flag_report {
-        if reportkind.to_lowercase().starts_with('d') {
-            // if it starts with d, its a detailed report
-            ReportKind::Detailed
-        } else {
-            // defaults to short if --report option is anything else
-            ReportKind::Short
-        }
+    let report = if args.flag_report.to_lowercase().starts_with('d') {
+        // if it starts with d, its a detailed report
+        ReportKind::Detailed
+    } else if args.flag_report.to_lowercase().starts_with('s') {
+        // if it starts with s, its a short report
+        ReportKind::Short
     } else {
         ReportKind::None
     };

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -147,6 +147,7 @@ Fetch options:
                                fetchp_cache_hit - cached hit flag, fetchp_retries - retry attempts, 
                                fetchp_elapsed - elapsed time & fetchp_response.
                                The short report only has the sevenn columns without the "qsv_fetchp_" prefix.
+                               [default: none]
     --redis                    Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/2"
                                with a connection pool size of 20, with a TTL of 28 days, and a cache hit 
                                NOT renewing an entry's TTL.
@@ -181,7 +182,7 @@ struct Args {
     flag_store_error: bool,
     flag_cache_error: bool,
     flag_cookies: bool,
-    flag_report: Option<String>,
+    flag_report: String,
     flag_redis: bool,
     flag_flushdb: bool,
     flag_output: Option<String>,
@@ -438,14 +439,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     // prepare report
-    let report = if let Some(reportkind) = args.flag_report {
-        if reportkind.to_ascii_lowercase().starts_with('d') {
-            // if it starts with d, its a detailed report
-            ReportKind::Detailed
-        } else {
-            // defaults to short if --report option is anything else
-            ReportKind::Short
-        }
+    let report = if args.flag_report.to_lowercase().starts_with('d') {
+        // if it starts with d, its a detailed report
+        ReportKind::Detailed
+    } else if args.flag_report.to_lowercase().starts_with('s') {
+        // if it starts with s, its a short report
+        ReportKind::Short
     } else {
         ReportKind::None
     };


### PR DESCRIPTION
specifying the --report option without a report type now defaults to no report automatically.

This should prevent `fetch` from seeming to hang when the report option is used without a report type.