### PR TITLE
Refactored `self_update` feature

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -122,7 +122,7 @@ jobs:
         command: build
         use-cross: false
         toolchain: ${{ matrix.rust }}
-        args: --profile release-nightly --bin qsvlite -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --features=lite --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+        args: --profile release-nightly --bin qsvlite -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --features=lite,self_update --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvdp-nightly
       env:
         RUSTFLAGS: --emit=asm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,7 +188,7 @@ jobs:
         command: build
         use-cross: ${{ matrix.job.use-cross }}
         toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+        args: --release --locked --bin qsvlite --features=lite,self_update --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvdp
       env:
         RUSTFLAGS: --emit=asm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ self_update = { version = "0.31", features = [
     "archive-zip",
     "compression-zip-deflate",
     "rustls",
-], default-features = false }
+], default-features = false, optional = true}
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 strsim = { version = "0.10", optional = true }
@@ -204,7 +204,7 @@ lua = ["mlua"]
 python = ["pyo3"]
 lite = []
 datapusher_plus = []
-full = []
+full = ["self_update"]
 nightly = [
     "regex/unstable",
     "rand/nightly",
@@ -213,4 +213,3 @@ nightly = [
     "pyo3/nightly",
     "hashbrown/nightly",
 ]
-no_self_update = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,13 +182,13 @@ fn main() -> QsvExitCode {
         return QsvExitCode::Good;
     }
     if args.flag_update {
-        #[cfg(feature = "no_self_update")]
+        #[cfg(not(feature = "self_update"))]
         {
             werr!("Self update engine disabled.");
             util::log_end(qsv_args, now);
             return QsvExitCode::IncorrectUsage;
         }
-        #[cfg(not(feature = "no_self_update"))]
+        #[cfg(feature = "self_update")]
         {
             util::qsv_check_for_update();
             util::log_end(qsv_args, now);

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -119,13 +119,13 @@ fn main() -> QsvExitCode {
         return QsvExitCode::Good;
     }
     if args.flag_update {
-        #[cfg(feature = "no_self_update")]
+        #[cfg(not(feature = "self_update"))]
         {
             werr!("Self update engine disabled.");
             util::log_end(qsv_args, now);
             return QsvExitCode::IncorrectUsage;
         }
-        #[cfg(not(feature = "no_self_update"))]
+        #[cfg(feature = "self_update")]
         {
             util::qsv_check_for_update();
             util::log_end(qsv_args, now);


### PR DESCRIPTION
- so we don't have to include the self_update crate if we're disabling self-update engine