### PR TITLE
refactor unix epoch dateparsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "qsv-dateparser"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac9a360a774ab3c85d4e3f9cf75b84e78c68f0f24a033701d13b7eb5662a411"
+checksum = "0db9c78aace71a71cb51ffc63806fc038f42dea688795652a21d8d3f1d3fa765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2975,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "qsv-sniffer"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889e5093cbed2441883b62da4000e8ceeb4e22914bde9e2a7cfd6a91b3d8e625"
+checksum = "a0de1ab66a3ac3e0effc22f6cd6eca1dbbb9a7cadaa41157f9c969b0a21b458b"
 dependencies = [
  "bitflags",
  "bytecount",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,10 @@ num_cpus = "1"
 once_cell = { version = "1.17", features = ["parking_lot"] }
 parking_lot = { version = "0.12", features = ["hardware-lock-elision"] }
 pyo3 = { version = "0.17", features = ["auto-initialize"], optional = true }
-qsv-dateparser = "0.5"
+qsv-dateparser = "0.6"
 qsv-stats = "0.5"
 qsv_currency = { version = "0.6", optional = true }
-qsv-sniffer = { version = "0.5", features = ["runtime-dispatch-simd"] }
+qsv-sniffer = { version = "0.6", features = ["runtime-dispatch-simd"] }
 rand = "0.8"
 rayon = "1.6"
 redis = { version = "0.22", features = [

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -2005,6 +2005,10 @@ fn apply_datefmt() {
             svec!["July 4, 2005"],
             svec!["2021-05-01T01:17:02.604456Z"],
             svec!["This is not a date and it will not be reformatted"],
+            svec!["1511648546"],
+            svec!["-770172300"],
+            svec!["1671673426.123456789"],
+            // svec!["-770172300"],
         ],
     );
     let mut cmd = wrk.command("apply");
@@ -2019,6 +2023,53 @@ fn apply_datefmt() {
         svec!["2005-07-04"],
         svec!["2021-05-01T01:17:02.604456+00:00"],
         svec!["This is not a date and it will not be reformatted"],
+        svec!["2017-11-25T22:22:26+00:00"],
+        svec!["1945-08-05T23:15:00+00:00"],
+        svec!["2022-12-22T01:43:46.123456768+00:00"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_datefmt_to_unixtime() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["Created Date"],
+            svec!["September 17, 2012 10:09am EST"],
+            svec!["Wed, 02 Jun 2021 06:31:39 GMT"],
+            svec!["2009-01-20 05:00 EST"],
+            svec!["July 4, 2005"],
+            svec!["2021-05-01T01:17:02.604456Z"],
+            svec!["This is not a date and it will not be reformatted"],
+            svec!["1511648546"],
+            svec!["1620021848429"],
+            svec!["1620024872717915000"],
+            svec!["1945-08-06T06:54:32.717915+00:00"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("datefmt")
+        .arg("Created Date")
+        .arg("--formatstr")
+        .arg("%s")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["Created Date"],
+        svec!["1347894540"],
+        svec!["1622615499"],
+        svec!["1232445600"],
+        svec!["1120435200"],
+        svec!["1619831822"],
+        svec!["This is not a date and it will not be reformatted"],
+        // %s formatstr can only do unixtime in seconds, that's why there's rounding here
+        svec!["1511648546"],
+        svec!["9223372036"],
+        svec!["9223372036"],
+        svec!["-770144728"],
     ];
     assert_eq!(got, expected);
 }

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -231,7 +231,7 @@ fn sniff_sample() {
     "GeoAreaLabel"
   ],
   "types": [
-    "DateTime",
+    "Date",
     "Text",
     "Text",
     "Text",


### PR DESCRIPTION
bringing back unix epoch dateparsing was more complicated than I thought:
- previous algorithm was doing a regex check. It did not support fractional timestamp values, nor negative timestamps
- changed unix epoch dateparsing in qsv-dateparser. New logic available in qsv-dateparser 0.6.0
- `sniff`, which uses qsv-sniffer, which in turn depends on qsv-dateparser had to be updated as well
- it turned out `sniff` was not properly sniffing date type fields, always inferring datetime even for date fields, so upgraded qsv-sniffer does not only use qsv-dateparser 0.6.0, this bug was also fixed

This should completely resolve #682 as `apply datefmt`, `stats` and `sniff`, along with `stats`-dependent commands `schema` and `validate` should now properly support unix timestamp values when inferring data types