### PR TITLE
`tojsonl`: more robust boolean inferencing

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -564,7 +564,10 @@ impl Stats {
         if let Some(v) = self.minmax.as_mut() {
             if let Some(ts_val) = timestamp_val {
                 // TODO: is there a better, non-allocating way to do this?
-                v.add(t, ts_val.to_string().as_bytes());
+                // v.add(t, ts_val.to_string().as_bytes());
+                // informal benchmarking suggest itoa is a tad faster
+                let mut buffer = itoa::Buffer::new();
+                v.add(t, buffer.format(ts_val).as_bytes());
             } else {
                 v.add(t, sample);
             }

--- a/tests/test_tojsonl.rs
+++ b/tests/test_tojsonl.rs
@@ -24,6 +24,148 @@ fn tojsonl_simple() {
 }
 
 #[test]
+fn tojsonl_boolean() {
+    let wrk = Workdir::new("tojsonl");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col1", "col2"],
+            svec!["true", "Mark"],
+            svec!["false", "John"],
+            svec!["false", "Bob"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"col1":true,"col2":"Mark"}
+{"col1":false,"col2":"John"}
+{"col1":false,"col2":"Bob"}"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn tojsonl_not_boolean_case_sensitive() {
+    let wrk = Workdir::new("tojsonl");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col1", "col2"],
+            svec!["True", "Mark"],
+            svec!["False", "John"],
+            svec!["false", "Bob"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+
+    // not treated as boolean since col1's domain has three values
+    // True, False and false
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"col1":"True","col2":"Mark"}
+{"col1":"False","col2":"John"}
+{"col1":"false","col2":"Bob"}"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn tojsonl_is_boolean_case_sensitive() {
+    let wrk = Workdir::new("tojsonl");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col1", "col2"],
+            svec!["True", "Mark"],
+            svec!["False", "John"],
+            svec!["False", "Bob"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+
+    // this is treated as boolean since col1's domain has two values
+    // True and False
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"col1":true,"col2":"Mark"}
+{"col1":false,"col2":"John"}
+{"col1":false,"col2":"Bob"}"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn tojsonl_boolean_yes() {
+    let wrk = Workdir::new("tojsonl");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col1", "col2"],
+            svec!["yes", "Mark"],
+            svec!["no", "John"],
+            svec!["no", "Bob"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"col1":true,"col2":"Mark"}
+{"col1":false,"col2":"John"}
+{"col1":false,"col2":"Bob"}"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn tojsonl_boolean_null() {
+    let wrk = Workdir::new("tojsonl");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col1", "col2"],
+            svec!["true", "Mark"],
+            svec!["", "John"],
+            svec!["", "Bob"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"col1":true,"col2":"Mark"}
+{"col1":false,"col2":"John"}
+{"col1":false,"col2":"Bob"}"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn tojsonl_boolean_yes_null() {
+    let wrk = Workdir::new("tojsonl");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["col1", "col2"],
+            svec!["y", "Mark"],
+            svec!["", "John"],
+            svec!["", "Bob"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"col1":true,"col2":"Mark"}
+{"col1":false,"col2":"John"}
+{"col1":false,"col2":"Bob"}"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn tojsonl_nested() {
     let wrk = Workdir::new("tojsonl_nested");
     wrk.create(


### PR DESCRIPTION
- remove panic if column's domain has two values and one is null
- null is inferred as false if the other value is one of the valid true values (true, yes, y)
- added explanation of boolean inferencing in usage text
- added boolean inferencing tests

resolves #708 