### PR TITLE
Standardize ignore case option

### DIFF
--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -21,7 +21,7 @@ sort options:
                                Note that the outputs will remain at the full width
                                of the CSV.
                                See 'qsv select --help' for the format details.
-    -C, --no-case              Compare strings disregarding case 
+    -i, --ignore-case          Compare strings disregarding case.
     --sorted                   The input is already sorted. Do not load the CSV into
                                memory to sort it first. Meant to be used in tandem and
                                after an extsort.
@@ -61,7 +61,7 @@ use crate::{
 struct Args {
     arg_input:           Option<String>,
     flag_select:         SelectColumns,
-    flag_no_case:        bool,
+    flag_ignore_case:    bool,
     flag_sorted:         bool,
     flag_dupes_output:   Option<String>,
     flag_output:         Option<String>,
@@ -73,7 +73,7 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let no_case = args.flag_no_case;
+    let ignore_case = args.flag_ignore_case;
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
@@ -106,8 +106,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             };
             let a = sel.select(&record);
             let b = sel.select(&next_record);
-            let comparison = if no_case {
-                iter_cmp_no_case(a, b)
+            let comparison = if ignore_case {
+                iter_cmp_ignore_case(a, b)
             } else {
                 iter_cmp(a, b)
             };
@@ -143,8 +143,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         while current + 1 < all.len() {
             let a = sel.select(&all[current]);
             let b = sel.select(&all[current + 1]);
-            if no_case {
-                if iter_cmp_no_case(a, b) == cmp::Ordering::Equal {
+            if ignore_case {
+                if iter_cmp_ignore_case(a, b) == cmp::Ordering::Equal {
                     dupe_count += 1;
                     if dupes_output {
                         dupewtr.write_byte_record(&all[current])?;
@@ -180,7 +180,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
 /// Try comparing `a` and `b` ignoring the case
 #[inline]
-pub fn iter_cmp_no_case<'a, L, R>(mut a: L, mut b: R) -> cmp::Ordering
+pub fn iter_cmp_ignore_case<'a, L, R>(mut a: L, mut b: R) -> cmp::Ordering
 where
     L: Iterator<Item = &'a [u8]>,
     R: Iterator<Item = &'a [u8]>,

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -4,7 +4,7 @@ Removes a set of CSV data from another set based on the specified columns.
 Also can compute the intersection of two CSV sets with the -v flag.
 
 Matching is always done by ignoring leading and trailing whitespace. By default,
-matching is done case sensitively, but this can be disabled with the --no-case
+matching is done case sensitively, but this can be disabled with the --ignore-case
 flag.
 
 The columns arguments specify the columns to match for each input. Columns can
@@ -18,7 +18,7 @@ Usage:
     qsv exclude --help
 
 exclude options:
-    --no-case              When set, matching is done case insensitively.
+    -i, --ignore-case      When set, matching is done case insensitively.
     -v                     When set, matching rows will be the only ones included,
                            forming set intersection, instead of the ones discarded.
 
@@ -49,15 +49,15 @@ type ByteString = Vec<u8>;
 
 #[derive(Deserialize)]
 struct Args {
-    arg_columns1:    SelectColumns,
-    arg_input1:      String,
-    arg_columns2:    SelectColumns,
-    arg_input2:      String,
-    flag_v:          bool,
-    flag_output:     Option<String>,
-    flag_no_headers: bool,
-    flag_no_case:    bool,
-    flag_delimiter:  Option<Delimiter>,
+    arg_columns1:     SelectColumns,
+    arg_input1:       String,
+    arg_columns2:     SelectColumns,
+    arg_input2:       String,
+    flag_v:           bool,
+    flag_output:      Option<String>,
+    flag_no_headers:  bool,
+    flag_ignore_case: bool,
+    flag_delimiter:   Option<Delimiter>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -133,7 +133,7 @@ impl Args {
             rdr2,
             sel2,
             no_headers: rconf1.no_headers,
-            casei: self.flag_no_case,
+            casei: self.flag_ignore_case,
         })
     }
 

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -5,7 +5,7 @@ The default join operation is an 'inner' join. This corresponds to the
 intersection of rows on the keys specified.
 
 Joins are always done by ignoring leading and trailing whitespace. By default,
-joins are done case sensitively, but this can be disabled with the --no-case
+joins are done case sensitively, but this can be disabled with the --ignore-case
 flag.
 
 The columns arguments specify the columns to join for each input. Columns can
@@ -23,7 +23,7 @@ input parameters:
     e.g. 'qsv frequency -s Agency nyc311.csv | qsv join value - id nycagencyinfo.csv'
 
 join options:
-    --no-case              When set, joins are done case insensitively.
+    -i, --ignore-case      When set, joins are done case insensitively.
     --left                 Do a 'left outer' join. This returns all rows in
                            first CSV data set, including rows with no
                            corresponding row in the second data set. When no
@@ -82,21 +82,21 @@ type ByteString = Vec<u8>;
 
 #[derive(Deserialize)]
 struct Args {
-    arg_columns1:    SelectColumns,
-    arg_input1:      String,
-    arg_columns2:    SelectColumns,
-    arg_input2:      String,
-    flag_left:       bool,
-    flag_left_anti:  bool,
-    flag_left_semi:  bool,
-    flag_right:      bool,
-    flag_full:       bool,
-    flag_cross:      bool,
-    flag_output:     Option<String>,
-    flag_no_headers: bool,
-    flag_no_case:    bool,
-    flag_nulls:      bool,
-    flag_delimiter:  Option<Delimiter>,
+    arg_columns1:     SelectColumns,
+    arg_input1:       String,
+    arg_columns2:     SelectColumns,
+    arg_input2:       String,
+    flag_left:        bool,
+    flag_left_anti:   bool,
+    flag_left_semi:   bool,
+    flag_right:       bool,
+    flag_full:        bool,
+    flag_cross:       bool,
+    flag_output:      Option<String>,
+    flag_no_headers:  bool,
+    flag_ignore_case: bool,
+    flag_nulls:       bool,
+    flag_delimiter:   Option<Delimiter>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -346,7 +346,7 @@ impl Args {
             rdr2,
             sel2,
             no_headers: rconf1.no_headers,
-            casei: self.flag_no_case,
+            casei: self.flag_ignore_case,
             nulls: self.flag_nulls,
         })
     }

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -27,7 +27,7 @@ Usage:
 sort options:
     -s, --select <arg>      Select a subset of columns to check for sort.
                             See 'qsv select --help' for the format details.
-    -C, --no-case           Compare strings disregarding case
+    -i, --ignore-case       Compare strings disregarding case
     --all                   Check all records. Do not stop the check on the
                             first unsorted record.
     --json                  Return results in JSON format, scanning --all records. 
@@ -66,7 +66,7 @@ use crate::{
 struct Args {
     arg_input:        Option<String>,
     flag_select:      SelectColumns,
-    flag_no_case:     bool,
+    flag_ignore_case: bool,
     flag_all:         bool,
     flag_no_headers:  bool,
     flag_delimiter:   Option<Delimiter>,
@@ -85,7 +85,7 @@ struct SortCheckStruct {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let no_case = args.flag_no_case;
+    let ignore_case = args.flag_ignore_case;
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
@@ -142,8 +142,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         };
         let a = sel.select(&record);
         let b = sel.select(&next_record);
-        let comparison = if no_case {
-            dedup::iter_cmp_no_case(a, b)
+        let comparison = if ignore_case {
+            dedup::iter_cmp_ignore_case(a, b)
         } else {
             iter_cmp(a, b)
         };

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -42,7 +42,7 @@ fn dedup_no_case() {
     );
 
     let mut cmd = wrk.command("dedup");
-    cmd.arg("-C").arg("in.csv");
+    cmd.arg("-i").arg("in.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![svec!["N", "S"], svec!["10", "a"], svec!["2", "b"]];
@@ -126,7 +126,7 @@ fn dedup_sorted_nocase() {
     );
 
     let mut cmd = wrk.command("dedup");
-    cmd.arg("--sorted").arg("--no-case").arg("in.csv");
+    cmd.arg("--sorted").arg("--ignore-case").arg("in.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -162,7 +162,7 @@ fn dedup_alreadysorted_nocase() {
     );
 
     let mut cmd = wrk.command("dedup");
-    cmd.arg("--no-case").arg("in.csv");
+    cmd.arg("--ignore-case").arg("in.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![


### PR DESCRIPTION
some had --no-case, others --ignore-case.

Use --ignore-case consistently across commands