### PR TITLE
Refine interpreters

### DIFF
--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -261,6 +261,10 @@ fn luau_map_error() {
         svec!["d", "7", "<ERROR>"],
     ];
     assert_eq!(got, expected);
+
+    wrk.assert_err(&mut cmd);
+    let stderr_string = wrk.output_stderr(&mut cmd);
+    assert!(stderr_string.ends_with("Luau errors encountered: 4\n"));
 }
 
 #[test]

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -437,6 +437,10 @@ fn py_filter_error() {
         svec!["d", "7"],
     ];
     assert_eq!(got, expected);
+
+    wrk.assert_err(&mut cmd);
+    let stderr_string = wrk.output_stderr(&mut cmd);
+    assert!(stderr_string.ends_with("Python errors encountered: 4\n"));
 }
 
 #[test]


### PR DESCRIPTION
- for both python and luau, when errors encountered, return non-zero exit code, along with error count to stderr
- for `luau`, expand usage note to mention state of special vars _idx and _rowcount during the prologue, main and epilogue stage