### PR TITLE
`apply`: fix currencytonum bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ parking_lot = { version = "0.12", features = ["hardware-lock-elision"] }
 pyo3 = { version = "0.17", features = ["auto-initialize"], optional = true }
 qsv-dateparser = "0.4"
 qsv-stats = "0.4"
-qsv_currency = { version = "0.5", optional = true }
+qsv_currency = { version = "0.6", optional = true }
 qsv-sniffer = { version = "0.5", features = ["runtime-dispatch-simd"] }
 rand = "0.8"
 rayon = "1.6"

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1294,6 +1294,12 @@ fn apply_ops_currencytonum() {
             svec!["EUR 1234.50"],
             svec!["JPY 9,999,999.99"],
             svec!["RMB 6543.21"],
+            svec!["$10.0099"],
+            svec!["$10.0777"],
+            svec!["$10.0723"],
+            svec!["$10.8723"],
+            svec!["$10.77777"],
+            svec!["$10.777"],
         ],
     );
     let mut cmd = wrk.command("apply");
@@ -1332,6 +1338,12 @@ fn apply_ops_currencytonum() {
         svec!["1234.50"],
         svec!["9999999.99"],
         svec!["6543.21"],
+        svec!["10.01"],
+        svec!["10.08"],
+        svec!["10.07"],
+        svec!["10.87"],
+        svec!["10.78"],
+        svec!["10.78"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
- qsv_currency 0.6 now support currency rounding to 2 decimal places
- currencytonum now also properly processes values with three decimal places, though only for values that use "." as the decimal separator

resolve #659  