### PR TITLE
`py`: batched python processing refactor

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -83,10 +83,9 @@ pub fn version() -> String {
     #[cfg(all(feature = "python", not(feature = "lite")))]
     {
         enabled_features.push_str("python-");
-        #[allow(deprecated)]
-        let gil = pyo3::Python::acquire_gil();
-        let py = gil.python();
-        enabled_features.push_str(py.version());
+        _ = pyo3::Python::with_gil(|py| {
+            enabled_features.push_str(py.version());
+        });
     }
     enabled_features.push('-');
 


### PR DESCRIPTION
- process CSV in batches of 30,000 rows, so we don't keep growing the memory, releasing the GILpool after each batch (see https://github.com/jqnatividad/qsv/issues/449)
- replace deprecated `acquire_gil` in the process, using `with_gil` introduced in pyo3 0.17.0 instead

resolves #454