### PR TITLE
`safenames`: optimize & refactor algorithm

### DIFF
--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -1,17 +1,41 @@
 static USAGE: &str = r#"
-Modify headers of a CSV to only have "safe" names - guaranteed "database-ready" names. 
+Modify headers of a CSV to only have "safe" names - guaranteed "database-ready" names
+(optimized specifically for PostgreSQL column identifiers). 
 
-Trim leading & trailing whitespaces. Replace whitespace/non-alphanumeric characters with _.
-If a column with the same name already exists, append a sequence suffix (e.g. col1, col1_2, col1_3).
-If the first character is a digit, replace the digit with _.
-Names are limited to 60 characters in length.
-Empty names are replaced with _ as well.
+Fold to lowercase. Trim leading & trailing whitespaces. Replace whitespace/non-alphanumeric
+characters with _. If the first character is a digit, replace the digit with _.
+If a header with the same name already exists, append a sequence suffix (e.g. c1, c1_2, c1_3).
+Names are limited to 60 characters in length. Empty names are replaced with _.
 
 In Always and Conditional mode, returns number of modified headers to stderr.
 In Verify Mode, returns number of unsafe headers to stderr.
+In Verbose Mode, returns number of headers; unsafe & safe headers; and duplicate count to stderr.
 
-  Change the name of the columns:
+Given data.csv:
+ c1,12_col,Col with Embedded Spaces,,Column!@Invalid+Chars,c1
+ 1,a2,a3,a4,a5,a6
+
   $ qsv safenames data.csv
+  c1,_2_col,col_with_embedded_spaces,_,column__invalid_chars,c1_2
+  1,a2,a3,a4,a5,a6
+  stderr: 5
+
+  Conditionally rename headers, allowing "quoted identifiers":
+  $ qsv safenames --mode c data.csv
+  c1,_2_col,Col with Embedded Spaces,_,column__invalid_chars,c1_2
+  1,a2,a3,a4,a5,a6
+  stderr: 4
+
+  Verify how many "unsafe" headers are found:
+  $ qsv safenames --mode v data.csv
+  stderr: 5
+
+  Verbose mode:
+  $ qsv safenames --mode V safenames.csv
+  stderr: 6 header/s
+  5 unsafe header/s: ["c1", "12_col", "Col with Embedded Spaces", "", "Column!@Invalid+Chars"]
+  2 safe header/s: ["c1", "Col with Embedded Spaces"]
+  1 duplicate/s found.
 
 For more examples, see https://github.com/jqnatividad/qsv/blob/master/tests/test_safenames.rs.
 
@@ -20,18 +44,23 @@ Usage:
     qsv safenames --help
 
 safenames options:
-    --mode <a|c|v>         Rename header names to "safe" names - i.e.
+    --mode <c|a|v|V>       Rename header names to "safe" names - i.e.
                            guaranteed "database-ready" names.
-                           It has three modes - Always, Conditional & Verify.
-                           Always - goes ahead and renames all headers
+                           It has four modes - conditional, always, verify & Verbose.
+                           conditional (c) - check first before renaming and allow
+                           "quoted identifiers" - mixed case with embedded spaces.
+                           always (a) - goes ahead and renames all headers
                            without checking if they're already "safe".
-                           Conditional - check first before renaming.
-                           Verify - count "unsafe" header names without
-                           modifying them.
-                           [default: conditional]
+                           verify (v) - count "unsafe" header names without
+                           modifying them. Note that verify does not count
+                           "quoted identifiers" as unsafe.
+                           verbose (V) - like verify, but verbose, showing
+                           total header count, unsafe headers & safe headers.
+                           [default: Always]
 Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.
+                           Note that no output is generated for 
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 "#;
@@ -51,23 +80,24 @@ struct Args {
     flag_delimiter: Option<Delimiter>,
 }
 
+#[derive(PartialEq)]
+enum SafeNameMode {
+    Always,
+    Conditional,
+    Verify,
+    VerifyVerbose,
+}
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    #[derive(PartialEq)]
-    enum SafeNameMode {
-        Always,
-        Conditional,
-        Verify,
-    }
-
     // set SafeNames Mode
-    let mut first_letter = args.flag_mode.chars().next().unwrap_or_default();
-    first_letter.make_ascii_lowercase();
+    let first_letter = args.flag_mode.chars().next().unwrap_or_default();
     let safenames_mode = match first_letter {
-        'c' => SafeNameMode::Conditional,
-        'a' => SafeNameMode::Always,
+        'c' | 'C' => SafeNameMode::Conditional,
+        'a' | 'A' => SafeNameMode::Always,
         'v' => SafeNameMode::Verify,
+        'V' => SafeNameMode::VerifyVerbose,
         _ => {
             return fail_clierror!("Invalid mode: {}", args.flag_mode);
         }
@@ -101,29 +131,49 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         eprintln!("{changed_count}");
     } else {
-        // Verify Mode
+        // Verify or VerifyVerbose Mode
         let mut checkednames_vec: Vec<String> = Vec::with_capacity(old_headers.len());
-        let mut unsafe_flag;
+        let mut safenames_vec: Vec<String> = Vec::new();
+        let mut unsafenames_vec: Vec<String> = Vec::new();
         let mut unsafe_count = 0_u16;
+        let mut dupe_count = 0_u16;
 
         for header_name in headers.iter() {
-            unsafe_flag = false;
-            if !util::is_safe_name(header_name) {
+            let unsafe_flag = if util::is_safe_name(header_name) {
+                if !safenames_vec.contains(&header_name.to_string()) {
+                    safenames_vec.push(header_name.to_string());
+                }
+                false
+            } else {
+                unsafenames_vec.push(header_name.to_string());
                 unsafe_count += 1;
-                unsafe_flag = true;
-            }
+                true
+            };
 
             // check for duplicate headers/columns
             // we use the unsafe_flag so we dont' double unsafe count
             // an already unsafe header that's also a duplicate
-            if !unsafe_flag && checkednames_vec.contains(&header_name.to_string()) {
-                unsafe_count += 1;
+            if checkednames_vec.contains(&header_name.to_string()) {
+                dupe_count += 1;
             } else {
+                if !unsafe_flag {
+                    unsafenames_vec.push(header_name.to_string());
+                    unsafe_count += 1;
+                }
                 checkednames_vec.push(header_name.to_string());
             }
         }
 
-        eprintln!("{unsafe_count}");
+        if safenames_mode == SafeNameMode::VerifyVerbose {
+            eprintln!(
+                "{} header/s\n{unsafe_count} unsafe header/s: {unsafenames_vec:?}\n{} safe header/s: \
+                 {safenames_vec:?}\n{dupe_count} duplicate/s",
+                headers.len(),
+                safenames_vec.len()
+            );
+        } else {
+            eprintln!("{unsafe_count}");
+        }
     }
 
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -746,7 +746,7 @@ pub fn safe_header_names(
 
 #[inline]
 pub fn is_safe_name(header_name: &str) -> bool {
-    if header_name.is_empty() || header_name.len() > 60 {
+    if header_name.trim().is_empty() || header_name.len() > 60 {
         return false;
     }
     let first_character = header_name.as_bytes()[0];

--- a/src/util.rs
+++ b/src/util.rs
@@ -700,10 +700,12 @@ pub fn safe_header_names(
     conditional: bool,
 ) -> (Vec<String>, u16) {
     // Create "safe" var/key names - to support dynfmt/url-template, valid python vars & db-safe
-    // column names. Trim leading & trailing whitespace. Replace whitespace/non-alphanumeric) with
-    // _. If name starts with a number & check_first_char is true, replace it with an _ as well.
-    // If a column with the same name already exists, append a sequence suffix (e.g. _n).
-    // Finally, names are limited to 60 characters in length.
+    // column names. Fold to lowercase. Trim leading & trailing whitespace.
+    // Replace whitespace/non-alphanumeric) with _. If name starts with a number & check_first_char
+    // is true, replace it with an _ as well. If a column with the same name already exists,
+    // append a sequence suffix (e.g. _n). Names are limited to 60 characters in length.
+    // Empty names are replaced with _ as well.
+
     // If conditional = true, only rename the header if its not already safe as embedded spaces
     // in certain circumstances (postgresql allows embeded spaces in names, but not python, dynfmt
     // and url-template)
@@ -725,7 +727,7 @@ pub fn safe_header_names(
                 safe_name_always.replace_range(0..1, "_");
             }
             safe_name_always[..safe_name_always.chars().map(char::len_utf8).take(60).sum()]
-                .to_string()
+                .to_lowercase()
         };
         let mut sequence_suffix = 2_u16;
         let mut candidate_name = safe_name.clone();


### PR DESCRIPTION
- we also fold to lowercase safenames (optimizing for Postgres identifiers)
- add Verbose mode
- add examples to usage text
- remove unnecessary mut for unsafe_flag