### PR TITLE
Unsafe empty column/header names are replaced with "_blank" instead of "_"

### DIFF
--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -45,7 +45,7 @@ Excel options:
                                sequential suffix (_n) appended; Leading/trailing whitespaces are trimmed;
                                Whitespace/non-alphanumeric characters are replaced with _;
                                If a column name starts with a digit, the digit is replaced with a _;
-                               maximum length is 60 characters; and empty header names are set to _.
+                               maximum length is 60 characters; and empty header names are set to "_blank".
                                It has two modes - Always & Conditional.
                                Always - goes ahead and renames all headers without checking if they're 
                                already "safe". Conditional - check first before renaming.

--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -5,7 +5,7 @@ Modify headers of a CSV to only have "safe" names - guaranteed "database-ready" 
 Fold to lowercase. Trim leading & trailing whitespaces. Replace whitespace/non-alphanumeric
 characters with _. If the first character is a digit, replace the digit with _.
 If a header with the same name already exists, append a sequence suffix (e.g. c1, c1_2, c1_3).
-Names are limited to 60 characters in length. Empty names are replaced with _.
+Names are limited to 60 characters in length. Empty names are replaced with "_blank".
 
 In Always and Conditional mode, returns number of modified headers to stderr, and sends
 CSV with safe headers output to stdout.
@@ -39,6 +39,10 @@ Given data.csv:
   5 unsafe header/s: ["c1", "12_col", "Col with Embedded Spaces", "", "Column!@Invalid+Chars"]
   2 safe header/s: ["c1", "Col with Embedded Spaces"]
   1 duplicate/s found.
+
+Note how "Col with Embedded Spaces" is both safe and unsafe. This is because it can be created 
+"safely" as a "quoted identifier" in PostgreSQL. However, it is also unsafe because the embedded
+spaces can cause problems later on (see https://lerner.co.il/2013/11/30/quoting-postgresql/).
 
 For more examples, see https://github.com/jqnatividad/qsv/blob/master/tests/test_safenames.rs.
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -706,7 +706,7 @@ pub fn safe_header_names(
     // Replace whitespace/non-alphanumeric) with _. If name starts with a number & check_first_char
     // is true, replace it with an _ as well. If a column with the same name already exists,
     // append a sequence suffix (e.g. _n). Names are limited to 60 characters in length.
-    // Empty names are replaced with _ as well.
+    // Empty names are replaced with _blank as well.
 
     // If conditional = true, only rename the header if its not already safe as embedded spaces
     // in certain circumstances (postgresql allows embeded spaces in names, but not python, dynfmt
@@ -719,7 +719,7 @@ pub fn safe_header_names(
             header_name.to_string()
         } else {
             let mut safe_name_always = if header_name.is_empty() {
-                "_".to_string()
+                "_blank".to_string()
             } else {
                 safename_regex
                     .replace_all(header_name.trim(), "_")

--- a/tests/test_safenames.rs
+++ b/tests/test_safenames.rs
@@ -31,7 +31,7 @@ fn safenames_conditional() {
             "col1",
             "this_is_a_column_with_invalid_chars___and_leading___trailing",
             // null column names are not allowed in postgres
-            "_",
+            "_blank",
             // though this is "safe", it's generally discouraged
             // to have embedded spaces and mixed case column names
             // as you will have to use quotes to refer to these columns
@@ -42,8 +42,8 @@ fn safenames_conditional() {
             // duplicate cols are not allowed in one table in postgres
             "col1_2",
             "col1_3",
-            "__2",
-            "__3"
+            "_blank_2",
+            "_blank_3"
         ],
         svec!["1", "b", "33", "1", "b", "33", "34", "z", "42"],
         svec!["2", "c", "34", "3", "d", "31", "3", "y", "3.14"],
@@ -85,7 +85,7 @@ fn safenames_always() {
         svec![
             "col1",
             "this_is_a_column_with_invalid_chars___and_leading___trailing",
-            "_",
+            "_blank",
             // we were using Always mode, so even though the
             // original header name was already valid,
             // we replaced spaces with _ regardless


### PR DESCRIPTION
- empty header/column names are replaced with "_blank".
- previously, we were replacing empty names with "_", which turns out is not a valid Postgres column identifier
- also add note about Postgres "quoted identifiers". That they can be safely created with embedded spaces, but is also unsafe and not recommended as they can cause problems with queries.
https://lerner.co.il/2013/11/30/quoting-postgresql/