### PR TITLE
`safenames`: add --reserved option

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -470,7 +470,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             return fail!("dynfmt/calcconv subcommand requires headers.");
         }
         // first, get the fields used in the dynfmt template
-        let (safe_headers, _) = util::safe_header_names(&headers, false, false);
+        let (safe_headers, _) = util::safe_header_names(&headers, false, false, &Vec::new());
         let formatstr_re: &'static Regex = crate::regex_once_cell!(r"\{(?P<key>\w+)?\}");
         for format_fields in formatstr_re.captures_iter(&args.flag_formatstr) {
             dynfmt_fields.push(format_fields.name("key").unwrap().as_str());

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -231,7 +231,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         .map(|h| {
                             let header = h.to_string();
 
-                            let safe_flag = util::is_safe_name(&header);
+                            let safe_flag = util::is_safe_name(&header, &Vec::new());
                             if safe_flag {
                                 if !safenames_vec.contains(&header) {
                                     safenames_vec.push(header.to_string());
@@ -474,8 +474,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 DataType::Error(ref e) => record.push_field(&format!("{e:?}")),
                 DataType::Bool(ref b) => record.push_field(&b.to_string()),
             };
-            // dates are stored as numbers in Excel
-            // that's why we need the --dates-whitelist, so we can convert the number to a date.
+            // dates are stored as floats in Excel
+            // that's why we need the --dates-whitelist, so we can convert the float to a date.
             // However, with the XLSX format, we can get a cell's format as an attribute. So we can
             // automatically process a cell as a date, even if its column is NOT in the whitelist
             if float_flag {

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -231,7 +231,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         .map(|h| {
                             let header = h.to_string();
 
-                            let safe_flag = util::is_safe_name(&header, &Vec::new());
+                            let safe_flag = util::is_safe_name(&header);
                             if safe_flag {
                                 if !safenames_vec.contains(&header) {
                                     safenames_vec.push(header.to_string());

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -372,7 +372,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         dynfmt_url_template = url_template.to_string();
         // first, get the fields used in the url template
-        let (safe_headers, _) = util::safe_header_names(&str_headers, false, false);
+        let (safe_headers, _) = util::safe_header_names(&str_headers, false, false, &Vec::new());
         let formatstr_re: &'static Regex = regex_once_cell!(r"\{(?P<key>\w+)?\}");
         for format_fields in formatstr_re.captures_iter(url_template) {
             dynfmt_fields.push(format_fields.name("key").unwrap().as_str());

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -231,7 +231,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     // ensure col/header names are valid and safe python variables
-    let (header_vec, _) = util::safe_header_names(&headers, true, false);
+    let (header_vec, _) = util::safe_header_names(&headers, true, false, &Vec::new());
 
     // amortize memory allocation by reusing record
     #[allow(unused_assignments)]

--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -73,6 +73,10 @@ safenames options:
                            JSON (j) - similar to verbose in minified JSON.
                            pretty JSON (J) - verbose in pretty-printed JSON
                            [default: Always]
+    --reserved <list>      Comma-delimited list of additional reserved names
+                           that are considered "unsafe."
+                           [default: _id]
+
 Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.
@@ -93,6 +97,7 @@ use crate::{
 struct Args {
     arg_input:      Option<String>,
     flag_mode:      String,
+    flag_reserved:  String,
     flag_output:    Option<String>,
     flag_delimiter: Option<Delimiter>,
 }
@@ -132,6 +137,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
     };
 
+    let reserved_names_vec: Vec<String> = args
+        .flag_reserved
+        .split(',')
+        .map(std::string::ToString::to_string)
+        .collect();
+
     let rconfig = Config::new(&args.arg_input)
         .checkutf8(true)
         .delimiter(args.flag_delimiter);
@@ -142,8 +153,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut headers = csv::StringRecord::from_byte_record_lossy(old_headers.clone());
     if let SafeNameMode::Conditional | SafeNameMode::Always = safenames_mode {
-        let (safe_headers, changed_count) =
-            util::safe_header_names(&headers, true, safenames_mode == SafeNameMode::Conditional);
+        let (safe_headers, changed_count) = util::safe_header_names(
+            &headers,
+            true,
+            safenames_mode == SafeNameMode::Conditional,
+            &reserved_names_vec,
+        );
 
         headers.clear();
         for header_name in safe_headers {
@@ -168,7 +183,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let mut dupe_count = 0_u16;
 
         for header_name in headers.iter() {
-            let safe_flag = util::is_safe_name(header_name);
+            let safe_flag = util::is_safe_name(header_name, &reserved_names_vec);
             if safe_flag {
                 if !safenames_vec.contains(&header_name.to_string()) {
                     safenames_vec.push(header_name.to_string());

--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -73,8 +73,9 @@ safenames options:
                            JSON (j) - similar to verbose in minified JSON.
                            pretty JSON (J) - verbose in pretty-printed JSON
                            [default: Always]
-    --reserved <list>      Comma-delimited list of additional reserved names
-                           that are considered "unsafe."
+    --reserved <list>      Comma-delimited list of additional case-insensitive reserved names
+                           that should be considered "unsafe." If a header name is found in 
+                           the reserved list, it will be prefixed with "_RESERVED_".
                            [default: _id]
 
 Common options:
@@ -140,7 +141,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let reserved_names_vec: Vec<String> = args
         .flag_reserved
         .split(',')
-        .map(std::string::ToString::to_string)
+        .map(str::to_lowercase)
         .collect();
 
     let rconfig = Config::new(&args.arg_input)
@@ -183,7 +184,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let mut dupe_count = 0_u16;
 
         for header_name in headers.iter() {
-            let safe_flag = util::is_safe_name(header_name, &reserved_names_vec);
+            let safe_flag = util::is_safe_name(header_name);
             if safe_flag {
                 if !safenames_vec.contains(&header_name.to_string()) {
                     safenames_vec.push(header_name.to_string());

--- a/tests/test_safenames.rs
+++ b/tests/test_safenames.rs
@@ -292,3 +292,135 @@ fn safenames_invalid_mode() {
 
     wrk.assert_err(&mut cmd);
 }
+
+#[test]
+fn safenames_reserved_names_default() {
+    let wrk = Workdir::new("safenames");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec![
+                "col1",
+                " This is a column with invalid chars!# and leading & trailing spaces ",
+                "_id",
+                "this is already a postgres safe column",
+                "1starts with 1",
+                "col1",
+                "col1"
+            ],
+            svec!["1", "b", "33", "1", "b", "33", "34"],
+            svec!["2", "c", "34", "3", "d", "31", "3"],
+        ],
+    );
+
+    let mut cmd = wrk.command("safenames");
+    cmd.arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![
+            "col1",
+            "this_is_a_column_with_invalid_chars___and_leading___trailing",
+            "_RESERVED__id",
+            "this_is_already_a_postgres_safe_column",
+            "_starts_with_1",
+            "col1_2",
+            "col1_3"
+        ],
+        svec!["1", "b", "33", "1", "b", "33", "34"],
+        svec!["2", "c", "34", "3", "d", "31", "3"],
+    ];
+    assert_eq!(got, expected);
+
+    let changed_headers = wrk.output_stderr(&mut cmd);
+    let expected_count = "6\n";
+    assert_eq!(changed_headers, expected_count);
+}
+
+#[test]
+fn safenames_reserved_names_specified() {
+    let wrk = Workdir::new("safenames");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec![
+                "col1",
+                " This is a column with invalid chars!# and leading & trailing spaces ",
+                "waldo",
+                "this is already a postgres safe column",
+                "1starts with 1",
+                "col1",
+                "col1"
+            ],
+            svec!["1", "b", "33", "1", "b", "33", "34"],
+            svec!["2", "c", "34", "3", "d", "31", "3"],
+        ],
+    );
+
+    let mut cmd = wrk.command("safenames");
+    cmd.arg("--reserved").arg("waldo").arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![
+            "col1",
+            "this_is_a_column_with_invalid_chars___and_leading___trailing",
+            "_RESERVED_waldo",
+            "this_is_already_a_postgres_safe_column",
+            "_starts_with_1",
+            "col1_2",
+            "col1_3"
+        ],
+        svec!["1", "b", "33", "1", "b", "33", "34"],
+        svec!["2", "c", "34", "3", "d", "31", "3"],
+    ];
+    assert_eq!(got, expected);
+
+    let changed_headers = wrk.output_stderr(&mut cmd);
+    let expected_count = "6\n";
+    assert_eq!(changed_headers, expected_count);
+}
+
+#[test]
+fn safenames_reserved_names_specified_case_insensitive() {
+    let wrk = Workdir::new("safenames");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec![
+                "col1",
+                " This is a column with invalid chars!# and leading & trailing spaces ",
+                "WaLdO",
+                "this is already a postgres safe column",
+                "1starts with 1",
+                "col1",
+                "col1"
+            ],
+            svec!["1", "b", "33", "1", "b", "33", "34"],
+            svec!["2", "c", "34", "3", "d", "31", "3"],
+        ],
+    );
+
+    let mut cmd = wrk.command("safenames");
+    cmd.arg("--reserved").arg("waldo").arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![
+            "col1",
+            "this_is_a_column_with_invalid_chars___and_leading___trailing",
+            "_RESERVED_waldo",
+            "this_is_already_a_postgres_safe_column",
+            "_starts_with_1",
+            "col1_2",
+            "col1_3"
+        ],
+        svec!["1", "b", "33", "1", "b", "33", "34"],
+        svec!["2", "c", "34", "3", "d", "31", "3"],
+    ];
+    assert_eq!(got, expected);
+
+    let changed_headers = wrk.output_stderr(&mut cmd);
+    let expected_count = "6\n";
+    assert_eq!(changed_headers, expected_count);
+}


### PR DESCRIPTION
Per the usage text:

    --reserved <list>      Comma-delimited list of additional case-insensitive reserved names
                           that should be considered "unsafe." If a header name is found in 
                           the reserved list, it will be prefixed with "_RESERVED_".
                           [default: _id]

As for the default value `_id`, that is a reserved column name for the first column of a CKAN datastore resource.