### PR TITLE
create `fail_format!` macro

### DIFF
--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -20,13 +20,22 @@ macro_rules! werr {
     });
 }
 
-// TODO: format parameter so we don't need to do fail!(format!())
 macro_rules! fail {
     ($e:expr) => {{
         use log::error;
         let err = ::std::convert::From::from($e);
         error!("{err}");
         Err(err)
+    }};
+}
+
+macro_rules! fail_format {
+    ($($t:tt)*) => {{
+        use log::error;
+        use crate::CliError;
+        let err = format!($($t)*);
+        error!("{err}");
+        Err(CliError::Other(err))
     }};
 }
 

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -376,7 +376,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if args.cmd_operations {
         for op in &operations {
             if !OPERATIONS.contains(op) {
-                return fail!(format!("Unknown '{op}' operation"));
+                return fail_format!("Unknown '{op}' operation");
             }
             #[allow(clippy::useless_asref)]
             match op.as_ref() {

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -90,7 +90,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut workbook = match open_workbook_auto(path) {
         Ok(workbook) => workbook,
-        Err(e) => return fail!(format!("Cannot open workbook: {e}.")),
+        Err(e) => return fail_format!("Cannot open workbook: {e}."),
     };
 
     let sheet_names = workbook.sheet_names();
@@ -124,7 +124,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     if let Ok(result) = result {
                         result
                     } else {
-                        return fail!(format!("Cannot retrieve range from {}", sheet_name));
+                        return fail_format!("Cannot retrieve range from {}", sheet_name);
                     }
                 }
                 None => Range::empty(),
@@ -171,10 +171,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 if sheet_index as usize <= sheet_names.len() {
                     sheet_names[sheet_index as usize].to_string()
                 } else {
-                    return fail!(format!(
+                    return fail_format!(
                         "sheet index {sheet_index} is greater than number of sheets {}",
                         sheet_names.len()
-                    ));
+                    );
                 }
             } else {
                 // if its a negative number, start from the end
@@ -205,7 +205,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         sheet = sheet_names[idx].clone();
         idx
     } else {
-        return fail!(format!("Cannot get sheet index for {sheet}"));
+        return fail_format!("Cannot get sheet index for {sheet}");
     };
 
     let range = match workbook.worksheet_range_at(sheet_index) {
@@ -213,7 +213,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             if let Ok(result) = result {
                 result
             } else {
-                return fail!(format!("Cannot retrieve range from {sheet}"));
+                return fail_format!("Cannot retrieve range from {sheet}");
             }
         }
         None => Range::empty(),

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -151,12 +151,12 @@ impl Args {
         let select1 = rconf1.selection(headers1)?;
         let select2 = rconf2.selection(headers2)?;
         if select1.len() != select2.len() {
-            return fail!(format!(
+            return fail_format!(
                 "Column selections must have the same number of columns, \
                  but found column selections with {} and {} columns.",
                 select1.len(),
                 select2.len()
-            ));
+            );
         }
         Ok((select1, select2))
     }

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -287,11 +287,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let mut redis_conn;
         match redis_client.get_connection() {
-            Err(e) => {
-                return fail!(format!(
-                    r#"Cannot connect to Redis using "{conn_str}": {e:?}"#
-                ))
-            }
+            Err(e) => return fail_format!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
             Ok(x) => redis_conn = x,
         }
 
@@ -387,7 +383,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             let vals: Vec<&str> = header.split(':').collect();
 
             if vals.len() != 2 {
-                return fail!(format!("{vals:?} is not a valid key-value pair. Expecting a key and a value seperated by a colon."));
+                return fail_format!("{vals:?} is not a valid key-value pair. Expecting a key and a value seperated by a colon.");
             }
 
             // allocate new String for header key to put into map

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -258,11 +258,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let mut redis_conn;
         match redis_client.get_connection() {
-            Err(e) => {
-                return fail!(format!(
-                    r#"Cannot connect to Redis using "{conn_str}": {e:?}"#
-                ))
-            }
+            Err(e) => return fail_format!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
             Ok(x) => redis_conn = x,
         }
 
@@ -350,7 +346,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             let vals: Vec<&str> = header.split(':').collect();
 
             if vals.len() != 2 {
-                return fail!(format!("{vals:?} is not a valid key-value pair. Expecting a key and a value seperated by a colon."));
+                return fail_format!("{vals:?} is not a valid key-value pair. Expecting a key and a value seperated by a colon.");
             }
 
             // allocate new String for header key to put into map

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -363,12 +363,12 @@ impl Args {
         let select1 = rconf1.selection(headers1)?;
         let select2 = rconf2.selection(headers2)?;
         if select1.len() != select2.len() {
-            return fail!(format!(
+            return fail_format!(
                 "Column selections must have the same number of columns, \
                  but found column selections with {} and {} columns.",
                 select1.len(),
                 select2.len()
-            ));
+            );
         }
         Ok((select1, select2))
     }

--- a/src/cmd/lua.rs
+++ b/src/cmd/lua.rs
@@ -134,7 +134,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let lua_script = if args.flag_script_file {
         match fs::read_to_string(&args.arg_script) {
             Ok(script_file) => script_file,
-            Err(e) => return fail!(format!("Cannot load lua file: {e}")),
+            Err(e) => return fail_format!("Cannot load lua file: {e}"),
         }
     } else {
         args.arg_script
@@ -191,7 +191,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let computed_value: mlua::Value = match lua.load(&lua_program).eval() {
             Ok(computed) => computed,
-            Err(e) => return fail!(format!("Cannot evaluate \"{lua_program}\".\n{e}")),
+            Err(e) => return fail_format!("Cannot evaluate \"{lua_program}\".\n{e}"),
         };
 
         if args.cmd_map {
@@ -214,7 +214,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     record.push_field("");
                 }
                 _ => {
-                    return fail!(format!("Unexpected value type returned by provided Lua expression. {computed_value:?}"));
+                    return fail_format!("Unexpected value type returned by provided Lua expression. {computed_value:?}");
                 }
             }
 

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -149,7 +149,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if let Some(helper_file) = args.flag_helper {
         helper_text = match fs::read_to_string(helper_file) {
             Ok(helper_file) => helper_file,
-            Err(e) => return fail!(format!("Cannot load python file: {e}")),
+            Err(e) => return fail_format!("Cannot load python file: {e}"),
         }
     }
 

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -160,7 +160,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         "detail": e.to_string()
                     }]
                 });
-                return fail!(format!("{json_result}"));
+                return fail_format!("{json_result}");
             }
         }
     } else {
@@ -182,7 +182,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 println!("{disp}");
             }
             Err(e) => {
-                return fail!(format!("sniff error: {e}"));
+                return fail_format!("sniff error: {e}");
             }
         }
     }

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -135,7 +135,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         });
                         return fail!(header_error.to_string());
                     }
-                    return fail!(format!("Cannot read header ({e})."));
+                    return fail_format!("Cannot read header ({e}).");
                 }
             }
         }
@@ -152,9 +152,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     });
                     return fail!(validation_error.to_string());
                 }
-                return fail!(format!(
+                return fail_format!(
                     r#"Validation error: {e}. Try "qsv fixlengths" or "qsv fmt" to fix it."#
-                ));
+                );
             }
             record_count += 1;
         }
@@ -219,17 +219,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         match JSONSchema::options().compile(&json) {
                             Ok(schema) => (json, schema),
                             Err(e) => {
-                                return fail!(format!("Cannot compile schema json. error: {e}"));
+                                return fail_format!("Cannot compile schema json. error: {e}");
                             }
                         }
                     }
                     Err(e) => {
-                        return fail!(format!("Unable to parse schema json. error: {e}"));
+                        return fail_format!("Unable to parse schema json. error: {e}");
                     }
                 }
             }
             Err(e) => {
-                return fail!(format!("Unable to retrieve json. error: {e}"));
+                return fail_format!("Unable to retrieve json. error: {e}");
             }
         };
 


### PR DESCRIPTION
so instead of:

` return fail!(format!("This is an error: {e}"));`

we can do:

`return fail_format!("This is an error: {e}");`