### PR TITLE
Rustfmt StdExternalCrate

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
     - name: Check formatting
       uses: actions-rs/cargo@v1
       with:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-# this project uses rustfmt defaults
+group_imports = "StdExternalCrate"

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -230,10 +230,6 @@ Common options:
     -p, --progressbar           Show progress bars. Not valid for stdin.
 "#;
 
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::CliResult;
-use crate::{regex_once_cell, util};
 use cached::proc_macro::cached;
 use censor::{Censor, Sex, Zealous};
 use dynfmt::Format;
@@ -254,6 +250,11 @@ use strsim::{
 use titlecase::titlecase;
 use vader_sentiment::SentimentIntensityAnalyzer;
 use whatlang::detect;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::CliResult;
+use crate::{regex_once_cell, util};
 
 // number of CSV rows to process in a batch
 const BATCH_SIZE: usize = 24_000;

--- a/src/cmd/behead.rs
+++ b/src/cmd/behead.rs
@@ -12,10 +12,11 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -32,10 +32,11 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -19,11 +19,12 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use log::{debug, info};
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use log::{debug, info};
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -45,16 +45,17 @@ Common options:
                                Must be a single character. (default: ,)
 "#;
 
+use std::cmp;
+
+use csv::ByteRecord;
+use rayon::prelude::*;
+use serde::Deserialize;
+
+use crate::cmd::sort::iter_cmp;
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
-use csv::ByteRecord;
-use rayon::prelude::*;
-use serde::Deserialize;
-use std::cmp;
-
-use crate::cmd::sort::iter_cmp;
 #[derive(Deserialize)]
 struct Args {
     arg_input: Option<String>,

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -46,12 +46,13 @@ Common options:
                              Must be a single character. (default: ,)
 "#;
 
+use serde::Deserialize;
+use uuid::Uuid;
+
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use uuid::Uuid;
 
 const NULL_VALUE: &str = "<NULL>";
 

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -56,15 +56,17 @@ Common options:
     -o, --output <file>        Write output to <file> instead of stdout.
 "#;
 
-use crate::config::Config;
-use crate::util;
-use crate::CliResult;
+use std::cmp;
+use std::path::PathBuf;
+
 use calamine::{open_workbook_auto, DataType, Range, Reader};
 use log::{debug, info};
 use serde::Deserialize;
-use std::cmp;
-use std::path::PathBuf;
 use thousands::Separable;
+
+use crate::config::Config;
+use crate::util;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -32,19 +32,21 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
-use crate::config::{Config, Delimiter};
-use crate::index::Indexed;
-use crate::select::{SelectColumns, Selection};
-use crate::util;
-use crate::CliResult;
-use ahash::AHashMap;
-use byteorder::{BigEndian, WriteBytesExt};
-use serde::Deserialize;
 use std::collections::hash_map::Entry;
 use std::fmt;
 use std::fs;
 use std::io;
 use std::str;
+
+use ahash::AHashMap;
+use byteorder::{BigEndian, WriteBytesExt};
+use serde::Deserialize;
+
+use crate::config::{Config, Delimiter};
+use crate::index::Indexed;
+use crate::select::{SelectColumns, Selection};
+use crate::util;
+use crate::CliResult;
 
 type ByteString = Vec<u8>;
 

--- a/src/cmd/explode.rs
+++ b/src/cmd/explode.rs
@@ -31,11 +31,12 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
 #[derive(Deserialize)]
 struct Args {
     arg_column: SelectColumns,

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -25,14 +25,16 @@ Common options:
                            appear as the header row in the output.
 ";
 
-use crate::util;
-use crate::CliResult;
-use ext_sort::{buffer::mem::MemoryLimitedBufferBuilder, ExternalSorter, ExternalSorterBuilder};
-use serde::Deserialize;
 use std::fs;
 use std::io::{self, prelude::*};
 use std::path;
+
+use ext_sort::{buffer::mem::MemoryLimitedBufferBuilder, ExternalSorter, ExternalSorterBuilder};
+use serde::Deserialize;
 use sysinfo::{System, SystemExt};
+
+use crate::util;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -167,11 +167,8 @@ Common options:
     -p, --progressbar          Show progress bars. Not valid for stdin.
 "#;
 
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::CliError;
-use crate::CliResult;
-use crate::{regex_once_cell, util};
+use std::{fs, thread, time};
+
 use cached::proc_macro::{cached, io_cached};
 use cached::{Cached, IOCached, RedisCache, Return};
 use dynfmt::Format;
@@ -188,8 +185,13 @@ use regex::Regex;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::{fs, thread, time};
 use url::Url;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::CliError;
+use crate::CliResult;
+use crate::{regex_once_cell, util};
 
 #[derive(Deserialize, Debug)]
 struct Args {

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -143,12 +143,8 @@ Common options:
     -p, --progressbar          Show progress bars. Not valid for stdin.
 "#;
 
-use crate::cmd::fetch::apply_jql;
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
+use std::{fs, thread, time};
+
 use cached::proc_macro::{cached, io_cached};
 use cached::{Cached, IOCached, RedisCache, Return};
 use governor::{
@@ -164,8 +160,14 @@ use regex::Regex;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::{fs, thread, time};
 use url::Url;
+
+use crate::cmd::fetch::apply_jql;
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
 
 #[derive(Deserialize, Debug)]
 struct Args {

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -49,15 +49,17 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::io;
+use std::iter;
+use std::ops;
+
+use ahash::AHashMap;
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::select::{SelectColumns, Selection};
 use crate::util;
 use crate::CliResult;
-use ahash::AHashMap;
-use serde::Deserialize;
-use std::io;
-use std::iter;
-use std::ops;
 
 type ByteString = Vec<u8>;
 type BoxedWriter = csv::Writer<Box<dyn io::Write + 'static>>;

--- a/src/cmd/fixlengths.rs
+++ b/src/cmd/fixlengths.rs
@@ -26,11 +26,13 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::cmp;
+
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use std::cmp;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/flatten.rs
+++ b/src/cmd/flatten.rs
@@ -30,13 +30,15 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::borrow::Cow;
+use std::io::{self, Write};
+
+use serde::Deserialize;
+use tabwriter::TabWriter;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use std::borrow::Cow;
-use std::io::{self, Write};
-use tabwriter::TabWriter;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/fmt.rs
+++ b/src/cmd/fmt.rs
@@ -29,10 +29,11 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/foreach.rs
+++ b/src/cmd/foreach.rs
@@ -35,17 +35,19 @@ Common options:
     -p, --progressbar      Show progress bars. Not valid for stdin.
 ";
 
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
-use indicatif::{ProgressBar, ProgressDrawTarget};
-use regex::bytes::{NoExpand, Regex};
-use serde::Deserialize;
 use std::ffi::OsStr;
 use std::io::BufReader;
 use std::os::unix::ffi::OsStrExt;
 use std::process::{Command, Stdio};
+
+use indicatif::{ProgressBar, ProgressDrawTarget};
+use regex::bytes::{NoExpand, Regex};
+use serde::Deserialize;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -46,16 +46,18 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::fs;
+use std::io;
+
+use serde::Deserialize;
+use stats::{merge_all, Frequencies};
+use threadpool::ThreadPool;
+
 use crate::config::{Config, Delimiter};
 use crate::index::Indexed;
 use crate::select::{SelectColumns, Selection};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use stats::{merge_all, Frequencies};
-use std::fs;
-use std::io;
-use threadpool::ThreadPool;
 
 #[derive(Clone, Deserialize)]
 pub struct Args {

--- a/src/cmd/generate.rs
+++ b/src/cmd/generate.rs
@@ -50,15 +50,17 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use serde::Deserialize;
 use std::env::temp_dir;
 use std::fs;
 use std::io::{self, Write};
+
+use serde::Deserialize;
 use test_data_generation::data_sample_parser::DataSampleParser;
 use uuid::Uuid;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/headers.rs
+++ b/src/cmd/headers.rs
@@ -24,12 +24,14 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::io;
+
+use serde::Deserialize;
+use tabwriter::TabWriter;
+
 use crate::config::Delimiter;
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use std::io;
-use tabwriter::TabWriter;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -28,14 +28,16 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliResult;
-use csv_index::RandomAccessSimple;
-use serde::Deserialize;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+
+use csv_index::RandomAccessSimple;
+use serde::Deserialize;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -39,11 +39,12 @@ Common options:
                              Must be a single character. (default: ,)
 "#;
 
+use log::info;
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use log::info;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -65,19 +65,21 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
-use crate::config::{Config, Delimiter, SeekRead};
-use crate::index::Indexed;
-use crate::select::{SelectColumns, Selection};
-use crate::util;
-use crate::CliResult;
-use ahash::AHashMap;
-use byteorder::{BigEndian, WriteBytesExt};
-use serde::Deserialize;
 use std::collections::hash_map::Entry;
 use std::fmt;
 use std::io;
 use std::iter::repeat;
 use std::str;
+
+use ahash::AHashMap;
+use byteorder::{BigEndian, WriteBytesExt};
+use serde::Deserialize;
+
+use crate::config::{Config, Delimiter, SeekRead};
+use crate::index::Indexed;
+use crate::select::{SelectColumns, Selection};
+use crate::util;
+use crate::CliResult;
 
 type ByteString = Vec<u8>;
 

--- a/src/cmd/jsonl.rs
+++ b/src/cmd/jsonl.rs
@@ -17,13 +17,15 @@ Common options:
     -o, --output <file>    Write output to <file> instead of stdout.
 ";
 
+use std::fs;
+use std::io::{self, BufRead, BufReader};
+
+use serde::Deserialize;
+use serde_json::Value;
+
 use crate::config::Config;
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use serde_json::Value;
-use std::fs;
-use std::io::{self, BufRead, BufReader};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/lua.rs
+++ b/src/cmd/lua.rs
@@ -75,15 +75,17 @@ Common options:
     -p, --progressbar      Show progress bars. Not valid for stdin.
 "#;
 
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
+use std::fs;
+
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use log::debug;
 use mlua::Lua;
 use serde::Deserialize;
-use std::fs;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/luajit.rs
+++ b/src/cmd/luajit.rs
@@ -78,15 +78,17 @@ Common options:
     -p, --progressbar      Show progress bars. Not valid for stdin.
 "#;
 
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
+use std::fs;
+
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use log::debug;
 use mluajit::Lua;
 use serde::Deserialize;
-use std::fs;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -28,18 +28,20 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util::{self, FilenameTemplate};
-use crate::CliResult;
-use ahash::AHashMap;
-use regex::Regex;
-use serde::Deserialize;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::Path;
+
+use ahash::AHashMap;
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util::{self, FilenameTemplate};
+use crate::CliResult;
 
 #[derive(Clone, Deserialize)]
 struct Args {

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -15,12 +15,13 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use ahash::AHashMap;
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
-use ahash::AHashMap;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -107,17 +107,19 @@ Common options:
     -p, --progressbar      Show progress bars. Not valid for stdin.
 "#;
 
-use crate::config::{Config, Delimiter};
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
+use std::fs;
+
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use log::{error, log_enabled, Level::Debug};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use serde::Deserialize;
-use std::fs;
+
+use crate::config::{Config, Delimiter};
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
 
 const HELPERS: &str = r#"
 def cast_as_string(value):

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -22,10 +22,11 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -47,17 +47,19 @@ Common options:
 
 ";
 
+use std::borrow::Cow;
+use std::env;
+
+#[cfg(any(feature = "full", feature = "lite"))]
+use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
+use regex::bytes::RegexBuilder;
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliError;
 use crate::CliResult;
-#[cfg(any(feature = "full", feature = "lite"))]
-use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
-use regex::bytes::RegexBuilder;
-use serde::Deserialize;
-use std::borrow::Cow;
-use std::env;
 
 #[allow(dead_code)]
 #[derive(Deserialize)]

--- a/src/cmd/reverse.rs
+++ b/src/cmd/reverse.rs
@@ -21,10 +21,11 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -34,14 +34,16 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::io;
+
+use log::debug;
+use rand::{self, rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::index::Indexed;
 use crate::util;
 use crate::CliResult;
-use log::debug;
-use rand::{self, rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
-use serde::Deserialize;
-use std::io;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -47,11 +47,8 @@ Common options:
                                Must be a single character. [default: ,]
 "#;
 
-use crate::cmd::stats::Stats;
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliResult;
+use std::{collections::HashSet, fs::File, io::Write, path::Path};
+
 use ahash::AHashMap;
 use csv::ByteRecord;
 use grex::RegExpBuilder;
@@ -60,7 +57,12 @@ use log::{debug, error, info, warn};
 use serde::Deserialize;
 use serde_json::{json, value::Number, Map, Value};
 use stats::Frequencies;
-use std::{collections::HashSet, fs::File, io::Write, path::Path};
+
+use crate::cmd::stats::Stats;
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliResult;
 
 #[derive(Deserialize, Clone)]
 pub struct Args {

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -53,17 +53,19 @@ Common options:
     -p, --progressbar      Show progress bars. Not valid for stdin.
 ";
 
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
+use std::env;
+
 #[cfg(any(feature = "full", feature = "lite"))]
 use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
 use log::{debug, info};
 use regex::bytes::RegexBuilder;
 use serde::Deserialize;
-use std::env;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
 
 #[allow(dead_code)]
 #[derive(Deserialize)]

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -60,19 +60,21 @@ Common options:
     -p, --progressbar      Show progress bars. Not valid for stdin.
 ";
 
-use crate::config::{Config, Delimiter};
-use crate::select::SelectColumns;
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
+use std::env;
+use std::fs::File;
+use std::io::{self, prelude::*, BufReader};
+
 #[cfg(any(feature = "full", feature = "lite"))]
 use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
 use log::{debug, info};
 use regex::bytes::RegexSetBuilder;
 use serde::Deserialize;
-use std::env;
-use std::fs::File;
-use std::io::{self, prelude::*, BufReader};
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectColumns;
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
 
 #[allow(dead_code)]
 #[derive(Deserialize)]

--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -45,11 +45,12 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -35,12 +35,14 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::fs;
+
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::index::Indexed;
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use std::fs;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -29,13 +29,14 @@ Common options:
     -h, --help             Display this message
 "#;
 
-use crate::config::Config;
-use crate::util;
-use crate::CliResult;
 use qsv_sniffer::{DatePreference, SampleSize, Sniffer};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use thousands::Separable;
+
+use crate::config::Config;
+use crate::util;
+use crate::CliResult;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -33,15 +33,17 @@ Common options:
                            to keep only one line per sorted value.
 ";
 
+use std::cmp;
+
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rayon::prelude::*;
+use serde::Deserialize;
+
 use self::Number::{Float, Int};
 use crate::config::{Config, Delimiter};
 use crate::select::SelectColumns;
 use crate::util;
 use crate::CliResult;
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
-use rayon::prelude::*;
-use serde::Deserialize;
-use std::cmp;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -47,6 +47,13 @@ Common options:
     -p, --progressbar       Show progress bars. Not valid for stdin.
 "#;
 
+use std::cmp;
+
+use csv::ByteRecord;
+#[cfg(any(feature = "full", feature = "lite"))]
+use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
+use serde::{Deserialize, Serialize};
+
 use crate::cmd::dedup;
 use crate::cmd::sort::iter_cmp;
 use crate::config::{Config, Delimiter};
@@ -54,11 +61,6 @@ use crate::select::SelectColumns;
 use crate::util;
 use crate::CliError;
 use crate::CliResult;
-use csv::ByteRecord;
-#[cfg(any(feature = "full", feature = "lite"))]
-use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
-use serde::{Deserialize, Serialize};
-use std::cmp;
 
 #[allow(dead_code)]
 #[derive(Deserialize)]

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -35,15 +35,17 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use serde::Deserialize;
+use threadpool::ThreadPool;
+
 use crate::config::{Config, Delimiter};
 use crate::index::Indexed;
 use crate::util::{self, FilenameTemplate};
 use crate::CliResult;
-use serde::Deserialize;
-use std::fs;
-use std::io;
-use std::path::Path;
-use threadpool::ThreadPool;
 
 #[derive(Clone, Deserialize)]
 struct Args {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -80,21 +80,23 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
+use std::str::{self, FromStr};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{borrow::ToOwned, default::Default, fmt, fs, io, iter::repeat};
+
+use itertools::Itertools;
+use once_cell::sync::OnceCell;
+use qsv_dateparser::parse_with_preference;
+use serde::Deserialize;
+use stats::{merge_all, Commute, MinMax, OnlineStats, Unsorted};
+use threadpool::ThreadPool;
+
 use self::FieldType::{TDate, TDateTime, TFloat, TInteger, TNull, TString};
 use crate::config::{Config, Delimiter};
 use crate::index::Indexed;
 use crate::select::{SelectColumns, Selection};
 use crate::util;
 use crate::CliResult;
-use itertools::Itertools;
-use once_cell::sync::OnceCell;
-use qsv_dateparser::parse_with_preference;
-use serde::Deserialize;
-use stats::{merge_all, Commute, MinMax, OnlineStats, Unsorted};
-use std::str::{self, FromStr};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::{borrow::ToOwned, default::Default, fmt, fs, io, iter::repeat};
-use threadpool::ThreadPool;
 
 #[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Clone, Deserialize)]

--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -31,13 +31,15 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::borrow::Cow;
+use std::convert::From;
+
+use serde::Deserialize;
+use tabwriter::{Alignment, TabWriter};
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use std::borrow::Cow;
-use std::convert::From;
-use tabwriter::{Alignment, TabWriter};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -17,15 +17,17 @@ Common options:
     -o, --output <file>    Write output to <file> instead of stdout.
 ";
 
+use std::env::temp_dir;
+use std::{fs::File, path::Path};
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
 use super::schema::infer_schema_from_stats;
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use serde::Deserialize;
-use serde_json::{Map, Value};
-use std::env::temp_dir;
-use std::{fs::File, path::Path};
-use uuid::Uuid;
 
 #[derive(Deserialize, Clone)]
 struct Args {

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -23,12 +23,14 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+use std::str;
+
+use csv::ByteRecord;
+use serde::Deserialize;
+
 use crate::config::{Config, Delimiter};
 use crate::util;
 use crate::CliResult;
-use csv::ByteRecord;
-use serde::Deserialize;
-use std::str;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -37,10 +37,8 @@ Common options:
     -p, --progressbar          Show progress bars. Not valid for stdin.
 ";
 
-use crate::config::{Config, Delimiter, DEFAULT_WTR_BUFFER_CAPACITY};
-use crate::util;
-use crate::CliError;
-use crate::CliResult;
+use std::{env, fs::File, io::BufReader, io::BufWriter, io::Read, io::Write, str};
+
 use csv::ByteRecord;
 #[cfg(any(feature = "full", feature = "lite"))]
 use indicatif::{ProgressBar, ProgressDrawTarget};
@@ -53,8 +51,12 @@ use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, value::Number, Map, Value};
-use std::{env, fs::File, io::BufReader, io::BufWriter, io::Read, io::Write, str};
 use thousands::Separable;
+
+use crate::config::{Config, Delimiter, DEFAULT_WTR_BUFFER_CAPACITY};
+use crate::util;
+use crate::CliError;
+use crate::CliResult;
 
 // number of CSV rows to process in a batch
 const BATCH_SIZE: usize = 24_000;
@@ -609,8 +611,9 @@ fn to_json_instance(
 #[cfg(test)]
 mod tests_for_csv_to_json_conversion {
 
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     /// get schema used for unit tests
     fn schema_json() -> Value {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,10 +35,12 @@
 )]
 
 extern crate crossbeam_channel as channel;
-use crate::clitypes::{CliError, CliResult, QsvExitCode};
+use std::{env, io, time::Instant};
+
 use docopt::Docopt;
 use serde::Deserialize;
-use std::{env, io, time::Instant};
+
+use crate::clitypes::{CliError, CliResult, QsvExitCode};
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -1,8 +1,10 @@
 extern crate crossbeam_channel as channel;
-use crate::clitypes::{CliError, CliResult, QsvExitCode};
+use std::{env, io, time::Instant};
+
 use docopt::Docopt;
 use serde::Deserialize;
-use std::{env, io, time::Instant};
+
+use crate::clitypes::{CliError, CliResult, QsvExitCode};
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -1,8 +1,10 @@
 extern crate crossbeam_channel as channel;
-use crate::clitypes::{CliError, CliResult, QsvExitCode};
+use std::{env, io, time::Instant};
+
 use docopt::Docopt;
 use serde::Deserialize;
-use std::{env, io, time::Instant};
+
+use crate::clitypes::{CliError, CliResult, QsvExitCode};
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,8 @@
-use crate::config::{Config, Delimiter};
-use crate::CliResult;
+#[cfg(any(feature = "full", feature = "lite"))]
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+use std::{env, fs, io, str, thread};
+
 use docopt::Docopt;
 #[cfg(any(feature = "full", feature = "lite"))]
 use indicatif::{HumanCount, ProgressBar, ProgressStyle};
@@ -8,10 +11,9 @@ use regex::Regex;
 use serde::de::DeserializeOwned;
 #[cfg(any(feature = "full", feature = "lite"))]
 use serde::de::{Deserialize, Deserializer, Error};
-#[cfg(any(feature = "full", feature = "lite"))]
-use std::borrow::Cow;
-use std::path::{Path, PathBuf};
-use std::{env, fs, io, str, thread};
+
+use crate::config::{Config, Delimiter};
+use crate::CliResult;
 
 #[macro_export]
 macro_rules! regex_once_cell {

--- a/tests/test_extsort.rs
+++ b/tests/test_extsort.rs
@@ -1,5 +1,6 @@
-use crate::workdir::Workdir;
 use newline_converter::dos2unix;
+
+use crate::workdir::Workdir;
 
 #[test]
 fn extsort() {

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -1,5 +1,6 @@
-use crate::workdir::Workdir;
 use serial_test::serial;
+
+use crate::workdir::Workdir;
 
 #[test]
 fn fetch_simple() {
@@ -345,7 +346,6 @@ use std::{sync::mpsc, thread};
 use actix_web::{
     dev::ServerHandle, middleware, rt, web, App, HttpRequest, HttpServer, Responder, Result,
 };
-
 use serde::Serialize;
 #[derive(Serialize)]
 struct MyObj {

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -1,13 +1,13 @@
-use ahash::AHashMap;
 use std::borrow::ToOwned;
 use std::collections::hash_map::Entry;
 use std::process;
 
+use ahash::AHashMap;
+use serde::Deserialize;
 use stats::Frequencies;
 
 use crate::workdir::Workdir;
 use crate::{qcheck_sized, Csv, CsvData};
-use serde::Deserialize;
 
 fn setup(name: &str) -> (Workdir, process::Command) {
     let rows = vec![

--- a/tests/test_reverse.rs
+++ b/tests/test_reverse.rs
@@ -1,5 +1,4 @@
 use crate::workdir::Workdir;
-
 use crate::{qcheck, Csv, CsvData};
 
 fn prop_reverse(name: &str, rows: CsvData, headers: bool) -> bool {

--- a/tests/test_schema.rs
+++ b/tests/test_schema.rs
@@ -1,7 +1,9 @@
-use crate::workdir::Workdir;
+use std::path::Path;
+
 use assert_json_diff::assert_json_eq;
 use serde_json::Value;
-use std::path::Path;
+
+use crate::workdir::Workdir;
 
 #[test]
 fn generate_schema_with_defaults_and_validate_with_no_errors() {

--- a/tests/test_sort.rs
+++ b/tests/test_sort.rs
@@ -1,7 +1,6 @@
 use std::cmp;
 
 use crate::workdir::Workdir;
-
 use crate::{qcheck, Csv, CsvData};
 
 fn prop_sort(name: &str, rows: CsvData, headers: bool) -> bool {

--- a/tests/test_transpose.rs
+++ b/tests/test_transpose.rs
@@ -1,5 +1,4 @@
 use crate::workdir::Workdir;
-
 use crate::{qcheck, CsvData};
 
 fn prop_transpose(name: &str, rows: CsvData, streaming: bool) -> bool {

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -1,7 +1,8 @@
-use crate::Csv;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::{env, fmt, fs, fs::File, process, str::FromStr, sync::atomic, time::Duration};
+
+use crate::Csv;
 
 static QSV_INTEGRATION_TEST_DIR: &str = "xit";
 


### PR DESCRIPTION
imports are grouped using StdExternalCrate formatting strategy

https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#group_imports