### PR TITLE
Smarter self update

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  QSV_KIND: prebuilt
+  QSV_KIND: prebuilt-nightly
 
 jobs:
   analyze-tags:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -70,14 +70,28 @@ Several commands support multithreading - `stats`, `frequency`, `schema`, `split
 
 qsv will automatically spawn parallel jobs equal to the detected number of logical processors. Should you want to manually override this, use the `--jobs` command-line option or the `QSV_MAX_JOBS` environment variable.
 
-To find out your jobs setting, call `qsv --version`. The second to the last number is the number of jobs qsv will use for multithreaded commands. The last number is the number of logical processors detected by qsv.  For example:
+To find out your jobs setting, call `qsv --version`. The second to the last number is the number of jobs qsv will use for multithreaded commands. The last number is the number of logical processors detected by qsv.
+
+## Version details
+The `--version` option shows a lot of information about qsv. It displays:
+ * qsv version
+ * the memory allocator (`standard` or `mimalloc`)
+ * all enabled features (`apply`, `fetch`, `foreach`, `generate`, `lua`, `python` & `self_update`)
+ * Python version required if the `python` feature was enabled
+ * the number of processors to use for multi-threading commands
+ * the number of logical processors detected
+ * the target platform
+ * the Rust version used to compile qsv
+ * QSV_KIND - `prebuilt`, `prebuilt-nightly`, `installed` & `compiled`.
+   The prebuilts are the qsv binaries published on Github with every release. `prebuilt` is built using the current Rust stable at the time of release. `prebuilt-nightly` is built using Rust nightly/unstable at the time of release.
+   `installed` is qsv built using `cargo install`. `compiled` is qsv built using `cargo build`.
 
 ```
 $ qsv --version
-qsv 0.66.0-mimalloc-apply;fetch;foreach;generate;lua;python-3.10.5 (v3.10.5:f377153967, Jun  6 2022, 12:36:10) [Clang 13.0.0 (clang-1300.0.29.30)];self_update-8-8 (aarch64-apple-darwin compiled with Rust 1.63)
+qsv 0.66.0-mimalloc-apply;fetch;foreach;generate;lua;python-3.10.5 (v3.10.5:f377153967, Jun  6 2022, 12:36:10) [Clang 13.0.0 (clang-1300.0.29.30)];self_update-8-8 (aarch64-apple-darwin compiled with Rust 1.63 ) prebuilt
 ```
 
-Shows that I'm running qsv version 0.66.0, with the `mimalloc` allocator (instead of `standard`), and I have the `apply`, `fetch`, `foreach`, `generate`, `lua`, `python` and `self_update` features enabled, and qsv will be using 8 logical processors out of 8 detected when running multithreaded commands, and the qsv binary was built to target the aarch64-apple-darwin platform (Apple Silicon), compiled using Rust 1.63.
+Shows that I'm running qsv version 0.66.0, with the `mimalloc` allocator (instead of `standard`), and I have the `apply`, `fetch`, `foreach`, `generate`, `lua`, `python` and `self_update` features enabled, and qsv will be using 8 logical processors out of 8 detected when running multithreaded commands, and the qsv binary was built to target the aarch64-apple-darwin platform (Apple Silicon), compiled using Rust 1.63. The binary is prebuilt (i.e. binaries prebuilt and published on GitHub with every release).
 
 ## Caching
 The `apply geocode` command [memoizes](https://en.wikipedia.org/wiki/Memoization) otherwise expensive geocoding operations and will report its cache hit rate. `apply geocode` memoization, however, is not persistent across sessions.


### PR DESCRIPTION
- `self-update` now checks if qsv was manually installed/compiled from source and only informs the user of a new release if so.
- in this way, users need not fear that their manually built qsv will be inadvertently overwritten by prebuilt qsv binaries on release.

Also, QSV_KIND info now also displayed by --version.