### PR TITLE
`safe names`: add --prefix option

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -470,7 +470,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             return fail!("dynfmt/calcconv subcommand requires headers.");
         }
         // first, get the fields used in the dynfmt template
-        let (safe_headers, _) = util::safe_header_names(&headers, false, false, &Vec::new());
+        let (safe_headers, _) = util::safe_header_names(&headers, false, false, &Vec::new(), "");
         let formatstr_re: &'static Regex = crate::regex_once_cell!(r"\{(?P<key>\w+)?\}");
         for format_fields in formatstr_re.captures_iter(&args.flag_formatstr) {
             dynfmt_fields.push(format_fields.name("key").unwrap().as_str());

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -311,7 +311,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             return fail!("dynfmt/calcconv subcommand requires headers.");
         }
         // first, get the fields used in the dynfmt template
-        let (safe_headers, _) = util::safe_header_names(&headers, false, false, &Vec::new());
+        let (safe_headers, _) = util::safe_header_names(&headers, false, false, &Vec::new(), "");
         let formatstr_re: &'static Regex = crate::regex_once_cell!(r"\{(?P<key>\w+)?\}");
         for format_fields in formatstr_re.captures_iter(&args.flag_formatstr) {
             dynfmt_fields.push(format_fields.name("key").unwrap().as_str());

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -372,7 +372,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         dynfmt_url_template = url_template.to_string();
         // first, get the fields used in the url template
-        let (safe_headers, _) = util::safe_header_names(&str_headers, false, false, &Vec::new());
+        let (safe_headers, _) =
+            util::safe_header_names(&str_headers, false, false, &Vec::new(), "");
         let formatstr_re: &'static Regex = regex_once_cell!(r"\{(?P<key>\w+)?\}");
         for format_fields in formatstr_re.captures_iter(url_template) {
             dynfmt_fields.push(format_fields.name("key").unwrap().as_str());

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -231,7 +231,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     // ensure col/header names are valid and safe python variables
-    let (header_vec, _) = util::safe_header_names(&headers, true, false, &Vec::new());
+    let (header_vec, _) = util::safe_header_names(&headers, true, false, &Vec::new(), "");
 
     // amortize memory allocation by reusing record
     #[allow(unused_assignments)]

--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -3,9 +3,9 @@ Modify headers of a CSV to only have "safe" names - guaranteed "database-ready" 
 (optimized specifically for PostgreSQL column identifiers). 
 
 Fold to lowercase. Trim leading & trailing whitespaces. Replace whitespace/non-alphanumeric
-characters with _. If the first character is a digit, replace the digit with _.
+characters with _. If the first character is a digit, replace the digit with the unsafe prefix.
 If a header with the same name already exists, append a sequence suffix (e.g. c1, c1_2, c1_3).
-Names are limited to 60 characters in length. Empty names are replaced with "_blank".
+Names are limited to 60 characters in length. Empty names are replaced with "unsafe_".
 
 In Always (a) and Conditional (c) mode, returns number of modified headers to stderr,
 and sends CSV with safe headers output to stdout.
@@ -75,8 +75,11 @@ safenames options:
                            [default: Always]
     --reserved <list>      Comma-delimited list of additional case-insensitive reserved names
                            that should be considered "unsafe." If a header name is found in 
-                           the reserved list, it will be prefixed with "_RESERVED_".
+                           the reserved list, it will be prefixed with "reserved_".
                            [default: _id]
+    --prefix <string>      Certain systems do not allow header names to start with "_" (e.g. CKAN Datastore).
+                           This option allows the specification of a prefix to use when a header starts with "_".
+                           [default: unsafe_]
 
 Common options:
     -h, --help             Display this message
@@ -99,6 +102,7 @@ struct Args {
     arg_input:      Option<String>,
     flag_mode:      String,
     flag_reserved:  String,
+    flag_prefix:    String,
     flag_output:    Option<String>,
     flag_delimiter: Option<Delimiter>,
 }
@@ -159,6 +163,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             true,
             safenames_mode == SafeNameMode::Conditional,
             &reserved_names_vec,
+            &args.flag_prefix,
         );
 
         headers.clear();

--- a/tests/test_safenames.rs
+++ b/tests/test_safenames.rs
@@ -31,19 +31,19 @@ fn safenames_conditional() {
             "col1",
             "this_is_a_column_with_invalid_chars___and_leading___trailing",
             // null column names are not allowed in postgres
-            "_blank",
+            "unsafe_",
             // though this is "safe", it's generally discouraged
             // to have embedded spaces and mixed case column names
             // as you will have to use quotes to refer to these columns
             // in Postgres
             "this is already a Postgres Safe Column",
             // a column cannot start with a digit
-            "_starts_with_1",
+            "unsafe_starts_with_1",
             // duplicate cols are not allowed in one table in postgres
             "col1_2",
             "col1_3",
-            "_blank_2",
-            "_blank_3"
+            "unsafe__2",
+            "unsafe__3"
         ],
         svec!["1", "b", "33", "1", "b", "33", "34", "z", "42"],
         svec!["2", "c", "34", "3", "d", "31", "3", "y", "3.14"],
@@ -85,12 +85,12 @@ fn safenames_always() {
         svec![
             "col1",
             "this_is_a_column_with_invalid_chars___and_leading___trailing",
-            "_blank",
+            "unsafe_",
             // we were using Always mode, so even though the
             // original header name was already valid,
             // we replaced spaces with _ regardless
             "this_is_already_a_postgres_safe_column",
-            "_starts_with_1",
+            "unsafe_starts_with_1",
             "col1_2",
             "col1_3"
         ],
@@ -321,9 +321,9 @@ fn safenames_reserved_names_default() {
         svec![
             "col1",
             "this_is_a_column_with_invalid_chars___and_leading___trailing",
-            "_RESERVED__id",
+            "reserved__id",
             "this_is_already_a_postgres_safe_column",
-            "_starts_with_1",
+            "unsafe_starts_with_1",
             "col1_2",
             "col1_3"
         ],
@@ -365,9 +365,9 @@ fn safenames_reserved_names_specified() {
         svec![
             "col1",
             "this_is_a_column_with_invalid_chars___and_leading___trailing",
-            "_RESERVED_waldo",
+            "reserved_waldo",
             "this_is_already_a_postgres_safe_column",
-            "_starts_with_1",
+            "unsafe_starts_with_1",
             "col1_2",
             "col1_3"
         ],
@@ -409,9 +409,9 @@ fn safenames_reserved_names_specified_case_insensitive() {
         svec![
             "col1",
             "this_is_a_column_with_invalid_chars___and_leading___trailing",
-            "_RESERVED_waldo",
+            "reserved_waldo",
             "this_is_already_a_postgres_safe_column",
-            "_starts_with_1",
+            "unsafe_starts_with_1",
             "col1_2",
             "col1_3"
         ],


### PR DESCRIPTION
to allow the creation of safe header names that start with a specified prefix other than "_", which is valid for Postgres, but systems like CKAN DataStore does not allow.

https://github.com/ckan/ckan/issues/6446 

This is primarily for Datapusher+