### PR TITLE
opt-in self-update

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ sponsored by datHere - Data Infrastructure Engineering
         return QsvExitCode::Good;
     }
     if args.flag_update {
-        let update_checked = util::qsv_check_for_update(false);
+        let update_checked = util::qsv_check_for_update(false, true);
         util::log_end(qsv_args, now);
         if update_checked.is_ok() {
             return QsvExitCode::Good;
@@ -201,7 +201,7 @@ Please choose one of the following {num_commands} commands:\n{enabled_commands}\
 sponsored by datHere - Data Infrastructure Engineering
 "
             );
-            _ = util::qsv_check_for_update(false);
+            _ = util::qsv_check_for_update(true, false);
             util::log_end(qsv_args, now);
             QsvExitCode::Good
         }
@@ -343,7 +343,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update(false);
+                _ = util::qsv_check_for_update(true, false);
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -99,7 +99,7 @@ fn main() -> QsvExitCode {
         return QsvExitCode::Good;
     }
     if args.flag_update {
-        let update_checked = util::qsv_check_for_update(false);
+        let update_checked = util::qsv_check_for_update(false, true);
         util::log_end(qsv_args, now);
         if update_checked.is_ok() {
             return QsvExitCode::Good;
@@ -114,7 +114,7 @@ fn main() -> QsvExitCode {
 Please choose one of the following commands:",
                 command_list!()
             ));
-            _ = util::qsv_check_for_update(true);
+            _ = util::qsv_check_for_update(true, false);
             util::log_end(qsv_args, now);
             QsvExitCode::Good
         }
@@ -207,7 +207,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update(true);
+                _ = util::qsv_check_for_update(true, false);
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -114,7 +114,7 @@ fn main() -> QsvExitCode {
         return QsvExitCode::Good;
     }
     if args.flag_update {
-        let update_checked = util::qsv_check_for_update(false);
+        let update_checked = util::qsv_check_for_update(false, true);
         util::log_end(qsv_args, now);
         if update_checked.is_ok() {
             return QsvExitCode::Good;
@@ -129,7 +129,7 @@ fn main() -> QsvExitCode {
 Please choose one of the following commands:",
                 command_list!()
             ));
-            _ = util::qsv_check_for_update(false);
+            _ = util::qsv_check_for_update(true, false);
             util::log_end(qsv_args, now);
             QsvExitCode::Good
         }
@@ -247,7 +247,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update(false);
+                _ = util::qsv_check_for_update(true, false);
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),

--- a/src/util.rs
+++ b/src/util.rs
@@ -492,7 +492,7 @@ pub fn init_logger() -> String {
 }
 
 #[cfg(feature = "self_update")]
-pub fn qsv_check_for_update(check_only: bool) -> Result<bool, String> {
+pub fn qsv_check_for_update(check_only: bool, send_survey: bool) -> Result<bool, String> {
     if env::var("QSV_NO_UPDATE").is_ok() {
         return Ok(false);
     }
@@ -579,16 +579,19 @@ or download the prebuilt binaries from GitHub."#
         winfo!("Up to date ({curr_version})... no update required.");
     };
 
-    if let Ok(status_code) = send_hwsurvey(&bin_name, updated, latest_release, curr_version, false)
-    {
-        log::info!("Survey sent. Status code: {status_code}");
+    if send_survey {
+        if let Ok(status_code) =
+            send_hwsurvey(&bin_name, updated, latest_release, curr_version, false)
+        {
+            log::info!("HW survey sent. Status code: {status_code}");
+        }
     }
 
     Ok(updated)
 }
 
 #[cfg(not(feature = "self_update"))]
-pub fn qsv_check_for_update(_check_only: bool) -> Result<bool, String> {
+pub fn qsv_check_for_update(_check_only: bool, send_survey: bool) -> Result<bool, String> {
     Ok(true)
 }
 


### PR DESCRIPTION
In connection with #639, qsv now only checks for new releases and inform the user.

They have to explicitly invoke --update to update prebuilt qsv and send hw_survey.

