### PR TITLE
`lua`: improved error handling

### DIFF
--- a/tests/test_lua.rs
+++ b/tests/test_lua.rs
@@ -58,6 +58,36 @@ fn lua_map_math() {
 }
 
 #[test]
+fn lua_map_error() {
+    let wrk = Workdir::new("lua");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["letter", "number"],
+            svec!["a", "13"],
+            svec!["b", "24"],
+            svec!["c", "72"],
+            svec!["d", "7"],
+        ],
+    );
+    let mut cmd = wrk.command("lua");
+    cmd.arg("map")
+        .arg("div")
+        .arg("math.dancefloor(number / 2)")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number", "div"],
+        svec!["a", "13", "<ERROR>"],
+        svec!["b", "24", "<ERROR>"],
+        svec!["c", "72", "<ERROR>"],
+        svec!["d", "7", "<ERROR>"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn lua_map_header_with_nonalphanumeric_chars() {
     let wrk = Workdir::new("lua");
     wrk.create(
@@ -230,6 +260,35 @@ fn lua_filter() {
         svec!["letter", "number"],
         svec!["b", "24"],
         svec!["c", "72"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn lua_filter_error() {
+    let wrk = Workdir::new("lua");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["letter", "number"],
+            svec!["a", "13"],
+            svec!["b", "24"],
+            svec!["c", "72"],
+            svec!["d", "7"],
+        ],
+    );
+    let mut cmd = wrk.command("lua");
+    cmd.arg("filter")
+        .arg("tothedancenumber(number) > 14")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number"],
+        svec!["a", "13"],
+        svec!["b", "24"],
+        svec!["c", "72"],
+        svec!["d", "7"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
* when mapping, don't return error on invalid Lua, continue and return the result "<ERROR>", like `py` command
* when filtering, if a Lua script fails, continue and do not filter, like `py` command