### PR TITLE
qsvdp update option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ generate = ["test-data-generation"]
 luau = ["mlua"]
 python = ["pyo3"]
 lite = []
-datapusher_plus = []
+datapusher_plus = ["self_update"]
 full = []
 nightly = [
     "regex/unstable",

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ sponsored by datHere - Data Infrastructure Engineering
         return QsvExitCode::Good;
     }
     if args.flag_update {
-        let update_checked = util::qsv_check_for_update();
+        let update_checked = util::qsv_check_for_update(false);
         util::log_end(qsv_args, now);
         if update_checked.is_ok() {
             return QsvExitCode::Good;
@@ -201,7 +201,7 @@ Please choose one of the following {num_commands} commands:\n{enabled_commands}\
 sponsored by datHere - Data Infrastructure Engineering
 "
             );
-            _ = util::qsv_check_for_update();
+            _ = util::qsv_check_for_update(false);
             util::log_end(qsv_args, now);
             QsvExitCode::Good
         }
@@ -343,7 +343,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update();
+                _ = util::qsv_check_for_update(false);
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -114,7 +114,7 @@ fn main() -> QsvExitCode {
         return QsvExitCode::Good;
     }
     if args.flag_update {
-        let update_checked = util::qsv_check_for_update();
+        let update_checked = util::qsv_check_for_update(false);
         util::log_end(qsv_args, now);
         if update_checked.is_ok() {
             return QsvExitCode::Good;
@@ -129,7 +129,7 @@ fn main() -> QsvExitCode {
 Please choose one of the following commands:",
                 command_list!()
             ));
-            _ = util::qsv_check_for_update();
+            _ = util::qsv_check_for_update(false);
             util::log_end(qsv_args, now);
             QsvExitCode::Good
         }
@@ -247,7 +247,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update();
+                _ = util::qsv_check_for_update(false);
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -32,22 +32,31 @@ mod workdir;
 
 #[cfg(feature = "apply")]
 mod test_apply;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_behead;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_cat;
 mod test_combos;
 mod test_comments;
 mod test_count;
 mod test_dedup;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_enumerate;
 mod test_excel;
 mod test_exclude;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_explode;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_extsort;
 #[cfg(feature = "fetch")]
 mod test_fetch;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_fill;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_fixlengths;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_flatten;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_fmt;
 #[cfg(all(feature = "foreach", target_family = "unix"))]
 mod test_foreach;
@@ -55,19 +64,24 @@ mod test_frequency;
 mod test_headers;
 mod test_index;
 mod test_input;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_join;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_jsonl;
 #[cfg(feature = "luau")]
 mod test_luau;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_partition;
 mod test_pseudo;
 #[cfg(feature = "python")]
 mod test_py;
 mod test_rename;
 mod test_replace;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_reverse;
 mod test_safenames;
 mod test_sample;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_schema;
 mod test_search;
 mod test_searchset;
@@ -75,10 +89,14 @@ mod test_select;
 mod test_slice;
 mod test_sniff;
 mod test_sort;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_split;
 mod test_stats;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_table;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_tojsonl;
+#[cfg(any(feature = "full", feature = "lite"))]
 mod test_transpose;
 mod test_validate;
 


### PR DESCRIPTION
- enable update engine on qsvdp, but only invoke self-update when explicitly invoked with the --update option.
- also fine-tune tests to only run applicable tests when testing qsvlite and qsvdp.