### PR TITLE
Use fail macros more consistently

### DIFF
--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -39,13 +39,22 @@ macro_rules! fail {
     }};
 }
 
-macro_rules! fail_format {
+macro_rules! fail_clierror {
     ($($t:tt)*) => {{
         use log::error;
         use crate::CliError;
         let err = format!($($t)*);
         error!("{err}");
         Err(CliError::Other(err))
+    }};
+}
+
+macro_rules! fail_format {
+    ($($t:tt)*) => {{
+        use log::error;
+        let err = format!($($t)*);
+        error!("{err}");
+        Err(err)
     }};
 }
 

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -387,7 +387,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if args.cmd_operations {
         for op in &operations {
             if !OPERATIONS.contains(op) {
-                return fail_format!("Unknown '{op}' operation");
+                return fail_clierror!("Unknown '{op}' operation");
             }
             #[allow(clippy::useless_asref)]
             match op.as_ref() {
@@ -561,7 +561,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     }
                 }
                 Err(e) => {
-                    return fail_format!("Error reading file: {e}");
+                    return fail_clierror!("Error reading file: {e}");
                 }
             }
         }

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -123,7 +123,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     record.clone_from(&next_record);
                 }
                 cmp::Ordering::Greater => {
-                    return fail_format!(
+                    return fail_clierror!(
                         "Aborting! Input not sorted! {record:?} is greater than {next_record:?}"
                     );
                 }

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -101,7 +101,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         } else if copy_operation {
             let current_header = match String::from_utf8(headers[copy_index].to_vec()) {
                 Ok(s) => s,
-                Err(e) => return fail_format!("Could not parse cell as utf-8! - {e}"),
+                Err(e) => return fail_clierror!("Could not parse cell as utf-8! - {e}"),
             };
             headers.push_field(format!("{current_header}_copy").as_bytes());
         } else {

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -91,7 +91,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut workbook = match open_workbook_auto(path) {
         Ok(workbook) => workbook,
-        Err(e) => return fail_format!("Cannot open workbook: {e}."),
+        Err(e) => return fail_clierror!("Cannot open workbook: {e}."),
     };
 
     let sheet_names = workbook.sheet_names();
@@ -125,7 +125,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     if let Ok(result) = result {
                         result
                     } else {
-                        return fail_format!("Cannot retrieve range from {}", sheet_name);
+                        return fail_clierror!("Cannot retrieve range from {}", sheet_name);
                     }
                 }
                 None => Range::empty(),
@@ -172,7 +172,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 if sheet_index as usize <= sheet_names.len() {
                     sheet_names[sheet_index as usize].to_string()
                 } else {
-                    return fail_format!(
+                    return fail_clierror!(
                         "sheet index {sheet_index} is greater than number of sheets {}",
                         sheet_names.len()
                     );
@@ -206,7 +206,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         sheet = sheet_names[idx].clone();
         idx
     } else {
-        return fail_format!("Cannot get sheet index for {sheet}");
+        return fail_clierror!("Cannot get sheet index for {sheet}");
     };
 
     let range = match workbook.worksheet_range_at(sheet_index) {
@@ -214,7 +214,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             if let Ok(result) = result {
                 result
             } else {
-                return fail_format!("Cannot retrieve range from {sheet}");
+                return fail_clierror!("Cannot retrieve range from {sheet}");
             }
         }
         None => Range::empty(),

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -150,7 +150,7 @@ impl Args {
         let select1 = rconf1.selection(headers1)?;
         let select2 = rconf2.selection(headers2)?;
         if select1.len() != select2.len() {
-            return fail_format!(
+            return fail_clierror!(
                 "Column selections must have the same number of columns, \
                  but found column selections with {} and {} columns.",
                 select1.len(),

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -65,12 +65,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut input_reader = io::BufReader::new(match fs::File::open(&args.arg_input) {
         Ok(f) => f,
-        Err(e) => return fail_format!("Cannot read input file {e}"),
+        Err(e) => return fail_clierror!("Cannot read input file {e}"),
     });
 
     let mut output_writer = io::BufWriter::new(match fs::File::create(&args.arg_output) {
         Ok(f) => f,
-        Err(e) => return fail_format!("Cannot create output file: {e}"),
+        Err(e) => return fail_clierror!("Cannot create output file: {e}"),
     });
 
     let sorter: ExternalSorter<String, io::Error, MemoryLimitedBufferBuilder> =
@@ -83,7 +83,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         {
             Ok(sorter) => sorter,
             Err(e) => {
-                return fail_format!("cannot create external sorter: {e}");
+                return fail_clierror!("cannot create external sorter: {e}");
             }
         };
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -295,7 +295,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let mut redis_conn;
         match redis_client.get_connection() {
-            Err(e) => return fail_clierror!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
+            Err(e) => {
+                return fail_clierror!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#)
+            }
             Ok(x) => redis_conn = x,
         }
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -295,7 +295,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let mut redis_conn;
         match redis_client.get_connection() {
-            Err(e) => return fail_format!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
+            Err(e) => return fail_clierror!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
             Ok(x) => redis_conn = x,
         }
 
@@ -392,7 +392,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             let vals: Vec<&str> = header.split(':').collect();
 
             if vals.len() != 2 {
-                return fail_format!("{vals:?} is not a valid key-value pair. Expecting a key and a value separated by a colon.");
+                return fail_clierror!("{vals:?} is not a valid key-value pair. Expecting a key and a value separated by a colon.");
             }
 
             // allocate new String for header key to put into map
@@ -622,7 +622,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }
             final_response = match serde_json::from_str(&intermediate_redis_value) {
                 Ok(r) => r,
-                Err(e)=> return fail_format!("Cannot deserialize Redis cache value. Try flushing the Redis cache with --flushdb - {e}"),
+                Err(e)=> return fail_clierror!("Cannot deserialize Redis cache value. Try flushing the Redis cache with --flushdb - {e}"),
             };
             if !args.flag_cache_error && final_response.status_code != 200 {
                 let key = format!(
@@ -1144,7 +1144,7 @@ use serde_json::{Deserializer, Value};
 pub fn apply_jql(json: &str, groups: &[jql::Group]) -> Result<String, String> {
     // check if api returned valid JSON before applying JQL selector
     if let Err(error) = serde_json::from_str::<Value>(json) {
-        return Err(format!("Invalid json: {error:?}"));
+        return fail_format!("Invalid json: {error:?}");
     }
 
     let mut result: Result<String, _> = Ok(String::default());

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -270,7 +270,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let mut redis_conn;
         match redis_client.get_connection() {
-            Err(e) => return fail_clierror!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
+            Err(e) => {
+                return fail_clierror!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#)
+            }
             Ok(x) => redis_conn = x,
         }
 

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -270,7 +270,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let mut redis_conn;
         match redis_client.get_connection() {
-            Err(e) => return fail_format!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
+            Err(e) => return fail_clierror!(r#"Cannot connect to Redis using "{conn_str}": {e:?}"#),
             Ok(x) => redis_conn = x,
         }
 
@@ -359,7 +359,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             let vals: Vec<&str> = header.split(':').collect();
 
             if vals.len() != 2 {
-                return fail_format!("{vals:?} is not a valid key-value pair. Expecting a key and a value separated by a colon.");
+                return fail_clierror!("{vals:?} is not a valid key-value pair. Expecting a key and a value separated by a colon.");
             }
 
             // allocate new String for header key to put into map
@@ -591,7 +591,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }
             final_response = match serde_json::from_str(&intermediate_redis_value) {
                 Ok(r) => r,
-                Err(e)=> return fail_format!("Cannot deserialize Redis cache value. Try flushing the Redis cache with --flushdb - {e}"),
+                Err(e)=> return fail_clierror!("Cannot deserialize Redis cache value. Try flushing the Redis cache with --flushdb - {e}"),
             };
             if !args.flag_cache_error && final_response.status_code != 200 {
                 let key = format!(

--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -100,7 +100,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if let Some(skip_llines) = args.flag_skip_lastlines {
         let row_count = util::count_rows(&rconfig)?;
         if skip_llines > row_count {
-            return fail_format!(
+            return fail_clierror!(
                 "--skip-lastlines: {skip_llines} is greater than row_count: {row_count}."
             );
         }

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -364,7 +364,7 @@ impl Args {
         let select1 = rconf1.selection(headers1)?;
         let select2 = rconf2.selection(headers2)?;
         if select1.len() != select2.len() {
-            return fail_format!(
+            return fail_clierror!(
                 "Column selections must have the same number of columns, \
                  but found column selections with {} and {} columns.",
                 select1.len(),

--- a/src/cmd/jsonl.rs
+++ b/src/cmd/jsonl.rs
@@ -147,7 +147,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     continue;
                 }
                 let human_idx = rowidx + 1; // not zero based, for readability
-                return fail_format!(
+                return fail_clierror!(
                     r#"Could not parse line {human_idx} as JSON! - {e}
 Use `--ignore-errors` option to skip malformed input lines.
 Use `tojsonl` command to convert _to_ jsonl instead of _from_ jsonl."#,

--- a/src/cmd/lua.rs
+++ b/src/cmd/lua.rs
@@ -139,7 +139,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let lua_script = if args.flag_script_file {
         match fs::read_to_string(&args.arg_script) {
             Ok(script_file) => script_file,
-            Err(e) => return fail_format!("Cannot load Lua file: {e}"),
+            Err(e) => return fail_clierror!("Cannot load Lua file: {e}"),
         }
     } else {
         args.arg_script
@@ -227,7 +227,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     record.push_field("");
                 }
                 _ => {
-                    return fail_format!("Unexpected value type returned by provided Lua expression. {computed_value:?}");
+                    return fail_clierror!("Unexpected value type returned by provided Lua expression. {computed_value:?}");
                 }
             }
 

--- a/src/cmd/luajit.rs
+++ b/src/cmd/luajit.rs
@@ -142,7 +142,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let lua_script = if args.flag_script_file {
         match fs::read_to_string(&args.arg_script) {
             Ok(script_file) => script_file,
-            Err(e) => return fail_format!("Cannot load LuaJIT file: {e}"),
+            Err(e) => return fail_clierror!("Cannot load LuaJIT file: {e}"),
         }
     } else {
         args.arg_script
@@ -230,7 +230,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     record.push_field("");
                 }
                 _ => {
-                    return fail_format!("Unexpected value type returned by provided LuaJIT expression. {computed_value:?}");
+                    return fail_clierror!("Unexpected value type returned by provided LuaJIT expression. {computed_value:?}");
                 }
             }
 

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -188,7 +188,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if let Some(helper_file) = args.flag_helper {
         helper_text = match fs::read_to_string(helper_file) {
             Ok(helper_file) => helper_file,
-            Err(e) => return fail_format!("Cannot load python file: {e}"),
+            Err(e) => return fail_clierror!("Cannot load python file: {e}"),
         }
     }
 
@@ -250,7 +250,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     }
                 }
                 Err(e) => {
-                    return fail_format!("Error reading file: {e}");
+                    return fail_clierror!("Error reading file: {e}");
                 }
             }
         }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -54,7 +54,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let new_headers = new_rdr.byte_headers()?;
 
     if headers.len() != new_headers.len() {
-        return fail_format!(
+        return fail_clierror!(
             "The length of the CSV headers ({}) is different from the provided one ({}).",
             headers.len(),
             new_headers.len()

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -112,7 +112,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         match infer_schema_from_stats(&args, &input_filename) {
             Ok(map) => map,
             Err(e) => {
-                return fail_format!("Failed to infer schema via stats and frequency: {e}");
+                return fail_clierror!("Failed to infer schema via stats and frequency: {e}");
             }
         };
 
@@ -144,7 +144,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let schema_pretty = match serde_json::to_string_pretty(&schema) {
         Ok(s) => s,
-        Err(e) => return fail_format!("Cannot prettify schema json - {e}"),
+        Err(e) => return fail_clierror!("Cannot prettify schema json - {e}"),
     };
 
     if args.flag_stdout {
@@ -514,7 +514,7 @@ fn convert_to_string(byte_slice: &[u8]) -> CliResult<String> {
         Ok(s) => s.to_string(),
         Err(e) => {
             let lossy_string = String::from_utf8_lossy(byte_slice);
-            return fail_format!("Can't convert byte slice to utf8 string. slice={byte_slice:?}, error={e}: {lossy_string}");
+            return fail_clierror!("Can't convert byte slice to utf8 string. slice={byte_slice:?}, error={e}: {lossy_string}");
         }
     };
 

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -160,7 +160,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         "detail": e.to_string()
                     }]
                 });
-                return fail_format!("{json_result}");
+                return fail_clierror!("{json_result}");
             }
         }
     } else {
@@ -182,7 +182,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 println!("{disp}");
             }
             Err(e) => {
-                return fail_format!("sniff error: {e}");
+                return fail_clierror!("sniff error: {e}");
             }
         }
     }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -366,9 +366,9 @@ fn init_date_inference(
             match INFER_DATE_FLAGS.set(vec![true; headers.len()]) {
                 Ok(_) => (),
                 Err(e) => {
-                    return Err(format!(
+                    return fail_format!(
                         "Cannot init date inference flags for ALL fields - {e:?}"
-                    ))
+                    )
                 }
             };
         } else {
@@ -394,13 +394,13 @@ fn init_date_inference(
             }
             match INFER_DATE_FLAGS.set(infer_date_flags) {
                 Ok(_) => (),
-                Err(e) => return Err(format!("Cannot init date inference flags - {e:?}")),
+                Err(e) => return fail_format!("Cannot init date inference flags - {e:?}"),
             };
         }
     } else {
         match INFER_DATE_FLAGS.set(vec![false; headers.len()]) {
             Ok(_) => (),
-            Err(e) => return Err(format!("Cannot init empty date inference flags - {e:?}")),
+            Err(e) => return fail_format!("Cannot init empty date inference flags - {e:?}"),
         };
     }
     Ok(())

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -366,9 +366,7 @@ fn init_date_inference(
             match INFER_DATE_FLAGS.set(vec![true; headers.len()]) {
                 Ok(_) => (),
                 Err(e) => {
-                    return fail_format!(
-                        "Cannot init date inference flags for ALL fields - {e:?}"
-                    )
+                    return fail_format!("Cannot init date inference flags for ALL fields - {e:?}")
                 }
             };
         } else {
@@ -641,7 +639,10 @@ impl Stats {
                 // calculate skewness using Quantile-based measures
                 // https://en.wikipedia.org/wiki/Skewness#Quantile-based_measures
                 // skewness = (q3 - (2.0 * q2) + q1) / iqr
-                pieces.push(round_num((2.0f64.mul_add(-q2, q3) + q1) / iqr, round_places));
+                pieces.push(round_num(
+                    (2.0f64.mul_add(-q2, q3) + q1) / iqr,
+                    round_places,
+                ));
             }
         }
         match self.modes.as_mut() {

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -82,7 +82,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         match infer_schema_from_stats(&schema_args, &input_filename) {
             Ok(map) => map,
             Err(e) => {
-                return fail_format!("Failed to infer field types via stats and frequency: {e}");
+                return fail_clierror!("Failed to infer field types via stats and frequency: {e}");
             }
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,9 +44,7 @@ impl Delimiter {
         }
 
         if s.len() != 1 {
-            return fail_format!(
-                "Could not convert '{s}' to a single ASCII character."
-            );
+            return fail_format!("Could not convert '{s}' to a single ASCII character.");
         }
 
         let c = s.chars().next().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,16 +44,16 @@ impl Delimiter {
         }
 
         if s.len() != 1 {
-            return Err(format!(
+            return fail_format!(
                 "Could not convert '{s}' to a single ASCII character."
-            ));
+            );
         }
 
         let c = s.chars().next().unwrap();
         if c.is_ascii() {
             Ok(Delimiter(c as u8))
         } else {
-            Err(format!("Could not convert '{c}' to ASCII delimiter."))
+            fail_format!("Could not convert '{c}' to ASCII delimiter.")
         }
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -103,10 +103,7 @@ impl SelectorParser {
     fn parse(&mut self) -> Result<Vec<Selector>, String> {
         if (self.chars.first(), self.chars.last()) == (Some(&'/'), Some(&'/')) {
             if self.chars.len() == 2 {
-                return fail_format!(
-                    "Empty regex: {}",
-                    self.chars.iter().collect::<String>()
-                );
+                return fail_format!("Empty regex: {}", self.chars.iter().collect::<String>());
             }
             let re: String = self.chars[1..(self.chars.len() - 1)].iter().collect();
             let regex = match Regex::new(&re) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -278,7 +278,7 @@ pub fn many_configs(
 pub fn errif_greater_one_stdin(inps: &[Config]) -> Result<(), String> {
     let nstd = inps.iter().filter(|inp| inp.is_stdin()).count();
     if nstd > 1 {
-        return Err("At most one <stdin> input is allowed.".to_owned());
+        return fail!("At most one <stdin> input is allowed.");
     }
     Ok(())
 }
@@ -353,16 +353,16 @@ pub fn range(start: Idx, end: Idx, len: Idx, index: Idx) -> Result<(usize, usize
         (None, None, None, Some(i)) => Ok((i, i + 1)),
         (_, _, _, Some(_)) => Err("--index cannot be used with --start, --end or --len".to_owned()),
         (_, Some(_), Some(_), None) => {
-            Err("--end and --len cannot be used at the same time.".to_owned())
+            fail!("--end and --len cannot be used at the same time.")
         }
         (_, None, None, None) => Ok((start.unwrap_or(0), ::std::usize::MAX)),
         (_, Some(e), None, None) => {
             let s = start.unwrap_or(0);
             if s > e {
-                Err(format!(
+                fail_format!(
                     "The end of the range ({e}) must be greater than or\n\
                              equal to the start of the range ({s})."
-                ))
+                )
             } else {
                 Ok((s, e))
             }
@@ -498,9 +498,9 @@ pub fn qsv_check_for_update() -> Result<bool, String> {
     let bin_name = match std::env::current_exe() {
         Ok(pb) => match pb.file_stem() {
             Some(fs) => fs.to_string_lossy().into_owned(),
-            None => return Err("Can't get the exec stem name".to_string()),
+            None => return fail!("Can't get the exec stem name"),
         },
-        Err(e) => return Err(format!("Can't get the exec path - {e}")),
+        Err(e) => return fail_format!("Can't get the exec path - {e}"),
     };
 
     winfo!("Checking GitHub for updates...");
@@ -519,10 +519,10 @@ pub fn qsv_check_for_update() -> Result<bool, String> {
         if let Ok(releases) = releases_list.fetch() {
             releases
         } else {
-            return Err(GITHUB_RATELIMIT_MSG.to_string());
+            return fail!(GITHUB_RATELIMIT_MSG);
         }
     } else {
-        return Err(GITHUB_RATELIMIT_MSG.to_string());
+        return fail!(GITHUB_RATELIMIT_MSG);
     };
     let latest_release = &releases[0].version;
 
@@ -653,7 +653,7 @@ fn send_hwsurvey(
             .build()
         {
             Ok(c) => c,
-            Err(e) => return Err(format!("Cannot build hw_survey reqwest client - {e}")),
+            Err(e) => return fail_format!("Cannot build hw_survey reqwest client - {e}"),
         };
 
         match client
@@ -773,7 +773,7 @@ impl ColumnNameParser {
         loop {
             match self.cur() {
                 None => {
-                    return Err("Unclose quote, missing \".".to_owned());
+                    return fail!("Unclosed quote, missing \".");
                 }
                 Some('"') => {
                     self.bump();


### PR DESCRIPTION
instead of just returning Err, use fail macros when possible:
* they log the error when logging is enabled
* no need to call `format!`
* no need to convert literal `to_string`/`to_owned`