### PR TITLE
Move command usage text to beginning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,51 +28,51 @@ See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for mor
 | Command | Description |
 | --- | --- |
 | [apply](/src/cmd/apply.rs#L29-L30)[^1][^5] | Apply series of string, date, currency & geocoding transformations to a CSV column. It also has some basic [NLP](https://en.wikipedia.org/wiki/Natural_language_processing) functions ([similarity](https://crates.io/crates/strsim), [sentiment analysis](https://crates.io/crates/vader_sentiment), [profanity](https://docs.rs/censor/latest/censor/), [eudex](https://github.com/ticki/eudex#eudex-a-blazingly-fast-phonetic-reductionhashing-algorithm) & [language detection](https://crates.io/crates/whatlang)).  |
-| [behead](/src/cmd/behead.rs#L7) | Drop headers from a CSV.  |
-| [cat](/src/cmd/cat.rs#L7) | Concatenate CSV files by row or by column. |
-| [count](/src/cmd/count.rs#L8)[^2] | Count the rows in a CSV file. (Instantaneous with an index.) |
-| [dedup](/src/cmd/dedup.rs#L14)[^3][^5] | Remove redundant rows (See also `sortcheck` command). |
-| [enum](/src/cmd/enumerate.rs#L10-L12) | Add a new column enumerating rows by adding a column of incremental or uuid identifiers. Can also be used to copy a column or fill a new column with a constant value.  |
-| [excel](/src/cmd/excel.rs#L12) | Exports a specified Excel/ODS sheet to a CSV file. |
-| [exclude](/src/cmd/exclude.rs#L18)[^2] | Removes a set of CSV data from another set based on the specified columns.  |
-| [explode](/src/cmd/explode.rs#L8-L9) | Explode rows into multiple ones by splitting a column value based on the given separator.  |
-| [extsort](/src/cmd/extsort.rs#L13)[^5] | Sort an arbitrarily large CSV/text file using a multithreaded [external merge sort](https://en.wikipedia.org/wiki/External_sorting) algorithm. |
-| [fetch](/src/cmd/fetch.rs#L28) | Fetches data from web services for every row using **HTTP Get**. Comes with [jql](https://github.com/yamafaktory/jql#%EF%B8%8F-usage) JSON query language support, dynamic throttling ([RateLimit](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html)) & caching with optional [Redis](https://redis.io/) support for persistent caching. |
-| [fetchpost](/src/cmd/fetchpost.rs#L28-L29) | Similar to `fetch`, but uses **HTTP Post**. ([HTTP GET vs POST methods](https://www.geeksforgeeks.org/difference-between-http-get-and-post-methods/)) |
-| [fill](/src/cmd/fill.rs#L13) | Fill empty values.  |
-| [fixlengths](/src/cmd/fixlengths.rs#L9-L11) | Force a CSV to have same-length records by either padding or truncating them. |
-| [flatten](/src/cmd/flatten.rs#L12-L15) | A flattened view of CSV records. Useful for viewing one record at a time.<br />e.g. `qsv slice -i 5 data.csv \| qsv flatten`. |
-| [fmt](/src/cmd/fmt.rs#L7) | Reformat a CSV with different delimiters, record terminators or quoting rules. (Supports ASCII delimited data.)  |
-| [foreach](/src/cmd/foreach.rs#L16-L17)[^1] | Loop over a CSV to execute bash commands. (not available on Windows)  |
-| [frequency](/src/cmd/frequency.rs#L15)[^2][^4] | Build [frequency tables](https://statisticsbyjim.com/basics/frequency-table/) of each column. (Uses multithreading to go faster if an index is present.) |
-| [generate](/src/cmd/generate.rs#L12-L13)[^1] | Generate test data by profiling a CSV using [Markov decision process](https://crates.io/crates/test-data-generation) machine learning.  |
-| [headers](/src/cmd/headers.rs#L11) | Show the headers of a CSV. Or show the intersection of all headers between many CSV files. |
-| [index](/src/cmd/index.rs#L13-L14) | Create an index for a CSV. This is very quick & provides constant time indexing into the CSV file. Also enables multithreading for `frequency`, `split`, `stats` and `schema` commands. |
-| [input](/src/cmd/input.rs#L8)[^2] | Read CSV data with special quoting, trimming, line-skipping and UTF-8 transcoding rules. Typically used to "normalize" a CSV for further processing with other qsv commands. |
-| [join](/src/cmd/join.rs#L18)[^2] | Inner, outer, cross, anti & semi joins. Uses a simple hash index to make it fast.  |
-| [jsonl](/src/cmd/jsonl.rs#L11) | Convert newline-delimited JSON ([JSONL](https://jsonlines.org/)/[NDJSON](http://ndjson.org/)) to CSV. See `tojsonl` command to convert CSV to JSONL.
-| [lua](/src/cmd/lua.rs#L12-L13)[^1] | Execute a [Lua](https://www.lua.org/about.html) 5.4.4 script over CSV lines to transform, aggregate or filter them.  |
-| [partition](/src/cmd/partition.rs#L17) | Partition a CSV based on a column value. |
-| [pseudo](/src/cmd/pseudo.rs#L10-L11) | [Pseudonymise](https://en.wikipedia.org/wiki/Pseudonymization) the value of the given column by replacing them with an incremental identifier.  |
-| [py](/src/cmd/python.rs#L45-L46)[^1] | Evaluate a Python expression over CSV lines to transform, aggregate or filter them. Python's [f-strings](https://www.freecodecamp.org/news/python-f-strings-tutorial-how-to-use-f-strings-for-string-formatting/) is particularly useful for extended formatting (Python 3.8+ required).  |
-| [rename](/src/cmd/rename.rs#L7) |  Rename the columns of a CSV efficiently.  |
-| [replace](/src/cmd/replace.rs#L14) | Replace CSV data using a regex.  |
-| [reverse](/src/cmd/reverse.rs#L7)[^3] | Reverse order of rows in a CSV. Unlike the `sort --reverse` command, it preserves the order of rows with the same key.  |
-| [sample](/src/cmd/sample.rs#L13-L14)[^2] | Randomly draw rows (with optional seed) from a CSV using [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) (i.e., use memory proportional to the size of the sample).  |
-| [schema](/src/cmd/schema.rs#L24)[^4] | Infer schema from CSV data and output in [JSON Schema](https://json-schema.org/) format. Uses multithreading to go faster if an index is present. See `validate` command to use the generated JSON Schema to validate if similar CSVs comply with the schema. |
-| [search](/src/cmd/search.rs#L15) | Run a regex over a CSV. Applies the regex to each field individually & shows only matching rows.  |
-| [searchset](/src/cmd/searchset.rs#L19) | **Run multiple regexes over a CSV in a single pass.** Applies the regexes to each field individually & shows only matching rows.  |
-| [select](/src/cmd/select.rs#L8) | Select, re-order, duplicate or drop columns.  |
-| [slice](/src/cmd/slice.rs#L10-L11)[^2][^3] | Slice rows from any part of a CSV. When an index is present, this only has to parse the rows in the slice (instead of all rows leading up to the start of the slice).  |
-| [sniff](/src/cmd/sniff.rs#L10-L11)[^2] | Quickly sniff CSV metadata (delimiter, header row, preamble rows, quote character, flexible, is_utf8, number of records, number of fields, field names & data types). |
-| [sort](/src/cmd/sort.rs#L13)[^5] | Sorts CSV data in alphabetical, numerical, reverse or random (with optional seed) order (See also `extsort` & `sortcheck` commands).  |
-| [sortcheck](/src/cmd/sortcheck.rs#L17-L18)[^2] | Check if a CSV is sorted. With the --json options, also retrieve record count, sort breaks & duplicate count. |
-| [split](/src/cmd/split.rs#L14)[^2][^4] | Split one CSV file into many CSV files of N chunks. (Uses multithreading to go faster if an index is present.) |
-| [stats](/src/cmd/stats.rs#L26)[^2][^3][^4] | Infer data type (Null, String, Float, Integer, Date, DateTime) & compute descriptive statistics for each column in a CSV (sum, min/max, min/max length, mean, stddev, variance, nullcount, quartiles, IQR, lower/upper fences, skewness, median, mode & cardinality). Uses multithreading to go faster if an index is present. |
-| [table](/src/cmd/table.rs#L12)[^3] | Show aligned output of a CSV using [elastic tabstops](https://github.com/BurntSushi/tabwriter).  |
-| [tojsonl](/src/cmd/tojsonl.rs#L14)[^4] | Converts CSV to a newline-delimited JSON (JSONL/NDJSON). See `jsonl` command to convert JSONL to CSV. |
-| [transpose](/src/cmd/transpose.rs#L9)[^3] | Transpose rows/columns of a CSV.  |
-| [validate](/src/cmd/validate.rs#L30-L31)[^2][^5] | Validate CSV data with a JSON Schema (See `schema` command). If no jsonschema file is provided, validates if a CSV conforms to the [RFC 4180 standard](https://datatracker.ietf.org/doc/html/rfc4180). |
+| [behead](/src/cmd/behead.rs#L2) | Drop headers from a CSV.  |
+| [cat](/src/cmd/cat.rs#L2) | Concatenate CSV files by row or by column. |
+| [count](/src/cmd/count.rs#L2)[^2] | Count the rows in a CSV file. (Instantaneous with an index.) |
+| [dedup](/src/cmd/dedup.rs#L2)[^3][^5] | Remove redundant rows (See also `sortcheck` command). |
+| [enum](/src/cmd/enumerate.rs#L2-L3) | Add a new column enumerating rows by adding a column of incremental or uuid identifiers. Can also be used to copy a column or fill a new column with a constant value.  |
+| [excel](/src/cmd/excel.rs#L2) | Exports a specified Excel/ODS sheet to a CSV file. |
+| [exclude](/src/cmd/exclude.rs#L2)[^2] | Removes a set of CSV data from another set based on the specified columns.  |
+| [explode](/src/cmd/explode.rs#L2-L3) | Explode rows into multiple ones by splitting a column value based on the given separator.  |
+| [extsort](/src/cmd/extsort.rs#L2)[^5] | Sort an arbitrarily large CSV/text file using a multithreaded [external merge sort](https://en.wikipedia.org/wiki/External_sorting) algorithm. |
+| [fetch](/src/cmd/fetch.rs#L2) | Fetches data from web services for every row using **HTTP Get**. Comes with [jql](https://github.com/yamafaktory/jql#%EF%B8%8F-usage) JSON query language support, dynamic throttling ([RateLimit](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html)) & caching with optional [Redis](https://redis.io/) support for persistent caching. |
+| [fetchpost](/src/cmd/fetchpost.rs#L2-L3) | Similar to `fetch`, but uses **HTTP Post**. ([HTTP GET vs POST methods](https://www.geeksforgeeks.org/difference-between-http-get-and-post-methods/)) |
+| [fill](/src/cmd/fill.rs#L2) | Fill empty values.  |
+| [fixlengths](/src/cmd/fixlengths.rs#L2-L4) | Force a CSV to have same-length records by either padding or truncating them. |
+| [flatten](/src/cmd/flatten.rs#L2-L5) | A flattened view of CSV records. Useful for viewing one record at a time.<br />e.g. `qsv slice -i 5 data.csv \| qsv flatten`. |
+| [fmt](/src/cmd/fmt.rs#L2) | Reformat a CSV with different delimiters, record terminators or quoting rules. (Supports ASCII delimited data.)  |
+| [foreach](/src/cmd/foreach.rs#L3-L4)[^1] | Loop over a CSV to execute bash commands. (not available on Windows)  |
+| [frequency](/src/cmd/frequency.rs#L2)[^2][^4] | Build [frequency tables](https://statisticsbyjim.com/basics/frequency-table/) of each column. (Uses multithreading to go faster if an index is present.) |
+| [generate](/src/cmd/generate.rs#L2-L3)[^1] | Generate test data by profiling a CSV using [Markov decision process](https://crates.io/crates/test-data-generation) machine learning.  |
+| [headers](/src/cmd/headers.rs#L2) | Show the headers of a CSV. Or show the intersection of all headers between many CSV files. |
+| [index](/src/cmd/index.rs#L2-L3) | Create an index for a CSV. This is very quick & provides constant time indexing into the CSV file. Also enables multithreading for `frequency`, `split`, `stats` and `schema` commands. |
+| [input](/src/cmd/input.rs#L2)[^2] | Read CSV data with special quoting, trimming, line-skipping and UTF-8 transcoding rules. Typically used to "normalize" a CSV for further processing with other qsv commands. |
+| [join](/src/cmd/join.rs#L2)[^2] | Inner, outer, cross, anti & semi joins. Uses a simple hash index to make it fast.  |
+| [jsonl](/src/cmd/jsonl.rs#L2) | Convert newline-delimited JSON ([JSONL](https://jsonlines.org/)/[NDJSON](http://ndjson.org/)) to CSV. See `tojsonl` command to convert CSV to JSONL.
+| [lua](/src/cmd/lua.rs#L2-L3)[^1] | Execute a [Lua](https://www.lua.org/about.html) 5.4.4 script over CSV lines to transform, aggregate or filter them.  |
+| [partition](/src/cmd/partition.rs#L2) | Partition a CSV based on a column value. |
+| [pseudo](/src/cmd/pseudo.rs#L2-L3) | [Pseudonymise](https://en.wikipedia.org/wiki/Pseudonymization) the value of the given column by replacing them with an incremental identifier.  |
+| [py](/src/cmd/python.rs#L2-L3)[^1] | Evaluate a Python expression over CSV lines to transform, aggregate or filter them. Python's [f-strings](https://www.freecodecamp.org/news/python-f-strings-tutorial-how-to-use-f-strings-for-string-formatting/) is particularly useful for extended formatting (Python 3.8+ required).  |
+| [rename](/src/cmd/rename.rs#L2) |  Rename the columns of a CSV efficiently.  |
+| [replace](/src/cmd/replace.rs#L2) | Replace CSV data using a regex.  |
+| [reverse](/src/cmd/reverse.rs#L2)[^3] | Reverse order of rows in a CSV. Unlike the `sort --reverse` command, it preserves the order of rows with the same key.  |
+| [sample](/src/cmd/sample.rs#L2-L3)[^2] | Randomly draw rows (with optional seed) from a CSV using [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) (i.e., use memory proportional to the size of the sample).  |
+| [schema](/src/cmd/schema.rs#L2)[^4] | Infer schema from CSV data and output in [JSON Schema](https://json-schema.org/) format. Uses multithreading to go faster if an index is present. See `validate` command to use the generated JSON Schema to validate if similar CSVs comply with the schema. |
+| [search](/src/cmd/search.rs#L2) | Run a regex over a CSV. Applies the regex to each field individually & shows only matching rows.  |
+| [searchset](/src/cmd/searchset.rs#L2) | **Run multiple regexes over a CSV in a single pass.** Applies the regexes to each field individually & shows only matching rows.  |
+| [select](/src/cmd/select.rs#L2) | Select, re-order, duplicate or drop columns.  |
+| [slice](/src/cmd/slice.rs#L2-L3)[^2][^3] | Slice rows from any part of a CSV. When an index is present, this only has to parse the rows in the slice (instead of all rows leading up to the start of the slice).  |
+| [sniff](/src/cmd/sniff.rs#L2-L3)[^2] | Quickly sniff CSV metadata (delimiter, header row, preamble rows, quote character, flexible, is_utf8, number of records, number of fields, field names & data types). |
+| [sort](/src/cmd/sort.rs#L2)[^5] | Sorts CSV data in alphabetical, numerical, reverse or random (with optional seed) order (See also `extsort` & `sortcheck` commands).  |
+| [sortcheck](/src/cmd/sortcheck.rs#L2-L3)[^2] | Check if a CSV is sorted. With the --json options, also retrieve record count, sort breaks & duplicate count. |
+| [split](/src/cmd/split.rs#L2)[^2][^4] | Split one CSV file into many CSV files of N chunks. (Uses multithreading to go faster if an index is present.) |
+| [stats](/src/cmd/stats.rs#L2)[^2][^3][^4] | Infer data type (Null, String, Float, Integer, Date, DateTime) & compute descriptive statistics for each column in a CSV (sum, min/max, min/max length, mean, stddev, variance, nullcount, quartiles, IQR, lower/upper fences, skewness, median, mode & cardinality). Uses multithreading to go faster if an index is present. |
+| [table](/src/cmd/table.rs#L2)[^3] | Show aligned output of a CSV using [elastic tabstops](https://github.com/BurntSushi/tabwriter).  |
+| [tojsonl](/src/cmd/tojsonl.rs#L2)[^4] | Converts CSV to a newline-delimited JSON (JSONL/NDJSON). See `jsonl` command to convert JSONL to CSV. |
+| [transpose](/src/cmd/transpose.rs#L2)[^3] | Transpose rows/columns of a CSV.  |
+| [validate](/src/cmd/validate.rs#L2-L3)[^2][^5] | Validate CSV data with a JSON Schema (See `schema` command). If no jsonschema file is provided, validates if a CSV conforms to the [RFC 4180 standard](https://datatracker.ietf.org/doc/html/rfc4180). |
 
 [^1]: enabled by optional feature flag. Not available on `qsvlite` & `qsvdp`.
 [^2]: uses an index when available.   

--- a/src/cmd/behead.rs
+++ b/src/cmd/behead.rs
@@ -1,8 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Drop a CSV file's header.
 
@@ -15,6 +10,11 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -1,8 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Concatenates CSV data by column or by row.
 
@@ -36,6 +31,11 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -1,9 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use log::{debug, info};
-use serde::Deserialize;
-
 static USAGE: &str = "
 Prints a count of the number of records in the CSV data.
 
@@ -23,6 +17,12 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use log::{debug, info};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -1,15 +1,3 @@
-use std::cmp;
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use csv::ByteRecord;
-use rayon::prelude::*;
-use serde::Deserialize;
-
-use crate::cmd::sort::iter_cmp;
-
 static USAGE: &str = r#"
 Deduplicates CSV rows. 
 
@@ -56,6 +44,16 @@ Common options:
                                Must be a single character. (default: ,)
 "#;
 
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
+use csv::ByteRecord;
+use rayon::prelude::*;
+use serde::Deserialize;
+use std::cmp;
+
+use crate::cmd::sort::iter_cmp;
 #[derive(Deserialize)]
 struct Args {
     arg_input: Option<String>,

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -1,11 +1,3 @@
-use uuid::Uuid;
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = r#"
 Add a new column enumerating the lines of a CSV file. This can be useful to keep
 track of a specific line order, give a unique identifier to each line or even
@@ -53,6 +45,13 @@ Common options:
     -d, --delimiter <arg>    The field delimiter for reading CSV data.
                              Must be a single character. (default: ,)
 "#;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use uuid::Uuid;
 
 const NULL_VALUE: &str = "<NULL>";
 

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -1,13 +1,3 @@
-use crate::config::Config;
-use crate::util;
-use crate::CliResult;
-use calamine::{open_workbook_auto, DataType, Range, Reader};
-use log::{debug, info};
-use serde::Deserialize;
-use std::cmp;
-use std::path::PathBuf;
-use thousands::Separable;
-
 static USAGE: &str = r#"
 Exports a specified Excel/ODS sheet to a CSV file.
 
@@ -64,6 +54,16 @@ Common options:
     -h, --help                 Display this message
     -o, --output <file>        Write output to <file> instead of stdout.
 "#;
+
+use crate::config::Config;
+use crate::util;
+use crate::CliResult;
+use calamine::{open_workbook_auto, DataType, Range, Reader};
+use log::{debug, info};
+use serde::Deserialize;
+use std::cmp;
+use std::path::PathBuf;
+use thousands::Separable;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -1,19 +1,3 @@
-use ahash::AHashMap;
-use std::collections::hash_map::Entry;
-use std::fmt;
-use std::fs;
-use std::io;
-use std::str;
-
-use byteorder::{BigEndian, WriteBytesExt};
-
-use crate::config::{Config, Delimiter};
-use crate::index::Indexed;
-use crate::select::{SelectColumns, Selection};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Removes a set of CSV data from another set based on the specified columns.
 
@@ -47,6 +31,20 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::index::Indexed;
+use crate::select::{SelectColumns, Selection};
+use crate::util;
+use crate::CliResult;
+use ahash::AHashMap;
+use byteorder::{BigEndian, WriteBytesExt};
+use serde::Deserialize;
+use std::collections::hash_map::Entry;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::str;
 
 type ByteString = Vec<u8>;
 

--- a/src/cmd/explode.rs
+++ b/src/cmd/explode.rs
@@ -1,9 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Explodes a row into multiple ones by splitting a column value based on the
 given separator.
@@ -37,6 +31,11 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
 #[derive(Deserialize)]
 struct Args {
     arg_column: SelectColumns,

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -1,14 +1,3 @@
-use std::fs;
-use std::io::{self, prelude::*};
-use std::path;
-
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-use ext_sort::{buffer::mem::MemoryLimitedBufferBuilder, ExternalSorter, ExternalSorterBuilder};
-use serde::Deserialize;
-use sysinfo::{System, SystemExt};
-
 static USAGE: &str = "
 Sort an arbitrarily large CSV/text file using a multithreaded external sort algorithm.
 
@@ -34,6 +23,16 @@ Common options:
                            of the rows. Otherwise, the first row will always
                            appear as the header row in the output.
 ";
+
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+use ext_sort::{buffer::mem::MemoryLimitedBufferBuilder, ExternalSorter, ExternalSorterBuilder};
+use serde::Deserialize;
+use std::fs;
+use std::io::{self, prelude::*};
+use std::path;
+use sysinfo::{System, SystemExt};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -1,29 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::CliError;
-use crate::CliResult;
-use crate::{regex_once_cell, util};
-use cached::proc_macro::{cached, io_cached};
-use cached::{Cached, IOCached, RedisCache, Return};
-use console::set_colors_enabled;
-use dynfmt::Format;
-use governor::{
-    clock::DefaultClock, middleware::NoOpMiddleware, state::direct::NotKeyed, state::InMemoryState,
-};
-use indicatif::{HumanCount, MultiProgress, ProgressBar, ProgressDrawTarget};
-use log::Level::{Debug, Info, Trace, Warn};
-use log::{debug, error, info, log_enabled, warn};
-use once_cell::sync::{Lazy, OnceCell};
-use rand::Rng;
-use redis;
-use regex::Regex;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-use std::time::Instant;
-use std::{fs, thread, time};
-use url::Url;
-
 static USAGE: &str = r#"
 Fetches data from web services for every row using HTTP Get.
 
@@ -191,6 +165,32 @@ Common options:
                                Must be a single character. (default: ,)
     -p, --progressbar          Show progress bars. Not valid for stdin.
 "#;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::CliError;
+use crate::CliResult;
+use crate::{regex_once_cell, util};
+use cached::proc_macro::{cached, io_cached};
+use cached::{Cached, IOCached, RedisCache, Return};
+use console::set_colors_enabled;
+use dynfmt::Format;
+use governor::{
+    clock::DefaultClock, middleware::NoOpMiddleware, state::direct::NotKeyed, state::InMemoryState,
+};
+use indicatif::{HumanCount, MultiProgress, ProgressBar, ProgressDrawTarget};
+use log::Level::{Debug, Info, Trace, Warn};
+use log::{debug, error, info, log_enabled, warn};
+use once_cell::sync::{Lazy, OnceCell};
+use rand::Rng;
+use redis;
+use regex::Regex;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::time::Instant;
+use std::{fs, thread, time};
+use url::Url;
 
 #[derive(Deserialize, Debug)]
 struct Args {

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -1,29 +1,3 @@
-use crate::cmd::fetch::apply_jql;
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-use cached::proc_macro::{cached, io_cached};
-use cached::{Cached, IOCached, RedisCache, Return};
-use console::set_colors_enabled;
-use governor::{
-    clock::DefaultClock, middleware::NoOpMiddleware, state::direct::NotKeyed, state::InMemoryState,
-};
-use indicatif::{HumanCount, MultiProgress, ProgressBar, ProgressDrawTarget};
-use log::Level::{Debug, Info, Trace, Warn};
-use log::{debug, error, info, log_enabled, warn};
-use once_cell::sync::{Lazy, OnceCell};
-use rand::Rng;
-use redis;
-use regex::Regex;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
-use std::time::Instant;
-use std::{fs, thread, time};
-use url::Url;
-
 static USAGE: &str = r#"
 Fetchpost fetches data from web services for every row using HTTP Post.
 As opposed to fetch, which uses HTTP Get.
@@ -167,6 +141,32 @@ Common options:
                                Must be a single character. (default: ,)
     -p, --progressbar          Show progress bars. Not valid for stdin.
 "#;
+
+use crate::cmd::fetch::apply_jql;
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+use cached::proc_macro::{cached, io_cached};
+use cached::{Cached, IOCached, RedisCache, Return};
+use console::set_colors_enabled;
+use governor::{
+    clock::DefaultClock, middleware::NoOpMiddleware, state::direct::NotKeyed, state::InMemoryState,
+};
+use indicatif::{HumanCount, MultiProgress, ProgressBar, ProgressDrawTarget};
+use log::Level::{Debug, Info, Trace, Warn};
+use log::{debug, error, info, log_enabled, warn};
+use once_cell::sync::{Lazy, OnceCell};
+use rand::Rng;
+use redis;
+use regex::Regex;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::time::Instant;
+use std::{fs, thread, time};
+use url::Url;
 
 #[derive(Deserialize, Debug)]
 struct Args {

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -1,14 +1,3 @@
-use ahash::AHashMap;
-use std::io;
-use std::iter;
-use std::ops;
-
-use crate::config::{Config, Delimiter};
-use crate::select::{SelectColumns, Selection};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Fill empty fields in selected columns of a CSV.
 
@@ -60,8 +49,17 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
-type ByteString = Vec<u8>;
+use crate::config::{Config, Delimiter};
+use crate::select::{SelectColumns, Selection};
+use crate::util;
+use crate::CliResult;
+use ahash::AHashMap;
+use serde::Deserialize;
+use std::io;
+use std::iter;
+use std::ops;
 
+type ByteString = Vec<u8>;
 type BoxedWriter = csv::Writer<Box<dyn io::Write + 'static>>;
 type BoxedReader = csv::Reader<Box<dyn io::Read + 'static>>;
 

--- a/src/cmd/fixlengths.rs
+++ b/src/cmd/fixlengths.rs
@@ -1,10 +1,3 @@
-use std::cmp;
-
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Transforms CSV data so that all records have the same length. The length is
 the length of the longest record in the data (not counting trailing empty fields,
@@ -31,6 +24,12 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use std::cmp;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/flatten.rs
+++ b/src/cmd/flatten.rs
@@ -1,13 +1,3 @@
-use std::borrow::Cow;
-use std::io::{self, Write};
-
-use tabwriter::TabWriter;
-
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Prints flattened records such that fields are labeled separated by a new line.
 This mode is particularly useful for viewing one record at a time. Each
@@ -38,6 +28,14 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use std::borrow::Cow;
+use std::io::{self, Write};
+use tabwriter::TabWriter;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/fmt.rs
+++ b/src/cmd/fmt.rs
@@ -1,8 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Formats CSV data with a custom delimiter or CRLF line endings.
 
@@ -32,6 +27,11 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/foreach.rs
+++ b/src/cmd/foreach.rs
@@ -1,17 +1,4 @@
 #![cfg(target_family = "unix")]
-use regex::bytes::{NoExpand, Regex};
-use std::ffi::OsStr;
-use std::io::BufReader;
-use std::os::unix::ffi::OsStrExt;
-use std::process::{Command, Stdio};
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use indicatif::{ProgressBar, ProgressDrawTarget};
-use serde::Deserialize;
-
 static USAGE: &str = "
 Execute a bash command once per line in given CSV file. Works only in
 Unix-like environments.
@@ -47,6 +34,18 @@ Common options:
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
+use indicatif::{ProgressBar, ProgressDrawTarget};
+use regex::bytes::{NoExpand, Regex};
+use serde::Deserialize;
+use std::ffi::OsStr;
+use std::io::BufReader;
+use std::os::unix::ffi::OsStrExt;
+use std::process::{Command, Stdio};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -1,16 +1,3 @@
-use std::fs;
-use std::io;
-
-use stats::{merge_all, Frequencies};
-use threadpool::ThreadPool;
-
-use crate::config::{Config, Delimiter};
-use crate::index::Indexed;
-use crate::select::{SelectColumns, Selection};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Compute a frequency table on CSV data.
 
@@ -57,6 +44,17 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::index::Indexed;
+use crate::select::{SelectColumns, Selection};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use stats::{merge_all, Frequencies};
+use std::fs;
+use std::io;
+use threadpool::ThreadPool;
 
 #[derive(Clone, Deserialize)]
 pub struct Args {

--- a/src/cmd/generate.rs
+++ b/src/cmd/generate.rs
@@ -1,13 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-use std::env::temp_dir;
-use std::fs;
-use std::io::{self, Write};
-use test_data_generation::data_sample_parser::DataSampleParser;
-use uuid::Uuid;
-
 static USAGE: &str = r#"
 Generates test data by profiling a CSV using a Markov decision process
 machine learning algorithm.
@@ -58,6 +48,16 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 "#;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use std::env::temp_dir;
+use std::fs;
+use std::io::{self, Write};
+use test_data_generation::data_sample_parser::DataSampleParser;
+use uuid::Uuid;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/headers.rs
+++ b/src/cmd/headers.rs
@@ -1,12 +1,3 @@
-use std::io;
-
-use tabwriter::TabWriter;
-
-use crate::config::Delimiter;
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Prints the fields of the first row in the CSV data.
 
@@ -31,6 +22,13 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::Delimiter;
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use std::io;
+use tabwriter::TabWriter;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -1,14 +1,3 @@
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
-
-use csv_index::RandomAccessSimple;
-
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Creates an index of the given CSV data, which can make other operations like
 slicing, splitting and gathering statistics much faster.
@@ -38,6 +27,15 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use csv_index::RandomAccessSimple;
+use serde::Deserialize;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -1,9 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use log::info;
-use serde::Deserialize;
-
 static USAGE: &str = r#"
 Read CSV data with special quoting, trimming, line-skipping & UTF-8 transcoding rules.
 
@@ -43,6 +37,12 @@ Common options:
     -d, --delimiter <arg>    The field delimiter for reading CSV data.
                              Must be a single character. (default: ,)
 "#;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use log::info;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -1,19 +1,3 @@
-use std::collections::hash_map::Entry;
-use std::fmt;
-use std::io;
-use std::iter::repeat;
-use std::str;
-
-use ahash::AHashMap;
-use byteorder::{BigEndian, WriteBytesExt};
-
-use crate::config::{Config, Delimiter, SeekRead};
-use crate::index::Indexed;
-use crate::select::{SelectColumns, Selection};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Joins two sets of CSV data on the specified columns.
 
@@ -80,6 +64,20 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter, SeekRead};
+use crate::index::Indexed;
+use crate::select::{SelectColumns, Selection};
+use crate::util;
+use crate::CliResult;
+use ahash::AHashMap;
+use byteorder::{BigEndian, WriteBytesExt};
+use serde::Deserialize;
+use std::collections::hash_map::Entry;
+use std::fmt;
+use std::io;
+use std::iter::repeat;
+use std::str;
 
 type ByteString = Vec<u8>;
 

--- a/src/cmd/jsonl.rs
+++ b/src/cmd/jsonl.rs
@@ -1,12 +1,3 @@
-use serde_json::Value;
-use std::fs;
-use std::io::{self, BufRead, BufReader};
-
-use crate::config::Config;
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Convert newline-delimited JSON (JSONL/NDJSON) to CSV.
 
@@ -25,6 +16,14 @@ Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.
 ";
+
+use crate::config::Config;
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use serde_json::Value;
+use std::fs;
+use std::io::{self, BufRead, BufReader};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/lua.rs
+++ b/src/cmd/lua.rs
@@ -1,13 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-use indicatif::{ProgressBar, ProgressDrawTarget};
-use log::debug;
-use mlua::Lua;
-use serde::Deserialize;
-use std::fs;
-
 static USAGE: &str = r#"
 Create a new column, filter rows or compute aggregations by executing a Lua
 script of every line of a CSV file.
@@ -81,6 +71,16 @@ Common options:
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
 "#;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+use indicatif::{ProgressBar, ProgressDrawTarget};
+use log::debug;
+use mlua::Lua;
+use serde::Deserialize;
+use std::fs;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -1,18 +1,3 @@
-use ahash::AHashMap;
-use std::collections::hash_map::Entry;
-use std::collections::HashSet;
-use std::fs;
-use std::io;
-use std::path::Path;
-
-use regex::Regex;
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util::{self, FilenameTemplate};
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Partitions the given CSV data into chunks based on the value of a column
 
@@ -42,6 +27,19 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util::{self, FilenameTemplate};
+use crate::CliResult;
+use ahash::AHashMap;
+use regex::Regex;
+use serde::Deserialize;
+use std::collections::hash_map::Entry;
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::Path;
 
 #[derive(Clone, Deserialize)]
 struct Args {

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -1,11 +1,3 @@
-use ahash::AHashMap;
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Pseudonymise the value of the given column by replacing them by an
 incremental identifier.
@@ -22,6 +14,13 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
+use ahash::AHashMap;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -1,8 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Rename the columns of CSV data efficiently.
 
@@ -26,6 +21,11 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -1,16 +1,3 @@
-use regex::bytes::RegexBuilder;
-use std::borrow::Cow;
-use std::env;
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-#[cfg(any(feature = "full", feature = "lite"))]
-use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
-use serde::Deserialize;
-
 static USAGE: &str = "
 Replace occurrences of a pattern across a CSV file.
 
@@ -59,6 +46,18 @@ Common options:
     -p, --progressbar      Show progress bars. Not valid for stdin.
 
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+#[cfg(any(feature = "full", feature = "lite"))]
+use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
+use regex::bytes::RegexBuilder;
+use serde::Deserialize;
+use std::borrow::Cow;
+use std::env;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/reverse.rs
+++ b/src/cmd/reverse.rs
@@ -1,8 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Reverses rows of CSV data.
 
@@ -24,6 +19,11 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -1,14 +1,3 @@
-use std::io;
-
-use rand::{self, rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
-
-use crate::config::{Config, Delimiter};
-use crate::index::Indexed;
-use crate::util;
-use crate::CliResult;
-use log::debug;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Randomly samples CSV data uniformly using memory proportional to the size of
 the sample.
@@ -44,6 +33,15 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::index::Indexed;
+use crate::util;
+use crate::CliResult;
+use log::debug;
+use rand::{self, rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
+use serde::Deserialize;
+use std::io;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -1,25 +1,3 @@
-use crate::cmd::stats::Stats;
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-use ahash::AHashMap;
-use csv::ByteRecord;
-use grex::RegExpBuilder;
-use itertools::Itertools;
-use log::{debug, error, info, warn};
-use serde::Deserialize;
-use serde_json::{json, value::Number, Map, Value};
-use stats::Frequencies;
-use std::{collections::HashSet, fs::File, io::Write, path::Path};
-
-macro_rules! fail {
-    ($mesg:expr) => {
-        return Err(CliError::Other($mesg));
-    };
-}
-
 static USAGE: &str = r#"
 Generate JSON Schema from CSV data.
 
@@ -67,6 +45,28 @@ Common options:
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character. [default: ,]
 "#;
+
+use crate::cmd::stats::Stats;
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+use ahash::AHashMap;
+use csv::ByteRecord;
+use grex::RegExpBuilder;
+use itertools::Itertools;
+use log::{debug, error, info, warn};
+use serde::Deserialize;
+use serde_json::{json, value::Number, Map, Value};
+use stats::Frequencies;
+use std::{collections::HashSet, fs::File, io::Write, path::Path};
+
+macro_rules! fail {
+    ($mesg:expr) => {
+        return Err(CliError::Other($mesg));
+    };
+}
 
 #[derive(Deserialize, Clone)]
 pub struct Args {

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -1,16 +1,3 @@
-use regex::bytes::RegexBuilder;
-use std::env;
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-#[cfg(any(feature = "full", feature = "lite"))]
-use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
-use log::{debug, info};
-use serde::Deserialize;
-
 static USAGE: &str = "
 Filters CSV data by whether the given regex matches a row.
 
@@ -64,6 +51,18 @@ Common options:
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+#[cfg(any(feature = "full", feature = "lite"))]
+use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
+use log::{debug, info};
+use regex::bytes::RegexBuilder;
+use serde::Deserialize;
+use std::env;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -1,20 +1,3 @@
-use regex::bytes::RegexSetBuilder;
-
-use std::env;
-use std::fs::File;
-use std::io::{self, prelude::*, BufReader};
-use std::path::Path;
-
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-#[cfg(any(feature = "full", feature = "lite"))]
-use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
-use log::{debug, info};
-use serde::Deserialize;
-
 static USAGE: &str = "
 Filters CSV data by whether the given regex set matches a row.
 
@@ -75,6 +58,21 @@ Common options:
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+#[cfg(any(feature = "full", feature = "lite"))]
+use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
+use log::{debug, info};
+use regex::bytes::RegexSetBuilder;
+use serde::Deserialize;
+use std::env;
+use std::fs::File;
+use std::io::{self, prelude::*, BufReader};
+use std::path::Path;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -1,9 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = r#"
 Select columns from CSV data efficiently.
 
@@ -50,6 +44,12 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 "#;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -1,11 +1,3 @@
-use std::fs;
-
-use crate::config::{Config, Delimiter};
-use crate::index::Indexed;
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Returns the rows in the range specified (starting at 0, half-open interval).
 The range does not include headers.
@@ -41,6 +33,13 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::index::Indexed;
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use std::fs;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -1,11 +1,3 @@
-use crate::config::Config;
-use crate::util;
-use crate::CliResult;
-use qsv_sniffer::{DatePreference, SampleSize, Sniffer};
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-use thousands::Separable;
-
 static USAGE: &str = r#"
 Quickly sniff CSV metadata (delimiter, header row, preamble rows, quote character, 
 flexible, is_utf8, number of records, number of fields, field names & data types).
@@ -35,6 +27,14 @@ sniff options:
 Common options:
     -h, --help             Display this message
 "#;
+
+use crate::config::Config;
+use crate::util;
+use crate::CliResult;
+use qsv_sniffer::{DatePreference, SampleSize, Sniffer};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use thousands::Separable;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -1,14 +1,3 @@
-use std::cmp;
-
-use self::Number::{Float, Int};
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
-use rayon::prelude::*;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Sorts CSV data lexicographically.
 
@@ -42,6 +31,16 @@ Common options:
     -u, --uniq             When set, identical consecutive lines will be dropped
                            to keep only one line per sorted value.
 ";
+
+use self::Number::{Float, Int};
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rayon::prelude::*;
+use serde::Deserialize;
+use std::cmp;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -1,18 +1,3 @@
-use std::cmp;
-
-use crate::cmd::dedup;
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-use csv::ByteRecord;
-#[cfg(any(feature = "full", feature = "lite"))]
-use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
-use serde::{Deserialize, Serialize};
-
-use crate::cmd::sort::iter_cmp;
-
 static USAGE: &str = r#"
 Check if a CSV is sorted. The check is done on a streaming basis (i.e. constant memory).
 With the --json options, also retrieve record count, sort breaks & duplicate count.
@@ -60,6 +45,19 @@ Common options:
                             Must be a single character. (default: ,)
     -p, --progressbar       Show progress bars. Not valid for stdin.
 "#;
+
+use crate::cmd::dedup;
+use crate::cmd::sort::iter_cmp;
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+use csv::ByteRecord;
+#[cfg(any(feature = "full", feature = "lite"))]
+use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
+use serde::{Deserialize, Serialize};
+use std::cmp;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -1,15 +1,3 @@
-use std::fs;
-use std::io;
-use std::path::Path;
-
-use threadpool::ThreadPool;
-
-use crate::config::{Config, Delimiter};
-use crate::index::Indexed;
-use crate::util::{self, FilenameTemplate};
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Splits the given CSV data into chunks.
 
@@ -46,6 +34,16 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::index::Indexed;
+use crate::util::{self, FilenameTemplate};
+use crate::CliResult;
+use serde::Deserialize;
+use std::fs;
+use std::io;
+use std::path::Path;
+use threadpool::ThreadPool;
 
 #[derive(Clone, Deserialize)]
 struct Args {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1,27 +1,3 @@
-use std::borrow::ToOwned;
-use std::default::Default;
-use std::fmt;
-use std::fs;
-use std::io;
-use std::iter::repeat;
-use std::str::{self, FromStr};
-use std::sync::atomic::{AtomicBool, Ordering};
-
-use itertools::Itertools;
-use stats::{merge_all, Commute, MinMax, OnlineStats, Unsorted};
-use threadpool::ThreadPool;
-
-use crate::config::{Config, Delimiter};
-use crate::index::Indexed;
-use crate::select::{SelectColumns, Selection};
-use crate::util;
-use crate::CliResult;
-use once_cell::sync::OnceCell;
-use qsv_dateparser::parse_with_preference;
-use serde::Deserialize;
-
-use self::FieldType::{TDate, TDateTime, TFloat, TInteger, TNull, TString};
-
 static USAGE: &str = r#"
 Computes descriptive statistics on CSV data.
 
@@ -99,6 +75,27 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 "#;
+
+use self::FieldType::{TDate, TDateTime, TFloat, TInteger, TNull, TString};
+use crate::config::{Config, Delimiter};
+use crate::index::Indexed;
+use crate::select::{SelectColumns, Selection};
+use crate::util;
+use crate::CliResult;
+use itertools::Itertools;
+use once_cell::sync::OnceCell;
+use qsv_dateparser::parse_with_preference;
+use serde::Deserialize;
+use stats::{merge_all, Commute, MinMax, OnlineStats, Unsorted};
+use std::borrow::ToOwned;
+use std::default::Default;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::iter::repeat;
+use std::str::{self, FromStr};
+use std::sync::atomic::{AtomicBool, Ordering};
+use threadpool::ThreadPool;
 
 #[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Clone, Deserialize)]

--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -1,13 +1,3 @@
-use std::borrow::Cow;
-use std::convert::From;
-
-use tabwriter::{Alignment, TabWriter};
-
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-
 static USAGE: &str = "
 Outputs CSV data as a table with columns in alignment.
 
@@ -39,6 +29,14 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use std::borrow::Cow;
+use std::convert::From;
+use tabwriter::{Alignment, TabWriter};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -1,15 +1,3 @@
-use std::{fs::File, path::Path};
-
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
-use serde_json::{Map, Value};
-use std::env::temp_dir;
-use uuid::Uuid;
-
-use super::schema::infer_schema_from_stats;
-
 static USAGE: &str = "
 Converts CSV to a newline-delimited JSON (JSONL/NDJSON).
 
@@ -28,6 +16,16 @@ Common options:
                            Must be a single character. (default: ,)
     -o, --output <file>    Write output to <file> instead of stdout.
 ";
+
+use super::schema::infer_schema_from_stats;
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::env::temp_dir;
+use std::{fs::File, path::Path};
+use uuid::Uuid;
 
 #[derive(Deserialize, Clone)]
 struct Args {

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -1,10 +1,3 @@
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use csv::ByteRecord;
-use serde::Deserialize;
-use std::str;
-
 static USAGE: &str = "
 Transpose the rows/columns of CSV data.
 
@@ -28,6 +21,13 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 ";
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
+use csv::ByteRecord;
+use serde::Deserialize;
+use std::str;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1,31 +1,3 @@
-use crate::config::{Config, Delimiter, DEFAULT_WTR_BUFFER_CAPACITY};
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
-use anyhow::{anyhow, Result};
-use csv::ByteRecord;
-#[cfg(any(feature = "full", feature = "lite"))]
-use indicatif::{ProgressBar, ProgressDrawTarget};
-use itertools::Itertools;
-use jsonschema::paths::PathChunk;
-use jsonschema::{output::BasicOutput, JSONSchema};
-#[allow(unused_imports)]
-use log::{debug, info};
-use rayon::prelude::*;
-use serde::{Deserialize, Serialize};
-use serde_json::{json, value::Number, Map, Value};
-use std::{env, fs::File, io::BufReader, io::BufWriter, io::Read, io::Write, str};
-use thousands::Separable;
-
-macro_rules! fail {
-    ($mesg:expr) => {
-        Err(CliError::Other($mesg))
-    };
-}
-
-// number of CSV rows to process in a batch
-const BATCH_SIZE: usize = 24_000;
-
 static USAGE: &str = "
 Validate CSV data with JSON Schema, and put invalid records into a separate file.
 When run without JSON Schema, only a simple CSV check (RFC 4180) is performed.
@@ -63,6 +35,34 @@ Common options:
                                Must be a single character. [default: ,]
     -p, --progressbar          Show progress bars. Not valid for stdin.
 ";
+
+use crate::config::{Config, Delimiter, DEFAULT_WTR_BUFFER_CAPACITY};
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
+use anyhow::{anyhow, Result};
+use csv::ByteRecord;
+#[cfg(any(feature = "full", feature = "lite"))]
+use indicatif::{ProgressBar, ProgressDrawTarget};
+use itertools::Itertools;
+use jsonschema::paths::PathChunk;
+use jsonschema::{output::BasicOutput, JSONSchema};
+#[allow(unused_imports)]
+use log::{debug, info};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, value::Number, Map, Value};
+use std::{env, fs::File, io::BufReader, io::BufWriter, io::Read, io::Write, str};
+use thousands::Separable;
+
+macro_rules! fail {
+    ($mesg:expr) => {
+        Err(CliError::Other($mesg))
+    };
+}
+
+// number of CSV rows to process in a batch
+const BATCH_SIZE: usize = 24_000;
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Deserialize)]


### PR DESCRIPTION
so its more stable, and not move around as the commands are improved over time.

Also removed spaces between use statements, so its sorted in a standard way by rustfmt.

Will also make it easier to parse out the usage text in the future.

Resolves #464 