### PR TITLE
`stats`: leading zero handling

### DIFF
--- a/resources/test/boston311-100-everything-8places-stats.csv
+++ b/resources/test/boston311-100-everything-8places-stats.csv
@@ -24,7 +24,7 @@ neighborhood_services_district,String,, ,9,1,2,,,,0,,,,,,,,,,3,16
 ward,String,, ,Ward 9,1,7,,,,0,,,,,,,,,,Ward 3,42
 precinct,String,, ,2210,0,4,,,,1,,,,,,,,,,0306,76
 location_street_name,String,,103 N Beacon St,INTERSECTION Verdun St & Gallivan Blvd,0,45,,,,1,,,,,,,,,,"20 Washington St,563 Columbus Ave,INTERSECTION Gallivan Blvd & Washington St",97
-location_zipcode,Integer,176426,2109,2215,0,5,2125.61445783,15.39428100,236.98388736,17,2085,2101.5,2118,2125,2129,11,2145.5,2162,-0.27272727,,24
+location_zipcode,String,,02109,02215,0,5,,,,17,,,,,,,,,,,24
 latitude,Float,4233.6674,42.2553,42.3806,6,7,42.33667400,0.03050279,0.00093042,0,42.20340000,42.26190000,42.32040000,42.34315,42.3594,0.03900000,42.41790000,42.47640000,-0.16666667,42.3594,78
 longitude,Float,-7107.26880000,-71.1626,-71.0298,6,8,-71.072688,0.03107450,0.00096562,0,-71.17405,-71.129425,-71.0848,-71.06085,-71.05505,0.02975000,-71.010425,-70.9658,-0.61008403,-71.0587,77
 source,String,,Citizens Connect App,Self Service,12,20,,,,0,,,,,,,,,,Citizens Connect App,4

--- a/resources/test/boston311-100-everything-date-stats.csv
+++ b/resources/test/boston311-100-everything-date-stats.csv
@@ -24,7 +24,7 @@ neighborhood_services_district,String,, ,9,1,2,,,,0,,,,,,,,,,3,16
 ward,String,, ,Ward 9,1,7,,,,0,,,,,,,,,,Ward 3,42
 precinct,String,, ,2210,0,4,,,,1,,,,,,,,,,0306,76
 location_street_name,String,,103 N Beacon St,INTERSECTION Verdun St & Gallivan Blvd,0,45,,,,1,,,,,,,,,,"20 Washington St,563 Columbus Ave,INTERSECTION Gallivan Blvd & Washington St",97
-location_zipcode,Integer,176426,2109,2215,0,5,2125.6145,15.3943,236.9839,17,2085,2101.5,2118,2125,2129,11,2145.5,2162,-0.2727,,24
+location_zipcode,String,,02109,02215,0,5,,,,17,,,,,,,,,,,24
 latitude,Float,4233.6674,42.2553,42.3806,6,7,42.3367,0.0305,0.0009,0,42.2034,42.2619,42.3204,42.3432,42.3594,0.0390,42.4179,42.4764,-0.1667,42.3594,78
 longitude,Float,-7107.2688,-71.1626,-71.0298,6,8,-71.0727,0.0311,0.0010,0,-71.1740,-71.1294,-71.0848,-71.0608,-71.0550,0.0298,-71.0104,-70.9658,-0.6101,-71.0587,77
 source,String,,Citizens Connect App,Self Service,12,20,,,,0,,,,,,,,,,Citizens Connect App,4

--- a/resources/test/boston311-100-everything-nodate-stats.csv
+++ b/resources/test/boston311-100-everything-nodate-stats.csv
@@ -24,7 +24,7 @@ neighborhood_services_district,String,, ,9,1,2,,,,0,,,,,,,,,,3,16
 ward,String,, ,Ward 9,1,7,,,,0,,,,,,,,,,Ward 3,42
 precinct,String,, ,2210,0,4,,,,1,,,,,,,,,,0306,76
 location_street_name,String,,103 N Beacon St,INTERSECTION Verdun St & Gallivan Blvd,0,45,,,,1,,,,,,,,,,"20 Washington St,563 Columbus Ave,INTERSECTION Gallivan Blvd & Washington St",97
-location_zipcode,Integer,176426,2109,2215,0,5,2125.6145,15.3943,236.9839,17,2085,2101.5,2118,2125,2129,11,2145.5,2162,-0.2727,,24
+location_zipcode,String,,02109,02215,0,5,,,,17,,,,,,,,,,,24
 latitude,Float,4233.6674,42.2553,42.3806,6,7,42.3367,0.0305,0.0009,0,42.2034,42.2619,42.3204,42.3432,42.3594,0.0390,42.4179,42.4764,-0.1667,42.3594,78
 longitude,Float,-7107.2688,-71.1626,-71.0298,6,8,-71.0727,0.0311,0.0010,0,-71.1740,-71.1294,-71.0848,-71.0608,-71.0550,0.0298,-71.0104,-70.9658,-0.6101,-71.0587,77
 source,String,,Citizens Connect App,Self Service,12,20,,,,0,,,,,,,,,,Citizens Connect App,4

--- a/resources/test/boston311-100-stats.csv
+++ b/resources/test/boston311-100-stats.csv
@@ -24,7 +24,7 @@ neighborhood_services_district,String,, ,9,1,2,,,,0
 ward,String,, ,Ward 9,1,7,,,,0
 precinct,String,, ,2210,0,4,,,,1
 location_street_name,String,,103 N Beacon St,INTERSECTION Verdun St & Gallivan Blvd,0,45,,,,1
-location_zipcode,Integer,176426,2109,2215,0,5,2125.6145,15.3943,236.9839,17
+location_zipcode,String,,02109,02215,0,5,,,,17
 latitude,Float,4233.6674,42.2553,42.3806,6,7,42.3367,0.0305,0.0009,0
 longitude,Float,-7107.2688,-71.1626,-71.0298,6,8,-71.0727,0.0311,0.0010,0
 source,String,,Citizens Connect App,Self Service,12,20,,,,0

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -215,8 +215,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 serde_json::to_string_pretty(&sortcheck_struct).unwrap()
             );
         } else {
-            let json_result = serde_json::to_string(&sortcheck_struct).unwrap();
-            println!("{json_result}");
+            println!("{}", serde_json::to_string(&sortcheck_struct).unwrap());
         };
     }
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -719,6 +719,10 @@ impl FieldType {
             || current_type == FieldType::TNull
         {
             if string.parse::<i64>().is_ok() {
+                // leading zero, its a string
+                if string.starts_with('0') {
+                    return TString;
+                }
                 return TInteger;
             }
 


### PR DESCRIPTION
if a field value can be parsed as an int, but has a leading zero, its a string

e.g. postalcodes - 07094; or state codes in Italy - 01;02;03

resolves #646 
