### PR TITLE
better `tojsonl` error handling; when checking stdin for utf8, make sure its not empty 

### DIFF
--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -68,7 +68,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let schema_args = crate::cmd::schema::Args {
         flag_enum_threshold:  3, // we only do three, as we're only inferring boolean based on enum
         flag_strict_dates:    false,
-        flag_pattern_columns: crate::select::SelectColumns::parse("").unwrap(),
+        flag_pattern_columns: crate::select::SelectColumns::parse("")?,
         flag_dates_whitelist: "none".to_string(), // json doesn't have a date type, so don't infer dates
         flag_prefer_dmy:      false,
         flag_stdout:          false,
@@ -105,7 +105,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // create a vec lookup about inferred field data types
     let mut field_type_vec: Vec<String> = Vec::with_capacity(headers.len());
     for (_field_name, field_def) in properties_map.iter() {
-        let field_map = field_def.as_object().unwrap();
+        let field_map = match field_def.as_object() {
+            Some(m) => m,
+            None => return fail!("Cannot create field map"),
+        };
         let prelim_type = field_map.get("type").unwrap();
         let field_values_enum = field_map.get("enum");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -322,16 +322,26 @@ impl Config {
                 if self.checkutf8 {
                     debug!("checking stdin encoding...");
                     // get first 8k of buffer
-                    let buffer_check = buffer
-                        .chunks_exact(std::cmp::min(DEFAULT_UTF8_CHECK_BUFFER_LEN, buffer.len()))
-                        .next()
-                        .unwrap();
-                    let s = std::str::from_utf8(buffer_check);
-                    if s.is_err() {
+                    if buffer.is_empty() {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            format!("<stdin> {UTF8_ERROR_MSG}"),
+                            "<stdin> is empty!".to_string(),
                         ));
+                    } else {
+                        let buffer_check = buffer
+                            .chunks_exact(std::cmp::min(
+                                DEFAULT_UTF8_CHECK_BUFFER_LEN,
+                                buffer.len(),
+                            ))
+                            .next()
+                            .unwrap();
+                        let s = std::str::from_utf8(buffer_check);
+                        if s.is_err() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("<stdin> {UTF8_ERROR_MSG}"),
+                            ));
+                        }
                     }
                 }
                 self.from_reader(Box::new(io::Cursor::new(buffer)))
@@ -447,19 +457,29 @@ impl Config {
                     let stdin_reader = io::stdin();
                     let mut buffer: Vec<u8> = Vec::new();
                     stdin_reader.lock().read_to_end(&mut buffer)?;
-                    // check if its utf8-encoded
-                    let buffer_check = buffer
-                        .chunks_exact(std::cmp::min(DEFAULT_UTF8_CHECK_BUFFER_LEN, buffer.len()))
-                        .next()
-                        .unwrap();
-                    let s = std::str::from_utf8(buffer_check);
-                    if s.is_err() {
+                    if buffer.is_empty() {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            format!("<stdin> {UTF8_ERROR_MSG}"),
+                            "<stdin> is empty!".to_string(),
                         ));
+                    } else {
+                        // check if its utf8-encoded
+                        let buffer_check = buffer
+                            .chunks_exact(std::cmp::min(
+                                DEFAULT_UTF8_CHECK_BUFFER_LEN,
+                                buffer.len(),
+                            ))
+                            .next()
+                            .unwrap();
+                        let s = std::str::from_utf8(buffer_check);
+                        if s.is_err() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("<stdin> {UTF8_ERROR_MSG}"),
+                            ));
+                        }
+                        Box::new(io::Cursor::new(buffer))
                     }
-                    Box::new(io::Cursor::new(buffer))
                 } else {
                     Box::new(io::stdin())
                 }


### PR DESCRIPTION
resolves #530 