### PR TITLE
Create README in prebuilt zip archive with platform specific notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,6 +176,10 @@ jobs:
         mkdir qsv-${{ needs.analyze-tags.outputs.previous-tag }}
         rm target/${{ matrix.job.target }}/release/*.d 
         cp -v target/${{ matrix.job.target }}/release/qsv* qsv-${{ needs.analyze-tags.outputs.previous-tag }}
+    - name: Create README
+      shell: bash
+      run: |
+        cat docs/publishing_assets/README.txt docs/publishing_assets/qsv-${{ matrix.job.target }}.txt > qsv-${{ needs.analyze-tags.outputs.previous-tag }}/README
     - name: zip up binaries
       run: 7z a -tzip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip ./qsv-${{ needs.analyze-tags.outputs.previous-tag }}/* -mx=9 -mmt=on
     - name: Upload zipped binaries to release

--- a/docs/publishing_assets/README.txt
+++ b/docs/publishing_assets/README.txt
@@ -1,0 +1,14 @@
+qsv is a command line program for indexing, slicing, analyzing, filtering, enriching, validating & joining CSV files.
+Commands are simple, fast & composable.
+
+For a list of Available Commands and how to use each one, go to 
+https://github.com/jqnatividad/qsv#qsv-ultra-fast-csv-data-wrangling-toolkit
+
+There are three binary variants of qsv:
+* qsv - feature-capable, with prebuilt binaries enabling all applicable features except Python
+* qsvlite - all features disabled (~40% the size of qsv)
+* qsvdp - qsv optimized for use with Datapusher+, with only Datapusher+ relevant commands (~40% the size of qsv)
+
+Datapusher+ is only relevant for CKAN installations that use the Datastore.
+For more info, see https://github.com/dathere/datapusher-plus#datapusher
+

--- a/docs/publishing_assets/qsv-x86_64-unknown-linux-gnu.txt
+++ b/docs/publishing_assets/qsv-x86_64-unknown-linux-gnu.txt
@@ -1,0 +1,9 @@
+If you get a "GLIBC_* not found" error when running qsv, your Linux distro does
+not have the necessary version of the GNU C Library that qsv dynamically links to
+at startup.
+
+Use the "linux-musl.zip" archive instead. It contains qsv statically linked to the
+musl C library.
+
+https://www.gnu.org/software/libc/
+https://musl.libc.org


### PR DESCRIPTION
for now, we have a note for linux-gnu.zip to use the must zip archive if they get GLIBC not found errors.

Resolves #639 