### PR TITLE
`python`: better error handling

### DIFF
--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -41,7 +41,8 @@ Some usage examples:
   Also, the following Python modules are automatically loaded and available to the user -
   builtsin, math and random. The user can import additional modules with the --helper option.
 
-  If a python expression cannot be evaluated, "<ERROR>" is returned.
+  With "py map", if a python expression is invalid, "<ERROR>" is returned.
+  With "py filter", if a python expression is invalid, false is returned.
 
 Usage:
     qsv py map [options] -n <script> [<input>]
@@ -299,7 +300,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         let result = helpers
                             .getattr(intern!(py, "cast_as_bool"))?
                             .call1((result,))?;
-                        let value: bool = result.extract()?;
+                        let value: bool = result.extract().unwrap_or(false);
 
                         if value {
                             if let Err(e) = wtr.write_record(&record) {

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -31,6 +31,36 @@ fn py_map() {
 }
 
 #[test]
+fn py_map_error() {
+    let wrk = Workdir::new("py");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["letter", "number"],
+            svec!["a", "13"],
+            svec!["b", "24"],
+            svec!["c", "72"],
+            svec!["d", "7"],
+        ],
+    );
+    let mut cmd = wrk.command("py");
+    cmd.arg("map")
+        .arg("inc")
+        .arg("integerthis(number) + 1")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number", "inc"],
+        svec!["a", "13", "<ERROR>"],
+        svec!["b", "24", "<ERROR>"],
+        svec!["c", "72", "<ERROR>"],
+        svec!["d", "7", "<ERROR>"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn py_map_builtins() {
     let wrk = Workdir::new("py");
     wrk.create(

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -381,6 +381,35 @@ fn py_filter() {
 }
 
 #[test]
+fn py_filter_error() {
+    let wrk = Workdir::new("py");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["letter", "number"],
+            svec!["a", "13"],
+            svec!["b", "24"],
+            svec!["c", "72"],
+            svec!["d", "7"],
+        ],
+    );
+    let mut cmd = wrk.command("py");
+    cmd.arg("filter")
+        .arg("integerthis(number) > 14")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number"],
+        svec!["a", "13"],
+        svec!["b", "24"],
+        svec!["c", "72"],
+        svec!["d", "7"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn py_format() {
     let wrk = Workdir::new("py");
     wrk.create(


### PR DESCRIPTION
- don't panic, bubble up errors
- when mapping, if a python expression evaluation fails, don't panic, continue and return "\<ERROR\>" instead
- when filtering, if a python expression evaluation fails, don't panic, continue and return false
- performance: only intern PyStrings that are used inside a loop