### PR TITLE
`validate`: schema less validation error improvements

### DIFF
--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -160,7 +160,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                 "detail" : format!("{e}")
                             }]
                         });
-                        return fail!(header_error.to_string());
+                        let json_error = if args.flag_pretty_json {
+                            serde_json::to_string_pretty(&header_error).unwrap()
+                        } else {
+                            header_error.to_string()
+                        };
+
+                        return fail!(json_error);
                     }
                     return fail_clierror!("Cannot read header ({e}).");
                 }
@@ -182,10 +188,20 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             "detail" : format!("Last valid row: {record_count} - {e}")
                         }]
                     });
-                    return fail!(validation_error.to_string());
+
+                    let json_error = if args.flag_pretty_json {
+                        serde_json::to_string_pretty(&validation_error).unwrap()
+                    } else {
+                        validation_error.to_string()
+                    };
+
+                    return fail!(json_error);
                 }
                 return fail_clierror!(
-                    r#"Validation error: {e}.\n Last valid row: {record_count}\nTry "qsv fixlengths" or "qsv fmt" to fix it."#
+                    r#"Validation error: {e}.
+Last valid row: {record_count}
+Use `qsv fixlengths` to fix record length issues.
+Use `qsv input` to fix formatting and to transcode to utf8 if required."#
                 );
             }
             record_count += 1;


### PR DESCRIPTION
when validating a CSV without a JSON schema, and checking if it conforms with RFC4180 standard:
- corrected CLI error suggestion to use `qsv input` to fix CSV formatting/encoding issues, rather than `qsv fmt`
- when `--pretty-json` option is set, also return errors as pretty-json