### PR TITLE
`tojsonl`: escape newlines and double quotes

### DIFF
--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -17,7 +17,7 @@ Common options:
     -o, --output <file>    Write output to <file> instead of stdout.
 ";
 
-use std::{env::temp_dir, fs::File, path::Path};
+use std::{borrow::Cow, env::temp_dir, fs::File, path::Path};
 
 use serde::Deserialize;
 use serde_json::{Map, Value};
@@ -155,7 +155,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let _ = write!(temp_str, "{{");
         for (idx, field) in record.iter().enumerate() {
             let field_val = match field_type_vec[idx].as_str() {
-                "string" => format!(r#""{field}""#),
+                "string" => format!(r#""{}""#, jsonl_escape(field)),
                 "number" => field.to_string(),
                 "boolean" => match field.to_lowercase().as_str() {
                     "true" | "yes" | "1" => "true".to_string(),
@@ -174,4 +174,34 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     Ok(wtr.flush()?)
+}
+
+fn jsonl_escape(input: &str) -> Cow<str> {
+    for (i, ch) in input.chars().enumerate() {
+        if escape_char(ch).is_some() {
+            let mut escaped_string = String::with_capacity(input.len());
+            escaped_string.push_str(&input[..i]);
+
+            for ch in input[i..].chars() {
+                match escape_char(ch) {
+                    Some(escaped_char) => escaped_string.push_str(escaped_char),
+                    None => escaped_string.push(ch),
+                };
+            }
+
+            return Cow::Owned(escaped_string);
+        }
+    }
+
+    Cow::Borrowed(input)
+}
+
+#[inline]
+fn escape_char(ch: char) -> Option<&'static str> {
+    match ch {
+        '\n' => Some(r#"\n"#),
+        '\r' => Some(r#"\r"#),
+        '"' => Some(r#"\""#),
+        _ => None,
+    }
 }

--- a/tests/test_tojsonl.rs
+++ b/tests/test_tojsonl.rs
@@ -33,6 +33,12 @@ fn tojsonl_nested() {
             svec!["1", "Mark", "Charlotte", "\"Tom\""],
             svec!["2", "John", "Ann", "\"Jessika\",\"Antony\",\"Jack\""],
             svec!["3", "Bob", "Monika", "\"Jerry\",\"Karol\""],
+            svec![
+                "4",
+                "John\nSmith",
+                "Jane \"Smiley\" Doe",
+                "\"Jack\",\"Jill\r\n \"Climber\""
+            ],
         ],
     );
 
@@ -40,9 +46,10 @@ fn tojsonl_nested() {
     cmd.arg("in.csv");
 
     let got: String = wrk.stdout(&mut cmd);
-    let expected = r#"{"id":1,"father":"Mark","mother":"Charlotte","children":""Tom""}
-{"id":2,"father":"John","mother":"Ann","children":""Jessika","Antony","Jack""}
-{"id":3,"father":"Bob","mother":"Monika","children":""Jerry","Karol""}"#;
+    let expected = r#"{"id":1,"father":"Mark","mother":"Charlotte","children":"\"Tom\""}
+{"id":2,"father":"John","mother":"Ann","children":"\"Jessika\",\"Antony\",\"Jack\""}
+{"id":3,"father":"Bob","mother":"Monika","children":"\"Jerry\",\"Karol\""}
+{"id":4,"father":"John\nSmith","mother":"Jane \"Smiley\" Doe","children":"\"Jack\",\"Jill\r\n \"Climber\""}"#;
 
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
also escapes carriage return ("\r")
fixes #552