### PR TITLE
Simplify python support

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -78,7 +78,7 @@ jobs:
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: build prep for x86_64-unknown-linux-musl
       if: ${{ matrix.job.musl-prep }}
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,7 +138,7 @@ jobs:
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: build prep for aarch64-apple-darwin
       if: ${{ matrix.job.build-prep }}
       run: |

--- a/.github/workflows/rust-beta.yml
+++ b/.github/workflows/rust-beta.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Update Rust Beta
       run: |
         rustup update beta

--- a/.github/workflows/rust-macos.yml
+++ b/.github/workflows/rust-macos.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Update Rust
       run: rustup update
     - name: Setup Rust-cache

--- a/.github/workflows/rust-nightly-bleeding-edge.yml
+++ b/.github/workflows/rust-nightly-bleeding-edge.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install and Run Redis
       run: |
         sudo apt-get install redis-server

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install and Run Redis
       run: |
         sudo apt-get install redis-server

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Update Rust
       run: rustup update
     - name: Setup Rust-cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4.2.0
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install and Run Redis
       run: |
         sudo apt-get install redis-server

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.23.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69139e86394985dfc6ba76eb4e8a0b3dd6c1de2b5a7e6971af63e2f539bd8084"
+checksum = "f4a12e3b5a8775259ee83ac38aea8cdf9c3a1667c02178d207378c0837808fa9"
 dependencies = [
  "flate2",
  "glob",
@@ -1956,7 +1956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4cf18c20f4f09995f3554e6bcf9b09bd5e4d6b67c562fdfaafa644526ba479"
 dependencies = [
  "once_cell",
- "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -1991,15 +1990,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a915bd72824962bf190bbd3e8a044cccb695d1409f73ff5493712eda5136c7a8"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,12 +104,7 @@ mlua = { version = "0.8", features = [
 ], optional = true }
 once_cell = { version = "1.14", features = ["parking_lot"] }
 parking_lot = { version = "0.12", features = ["hardware-lock-elision"] }
-pyo3 = { version = "0.17", features = [
-    "abi3",
-    "abi3-py38",
-    "auto-initialize",
-    "generate-import-lib",
-], optional = true }
+pyo3 = { version = "0.17", features = ["auto-initialize"], optional = true }
 qsv-dateparser = "0.4"
 qsv-stats = "0.4"
 qsv_currency = { version = "0.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for mor
 | [lua](/src/cmd/lua.rs#L2)[^1] | Execute a [Lua](https://www.lua.org/about.html) 5.4.4 script over CSV lines to transform, aggregate or filter them.  |
 | [partition](/src/cmd/partition.rs#L2) | Partition a CSV based on a column value. |
 | [pseudo](/src/cmd/pseudo.rs#L2) | [Pseudonymise](https://en.wikipedia.org/wiki/Pseudonymization) the value of the given column by replacing them with an incremental identifier.  |
-| [py](/src/cmd/python.rs#L2)[^1] | Evaluate a Python expression over CSV lines to transform, aggregate or filter them. Python's [f-strings](https://www.freecodecamp.org/news/python-f-strings-tutorial-how-to-use-f-strings-for-string-formatting/) is particularly useful for extended formatting (Python 3.8+ required).  |
+| [py](/src/cmd/python.rs#L2)[^1] | Evaluate a Python expression over CSV lines to transform, aggregate or filter them. Python's [f-strings](https://www.freecodecamp.org/news/python-f-strings-tutorial-how-to-use-f-strings-for-string-formatting/) is particularly useful for extended formatting ([Python 3.6 and up supported, with Python 3.10 required on prebuilt qsv](#python)).  |
 | [rename](/src/cmd/rename.rs#L2) |  Rename the columns of a CSV efficiently.  |
 | [replace](/src/cmd/replace.rs#L2) | Replace CSV data using a regex.  |
 | [reverse](/src/cmd/reverse.rs#L2)[^3] | Reverse order of rows in a CSV. Unlike the `sort --reverse` command, it preserves the order of rows with the same key.  |
@@ -90,14 +90,19 @@ There are four variants of qsv:
  * `qsvlite` has all features disabled (~half the size of `qsv`)
  * `qsvdp` is optimized for use with [DataPusher+](https://github.com/dathere/datapusher-plus), with only DataPusher+ relevant commands and the self-update engine removed (~sixth of the size of `qsv`).
 
-Alternatively, you can install from source by [installing Cargo](https://crates.io/install)
-([Rust's](https://www.rust-lang.org/) package manager) and installing `qsv` using Cargo:
+Alternatively, you can install from source by [installing Rust](https://www.rust-lang.org/tools/install)
+and installing `qsv` using Rust's cargo command[^6]:
+
+[^6]: Of course, you'll also need a linker and a C compiler. Linux users should generally install GCC or Clang, according to their distribution’s documentation.
+For example, if you use Ubuntu, you can install the `build-essential` package. On macOS, you can get a C compiler by running `$ xcode-select --install`.
+For Windows, this means installing [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/). When prompted for workloads, include "Desktop Development with C++",
+the Windows 10 or 11 SDK, and the English language pack, along with any other language packs your require.
 
 ```bash
 cargo install qsv --features all_full
 ```
 
-If you encounter compilation errors, ensure you have at least Python 3.8 installed and you're using the exact
+If you encounter compilation errors, ensure you have the Python development libraries installed and you're using the exact
 version of the dependencies qsv was built with by issuing:
 
 ```bash
@@ -144,7 +149,7 @@ cargo build --release --features datapusher_plus
 ```
 
 [^6]: The `foreach` feature is not available on Windows. The `python` feature is not enabled on cross-compiled pre-built binaries as we don't have
-access to a native python interpreter for those platforms (aarch64, i686, and arm) on GitHub's x86_64-based action runners. Compile natively on those platforms with Python 3.8+ installed, if you want to enable the `python` feature.
+access to a native python interpreter for those platforms (aarch64, i686, and arm) on GitHub's x86_64-based action runners. Compile natively on those platforms with Python 3.6+ development environment installed, if you want to enable the `python` feature.
 
 ### Minimum Supported Rust Version
 
@@ -215,6 +220,25 @@ Which is weird, since you would think [Microsoft's own Excel would properly reco
 ```
 qsv stats wcp.csv --output wcpstats.csv
 ```
+
+## Python
+
+With the `python` feature, `qsv` will look for Python shared libraries (libpython* on Linux/macOS, python*.dll on Windows) against which it was compiled, 
+and abort with an error if not found, detailing the Python library it was looking for.
+
+Note that this will happen as soon as the qsv binary is invoked, even if you're not running the `py` command.
+
+If you don't need to run the `py` command, simply use `qsvnp` ("np" stands for "no python"), `qsvlite`, or `qsvdp`.
+
+If you need the `py` command, the [prebuilt qsv binary](https://github.com/jqnatividad/qsv/releases/latest) is compiled, as a policy,
+using the latest stable Python minor version (currently Python 3.10).
+
+If you require a different Python version (Python 3.6 and up are supported), you'll need to install/compile from source, making sure you have
+the development libraries for the desired Python version installed when doing so. [PyO3](https://pyo3.rs) - the underlying crate that enables the `python` feature,
+uses a build script to determine the Python version and set the correct linker arguments. By default it uses the python3 executable.
+You can override the Python interpreter by setting `PYO3_PYTHON`, e.g., `PYO3_PYTHON=python3.6`.
+
+See the [PyO3 User Guide](https://pyo3.rs/v0.17.1/building_and_distribution.html) for more information.
 
 ## Environment Variables
 

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -32,10 +32,11 @@ Some usage examples:
   Load helper file with function to compute Fibonacci sequence of the column "num_col"
   $ qsv py map --helper-file fibonacci.py fib qsv_uh.fibonacci(num_col) data.csv
 
-  NOTE: The py command requires Python 3.8+. If you wish qsv to use a specific 
-  Python version other than your system's default - either run it in a python 
-  virtual environment, or copy the shared library of the desired Python version 
-  in the same directory as qsv (libpython* on Linux/macOS, python*.dll on Windows).
+  NOTE: The prebuilt qsv binaries are linked against Python 3.10 and will require access
+  to the Python 3.10 shared libraries (libpython* on Linux/macOS, python*.dll on Windows)
+  during runtime for the py command to run. 
+  
+  If you wish qsv to use another Python version, you'll need to install/compile qsv from source.
 
   Also, the following Python modules are automatically loaded and available to the user -
   builtsin, math and random. The user can import additional modules with the --helper option.

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,6 @@
 extern crate crossbeam_channel as channel;
 use crate::clitypes::{CliError, CliResult, QsvExitCode};
 use docopt::Docopt;
-#[cfg(all(feature = "python", not(feature = "lite")))]
-use pyo3::Python;
 use serde::Deserialize;
 use std::{env, io, time::Instant};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,20 +142,9 @@ struct Args {
     flag_update: bool,
 }
 
-#[cfg(all(feature = "python", not(feature = "lite")))]
-fn check_python() -> bool {
-    Python::with_gil(|py| py.version_info() >= (3, 8))
-}
-
 fn main() -> QsvExitCode {
     let now = Instant::now();
     let qsv_args = util::init_logger();
-
-    #[cfg(all(feature = "python", not(feature = "lite")))]
-    if !check_python() {
-        werr!("Python 3.8+ required. Either upgrade python, use a python virtual environment with Python 3.8+ or use qsvnp/qsvlite.");
-        return QsvExitCode::Abort;
-    }
 
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {


### PR DESCRIPTION
- prebuilt qsv binary targets Python 3.10
- if another Python version is required (Python 3.6 and up are supported), add instructions on how to install/compile from source
- also add detailed instructions targeted to non-developers for installing/compiling from source