### PR TITLE
`apply`: Multi-column subcommands

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -338,7 +338,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             headers = replace_column_value(&headers, *col_index, &new_col_names[i]);
             i += 1;
         }
-        
     }
 
     if !rconfig.no_headers {
@@ -630,7 +629,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     }
                 }
 
-                
                 record
             })
             .collect_into_vec(&mut batch_results);

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -329,7 +329,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut headers = rdr.headers()?.clone();
 
     if let Some(new_name) = args.flag_rename {
-        headers = replace_column_value(&headers, column_index, &new_name);
+        let new_col_names = util::ColumnNameParser::new(&new_name).parse()?;
+        if new_col_names.len() != sel.len() {
+            return fail!("Invalid arguments.");
+        }
+        let mut i = 0;
+        for col_index in sel.iter() {
+            headers = replace_column_value(&headers, *col_index, &new_col_names[i]);
+            i += 1;
+        }
+        
     }
 
     if !rconfig.no_headers {
@@ -533,45 +542,72 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .par_iter()
             .map(|record_item| {
                 let mut record = record_item.clone();
-                let mut cell = record[column_index].to_owned();
-
                 match apply_cmd {
                     ApplySubCmd::Geocode => {
+                        let mut cell = record[column_index].to_owned();
                         if !cell.is_empty() {
                             let search_result = search_cached(&cell, &args.flag_formatstr);
                             if let Some(geocoded_result) = search_result {
                                 cell = geocoded_result;
                             }
                         }
+                        if args.flag_new_column.is_some() {
+                            record.push_field(&cell);
+                        } else {
+                            record = replace_column_value(&record, column_index, &cell);
+                        }
                     }
                     ApplySubCmd::Operations => {
-                        apply_operations(
-                            &operations,
-                            &mut cell,
-                            &args.flag_comparand,
-                            &args.flag_replacement,
-                        );
+                        for col_index in sel.iter() {
+                            let mut cell = record[*col_index].to_owned();
+                            apply_operations(
+                                &operations,
+                                &mut cell,
+                                &args.flag_comparand,
+                                &args.flag_replacement,
+                            );
+                            if args.flag_new_column.is_some() {
+                                record.push_field(&cell);
+                            } else {
+                                record = replace_column_value(&record, *col_index, &cell);
+                            }
+                        }
                     }
                     ApplySubCmd::EmptyReplace => {
+                        let mut cell = record[column_index].to_owned();
                         if cell.trim().is_empty() {
                             cell = args.flag_replacement.to_string();
                         }
+                        if args.flag_new_column.is_some() {
+                            record.push_field(&cell);
+                        } else {
+                            record = replace_column_value(&record, column_index, &cell);
+                        }
                     }
                     ApplySubCmd::DateFmt => {
-                        if !cell.is_empty() {
-                            let parsed_date = parse_with_preference(&cell, prefer_dmy);
-                            if let Ok(format_date) = parsed_date {
-                                let formatted_date =
-                                    format_date.format(&args.flag_formatstr).to_string();
-                                if formatted_date.ends_with("T00:00:00+00:00") {
-                                    cell = formatted_date[..10].to_string();
-                                } else {
-                                    cell = formatted_date;
+                        for col_index in sel.iter() {
+                            let mut cell = record[*col_index].to_owned();
+                            if !cell.is_empty() {
+                                let parsed_date = parse_with_preference(&cell, prefer_dmy);
+                                if let Ok(format_date) = parsed_date {
+                                    let formatted_date =
+                                        format_date.format(&args.flag_formatstr).to_string();
+                                    if formatted_date.ends_with("T00:00:00+00:00") {
+                                        cell = formatted_date[..10].to_string();
+                                    } else {
+                                        cell = formatted_date;
+                                    }
                                 }
+                            }
+                            if args.flag_new_column.is_some() {
+                                record.push_field(&cell);
+                            } else {
+                                record = replace_column_value(&record, *col_index, &cell);
                             }
                         }
                     }
                     ApplySubCmd::DynFmt => {
+                        let mut cell = record[column_index].to_owned();
                         if !cell.is_empty() {
                             let mut record_vec: Vec<String> = Vec::with_capacity(record.len());
                             for field in &record {
@@ -583,17 +619,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                 cell = formatted.to_string();
                             }
                         }
+                        if args.flag_new_column.is_some() {
+                            record.push_field(&cell);
+                        } else {
+                            record = replace_column_value(&record, column_index, &cell);
+                        }
                     }
                     ApplySubCmd::Unknown => {
                         unreachable!("apply subcommands are always known");
                     }
                 }
 
-                if args.flag_new_column.is_some() {
-                    record.push_field(&cell);
-                } else {
-                    record = replace_column_value(&record, column_index, &cell);
-                }
+                
                 record
             })
             .collect_into_vec(&mut batch_results);

--- a/src/util.rs
+++ b/src/util.rs
@@ -682,3 +682,86 @@ fn test_hw_survey() {
     // we have this test primarily to exercise the sysinfo module
     assert!(send_hwsurvey("qsv", false, "0.0.2", "0.0.1", true).is_ok());
 }
+
+pub struct ColumnNameParser {
+    chars: Vec<char>,
+    pos: usize,
+}
+
+impl ColumnNameParser {
+    pub fn new(s: &str) -> ColumnNameParser {
+       ColumnNameParser {
+            chars: s.chars().collect(),
+            pos: 0,
+       } 
+    }
+
+    pub fn parse(&mut self) -> Result<Vec<String>, String> {
+        let mut new_cols_name = vec![];
+        loop {
+            if self.cur().is_none() {
+                break;
+            }
+            if self.cur() == Some('"') {
+                self.bump();
+                new_cols_name.push(self.parse_quoted_name()?);
+            } else {
+                new_cols_name.push(self.parse_name());
+            }
+            self.bump();
+        }
+        Ok(new_cols_name)
+    }
+
+    fn cur(&self) -> Option<char> {
+        self.chars.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) {
+        if self.pos < self.chars.len() {
+            self.pos += 1;
+        }
+    }
+
+    fn is_end_of_field(&self) -> bool {
+        self.cur().map_or(true, |c| c == ',')
+    }
+
+    fn parse_quoted_name(&mut self) -> Result<String, String> {
+        let mut name = String::new();
+        loop {
+            match self.cur() {
+                None => {
+                    return Err("Unclose quote, missing \".".to_owned());
+                }
+                Some('"') => {
+                    self.bump();
+                    if self.cur() == Some('"') {
+                        self.bump();
+                        name.push('"');
+                        name.push('"');
+                        continue;
+                    }
+                    break;
+                }
+                Some(c) => {
+                    name.push(c);
+                    self.bump();
+                }
+            }
+        }
+        Ok(name)
+    } 
+
+    fn parse_name(&mut self) -> String {
+        let mut name = String::new();
+        loop {
+            if self.is_end_of_field() {
+                break;
+            }
+            name.push(self.cur().unwrap());
+            self.bump();
+        }
+        name
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -690,10 +690,10 @@ pub struct ColumnNameParser {
 
 impl ColumnNameParser {
     pub fn new(s: &str) -> ColumnNameParser {
-       ColumnNameParser {
+        ColumnNameParser {
             chars: s.chars().collect(),
             pos: 0,
-       } 
+        }
     }
 
     pub fn parse(&mut self) -> Result<Vec<String>, String> {
@@ -751,7 +751,7 @@ impl ColumnNameParser {
             }
         }
         Ok(name)
-    } 
+    }
 
     fn parse_name(&mut self) -> String {
         let mut name = String::new();

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -38,7 +38,7 @@ fn apply_ops_upper() {
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
-        svec!["name","surname"],
+        svec!["name", "surname"],
         svec!["JOHN", "CENA"],
         svec!["MARY", "JANE"],
         svec!["SUE", "BIRD"],
@@ -1020,16 +1020,25 @@ fn apply_datefmt_multiple_cols() {
         "data.csv",
         vec![
             svec!["Created Date", "End Date"],
-            svec!["September 17, 2012 10:09am EST", "September 18, 2012 10:09am EST"],
-            svec!["Wed, 02 Jun 2021 06:31:39 GMT", "Wed, 02 Jun 2021 08:31:39 GMT"],
+            svec![
+                "September 17, 2012 10:09am EST",
+                "September 18, 2012 10:09am EST"
+            ],
+            svec![
+                "Wed, 02 Jun 2021 06:31:39 GMT",
+                "Wed, 02 Jun 2021 08:31:39 GMT"
+            ],
             svec!["2009-01-20 05:00 EST", "2009-01-21 05:00 EST"],
             svec!["July 4, 2005", "July 5, 2005"],
-            svec!["2021-05-01T01:17:02.604456Z","2021-05-02T01:17:02.604456Z"],
-            svec!["This is not a date and it will not be reformatted", "This is not a date and it will not be reformatted"],
+            svec!["2021-05-01T01:17:02.604456Z", "2021-05-02T01:17:02.604456Z"],
+            svec![
+                "This is not a date and it will not be reformatted",
+                "This is not a date and it will not be reformatted"
+            ],
         ],
     );
     let mut cmd = wrk.command("apply");
-    cmd.arg("datefmt").arg("Created Date").arg("data.csv");
+    cmd.arg("datefmt").arg("Created Date,End Date").arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1038,8 +1047,14 @@ fn apply_datefmt_multiple_cols() {
         svec!["2021-06-02T06:31:39+00:00", "2021-06-02T08:31:39+00:00"],
         svec!["2009-01-20T10:00:00+00:00", "2009-01-21T10:00:00+00:00"],
         svec!["2005-07-04", "2005-07-05"],
-        svec!["2021-05-01T01:17:02.604456+00:00", "2021-05-02T01:17:02.604456+00:00"],
-        svec!["This is not a date and it will not be reformatted", "This is not a date and it will not be reformatted"],
+        svec![
+            "2021-05-01T01:17:02.604456+00:00",
+            "2021-05-02T01:17:02.604456+00:00"
+        ],
+        svec![
+            "This is not a date and it will not be reformatted",
+            "This is not a date and it will not be reformatted"
+        ],
     ];
     assert_eq!(got, expected);
 }

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -23,26 +23,115 @@ fn apply_ops_upper() {
     wrk.create(
         "data.csv",
         vec![
-            svec!["name"],
-            svec!["John"],
-            svec!["Mary"],
-            svec!["Sue"],
-            svec!["Hopkins"],
+            svec!["name", "surname"],
+            svec!["John", "Cena"],
+            svec!["Mary", "Jane"],
+            svec!["Sue", "Bird"],
+            svec!["Hopkins", "Jade"],
         ],
     );
     let mut cmd = wrk.command("apply");
     cmd.arg("operations")
         .arg("upper")
-        .arg("name")
+        .arg("name,surname")
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
-        svec!["name"],
-        svec!["JOHN"],
-        svec!["MARY"],
-        svec!["SUE"],
-        svec!["HOPKINS"],
+        svec!["name","surname"],
+        svec!["JOHN", "CENA"],
+        svec!["MARY", "JANE"],
+        svec!["SUE", "BIRD"],
+        svec!["HOPKINS", "JADE"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_ops_upper_rename() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["name", "surname"],
+            svec!["John", "Cena"],
+            svec!["Mary", "Jane"],
+            svec!["Sue", "Bird"],
+            svec!["Hopkins", "Jade"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("upper")
+        .arg("name,surname")
+        .arg("--rename")
+        .arg("uname,usurname")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["uname", "usurname"],
+        svec!["JOHN", "CENA"],
+        svec!["MARY", "JANE"],
+        svec!["SUE", "BIRD"],
+        svec!["HOPKINS", "JADE"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_ops_upper_rename_invalid() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["name", "surname"],
+            svec!["John", "Cena"],
+            svec!["Mary", "Jane"],
+            svec!["Sue", "Bird"],
+            svec!["Hopkins", "Jade"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("upper")
+        .arg("name,surname")
+        .arg("--rename")
+        .arg("uname")
+        .arg("data.csv");
+
+    let got: String = wrk.output_stderr(&mut cmd);
+    assert_eq!(got, "Invalid arguments.\n");
+}
+
+#[test]
+fn apply_ops_upper_index_params() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["name", "surname"],
+            svec!["John", "Cena"],
+            svec!["Mary", "Jane"],
+            svec!["Sue", "Bird"],
+            svec!["Hopkins", "Jade"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("upper")
+        .arg("1,2")
+        .arg("--rename")
+        .arg("uname,usurname")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["uname", "usurname"],
+        svec!["JOHN", "CENA"],
+        svec!["MARY", "JANE"],
+        svec!["SUE", "BIRD"],
+        svec!["HOPKINS", "JADE"],
     ];
     assert_eq!(got, expected);
 }
@@ -920,6 +1009,37 @@ fn apply_datefmt() {
         svec!["2005-07-04"],
         svec!["2021-05-01T01:17:02.604456+00:00"],
         svec!["This is not a date and it will not be reformatted"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_datefmt_multiple_cols() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["Created Date", "End Date"],
+            svec!["September 17, 2012 10:09am EST", "September 18, 2012 10:09am EST"],
+            svec!["Wed, 02 Jun 2021 06:31:39 GMT", "Wed, 02 Jun 2021 08:31:39 GMT"],
+            svec!["2009-01-20 05:00 EST", "2009-01-21 05:00 EST"],
+            svec!["July 4, 2005", "July 5, 2005"],
+            svec!["2021-05-01T01:17:02.604456Z","2021-05-02T01:17:02.604456Z"],
+            svec!["This is not a date and it will not be reformatted", "This is not a date and it will not be reformatted"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("datefmt").arg("Created Date").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["Created Date", "End Date"],
+        svec!["2012-09-17T15:09:00+00:00", "2012-09-18T15:09:00+00:00"],
+        svec!["2021-06-02T06:31:39+00:00", "2021-06-02T08:31:39+00:00"],
+        svec!["2009-01-20T10:00:00+00:00", "2009-01-21T10:00:00+00:00"],
+        svec!["2005-07-04", "2005-07-05"],
+        svec!["2021-05-01T01:17:02.604456+00:00", "2021-05-02T01:17:02.604456+00:00"],
+        svec!["This is not a date and it will not be reformatted", "This is not a date and it will not be reformatted"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
With this CL, we add a new feature of applying operations to
multiple columns simultaneously,

- qsv apply operations trim,upper name,surname ~/userdetails.csv
- qsv apply operations trim,upper 1,2 ~/userdetails.csv

In addition of selecting multiple columns, we support renaming them.
However, the no of columns being selected should be equal to number
of columns being renamed.

So this is valid:

- qsv apply operations trim,upper name,surname --rename uname,usurname
  ~/userdetails.csv

But this is invalid:

- qsv apply operations trim,upper name,surname --rename uname ~/userdetails.csv

We do not support multi column operations for apply subcommands `dynfmt`
and `geocode`. As it logically does not make sense.