### PR TITLE
`safenames`: add --verify mode

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -743,7 +743,7 @@ pub fn safe_header_names(
 }
 
 #[inline]
-fn is_safe_name(header_name: &str) -> bool {
+pub fn is_safe_name(header_name: &str) -> bool {
     if header_name.is_empty() || header_name.len() > 60 {
         return false;
     }

--- a/tests/test_safenames.rs
+++ b/tests/test_safenames.rs
@@ -101,6 +101,38 @@ fn safenames_always() {
 }
 
 #[test]
+fn safenames_verify() {
+    let wrk = Workdir::new("safenames");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec![
+                "col1",
+                " This is a column with invalid chars!# and leading & trailing spaces ",
+                "",
+                "this is already a postgres safe column",
+                "1starts with 1",
+                "col1",
+                "col1",
+                "",
+                "",
+            ],
+            svec!["1", "b", "33", "1", "b", "33", "34", "z", "42"],
+            svec!["2", "c", "34", "3", "d", "31", "3", "y", "3.14"],
+        ],
+    );
+
+    let mut cmd = wrk.command("safenames");
+    cmd.arg("--mode").arg("verify").arg("in.csv");
+
+    let changed_headers = wrk.output_stderr(&mut cmd);
+    let expected_count = "7\n";
+    assert_eq!(changed_headers, expected_count);
+
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
 fn safenames_ignore_invalid_mode() {
     let wrk = Workdir::new("safenames");
     wrk.create(
@@ -122,24 +154,6 @@ fn safenames_ignore_invalid_mode() {
 
     let mut cmd = wrk.command("safenames");
     cmd.arg("--mode").arg("invalidmode").arg("in.csv");
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-
-    // if the mode is invalid, its a noop and we do not modify the header names
-    let expected = vec![
-        svec![
-            "col1",
-            " This is a column with invalid chars!# and leading & trailing spaces ",
-            "",
-            "this is already a postgres safe column",
-            "1starts with 1",
-            "col1",
-            "col1"
-        ],
-        svec!["1", "b", "33", "1", "b", "33", "34"],
-        svec!["2", "c", "34", "3", "d", "31", "3"],
-    ];
-    assert_eq!(got, expected);
 
     wrk.assert_err(&mut cmd);
 }


### PR DESCRIPTION
also refactored command while at it.

Invalid mode just results in an error and no output is produced.