### PR TITLE
Implement new command `diff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,8 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "csv-diff"
-version = "0.1.0-beta.0"
-source = "git+https://gitlab.com/janriemer/csv-diff?branch=additions-for-qsv#4f8cae2ece32c3987ef62489af7bd92c105f2ec4"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86823063631fc35d5099bdfa24800463558ff69f5891d0bfcc648c426febbec"
 dependencies = [
  "ahash 0.8.2",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "csv-diff"
 version = "0.1.0-beta.0"
-source = "git+https://gitlab.com/janriemer/csv-diff?branch=additions-for-qsv#085ea83267656cd2784bfcef4bcde20f71a4c42a"
+source = "git+https://gitlab.com/janriemer/csv-diff?branch=additions-for-qsv#4f8cae2ece32c3987ef62489af7bd92c105f2ec4"
 dependencies = [
  "ahash 0.8.2",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv-diff"
+version = "0.1.0-beta.0"
+source = "git+https://gitlab.com/janriemer/csv-diff?branch=additions-for-qsv#085ea83267656cd2784bfcef4bcde20f71a4c42a"
+dependencies = [
+ "ahash 0.8.2",
+ "crossbeam-channel",
+ "csv",
+ "mown",
+ "rayon",
+ "thiserror",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "csv-index"
 version = "0.1.6"
 source = "git+https://github.com/jqnatividad/rust-csv?branch=perf-tweaks#134a2a81f80f36afac1ed2d662a042317337e2f8"
@@ -2330,6 +2344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mown"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7627d8bbeb17edbf1c3f74b21488e4af680040da89713b4217d0010e9cbd97e"
+
+[[package]]
 name = "multiversion"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,6 +2924,7 @@ dependencies = [
  "crossbeam-channel",
  "csv",
  "csv-core",
+ "csv-diff",
  "csv-index",
  "csvs_convert",
  "data-encoding",
@@ -4506,6 +4527,12 @@ checksum = "21f7eb250da9497cc9c4ff55c01a436b8adde7e97c4f3f528bf1b0701af6435b"
 dependencies = [
  "libxlsxwriter-sys",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ cpc = { version = "1.9", optional = true }
 crossbeam-channel = "0.5"
 csv = "1.1"
 csv-core = "0.1"
+csv-diff = { git = "https://gitlab.com/janriemer/csv-diff", branch = "additions-for-qsv" }
 csv-index = "0.1"
 csvs_convert = { version = "0.7", optional = true }
 data-encoding = { version = "2.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ cpc = { version = "1.9", optional = true }
 crossbeam-channel = "0.5"
 csv = "1.1"
 csv-core = "0.1"
-csv-diff = { git = "https://gitlab.com/janriemer/csv-diff", branch = "additions-for-qsv" }
+csv-diff = "0.1.0-beta.1"
 csv-index = "0.1"
 csvs_convert = { version = "0.7", optional = true }
 data-encoding = { version = "2.3", optional = true }

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -38,14 +38,14 @@ use crate::{
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input_left: Option<String>,
-    arg_input_right: Option<String>,
-    flag_output: Option<String>,
-    flag_no_headers_left: bool,
+    arg_input_left:        Option<String>,
+    arg_input_right:       Option<String>,
+    flag_output:           Option<String>,
+    flag_no_headers_left:  bool,
     flag_no_headers_right: bool,
-    flag_delimiter_left: Option<Delimiter>,
-    flag_delimiter_right: Option<Delimiter>,
-    flag_primary_key_idx: Option<String>,
+    flag_delimiter_left:   Option<Delimiter>,
+    flag_delimiter_right:  Option<Delimiter>,
+    flag_primary_key_idx:  Option<String>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -109,7 +109,8 @@ impl<W: Write> CsvDiffWriter<W> {
                 rdr_bh.write_diffresult_header(&mut self.csv_writer)?;
                 // we also read the headers from the right CSV, so that both readers end up
                 // before the actual records. Otherwise, it would lead to errors when we
-                // diff the CSVs, because the header of one CSV would have been read and the other not.
+                // diff the CSVs, because the header of one CSV would have been read and the other
+                // not.
                 let _ = rdr_right.byte_headers()?;
             }
             (true, false) => {
@@ -153,7 +154,8 @@ impl<W: Write> CsvDiffWriter<W> {
             DiffByteRecord::Modify {
                 delete,
                 add,
-                // TODO: this should be used in the future to highlight the column where differences occur
+                // TODO: this should be used in the future to highlight the column where differences
+                // occur
                 field_indices: _field_indices,
             } => {
                 let mut vec_del = vec![remove_sign];

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -61,16 +61,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .checkutf8(false)
         .no_headers(args.flag_no_headers_right);
 
-    let primary_key_cols = args
-        .flag_primary_key_idx
-        .map(|s| {
-            s.split(',')
-                .map(|idx| idx.parse::<usize>())
-                .collect::<Result<Vec<_>, _>>()
-        })
-        .transpose()
-        .map_err(|err| CliError::Other(err.to_string()))?
-        .unwrap_or_else(|| vec![0]);
+    let primary_key_cols = match args.flag_primary_key_idx {
+        None => vec![0],
+        Some(s) => s
+            .split(',')
+            .map(|idx| idx.parse::<usize>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| CliError::Other(err.to_string()))?,
+    };
 
     let wtr = Config::new(&args.flag_output).writer()?;
     let mut csv_rdr_left = rconfig_left.reader()?;

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -141,9 +141,12 @@ impl<W: Write> CsvDiffWriter<W> {
     }
 
     fn write_diff_byte_record(&mut self, diff_byte_record: DiffByteRecord) -> csv::Result<()> {
+        let add_sign: &[u8] = &b"+"[..];
+        let remove_sign: &[u8] = &b"-"[..];
+
         match &diff_byte_record {
             DiffByteRecord::Add(add) => {
-                let mut vec = vec![&b"+"[..]];
+                let mut vec = vec![add_sign];
                 vec.extend(add.byte_record());
                 self.csv_writer.write_record(vec)
             }
@@ -153,16 +156,16 @@ impl<W: Write> CsvDiffWriter<W> {
                 // TODO: this should be used in the future to highlight the column where differences occur
                 field_indices: _field_indices,
             } => {
-                let mut vec_del = vec![&b"-"[..]];
+                let mut vec_del = vec![remove_sign];
                 vec_del.extend(delete.byte_record());
                 self.csv_writer.write_record(vec_del)?;
 
-                let mut vec_add = vec![&b"+"[..]];
+                let mut vec_add = vec![add_sign];
                 vec_add.extend(add.byte_record());
                 self.csv_writer.write_record(vec_add)
             }
             DiffByteRecord::Delete(del) => {
-                let mut vec = vec![&b"-"[..]];
+                let mut vec = vec![remove_sign];
                 vec.extend(del.byte_record());
                 self.csv_writer.write_record(vec)
             }

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -1,0 +1,192 @@
+static USAGE: &str = r#"
+Creates the difference between two CSVs.
+
+Usage:
+    qsv diff [options] [<input-left>] [<input-right>]
+    qsv diff --help
+
+Common options:
+    -h, --help                  Display this message
+    -o, --output <file>         Write output to <file> instead of stdout.
+    --no-headers-left           When set, the first row will be considered as part of
+                                the left CSV to diff. (When not set, the
+                                first row is the header row and will be skipped during
+                                the diff. It will always appear in the output.)
+    --no-headers-right          When set, the first row will be considered as part of
+                                the right CSV to diff. (When not set, the
+                                first row is the header row and will be skipped during
+                                the diff. It will always appear in the output.)
+    --delimiter-left <arg>      The field delimiter for reading CSV data on the left.
+                                Must be a single character. (default: ,)
+    --delimiter-right <arg>     The field delimiter for reading CSV data on the right.
+                                Must be a single character. (default: ,)
+    --primary-key-idx <arg...>  The column indices that uniquely identify a record
+                                as a comma separated list of indices, e.g. 0,1,2.
+                                (default: 0)
+"#;
+
+use std::io::{self, Read, Write};
+
+use csv_diff::{csv_diff::CsvByteDiffBuilder, diff_row::DiffByteRecord};
+use serde::Deserialize;
+
+use crate::{
+    clitypes::CliError,
+    config::{Config, Delimiter},
+    util, CliResult,
+};
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input_left: Option<String>,
+    arg_input_right: Option<String>,
+    flag_output: Option<String>,
+    flag_no_headers_left: bool,
+    flag_no_headers_right: bool,
+    flag_delimiter_left: Option<Delimiter>,
+    flag_delimiter_right: Option<Delimiter>,
+    flag_primary_key_idx: Option<String>,
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    let rconfig_left = Config::new(&args.arg_input_left)
+        .delimiter(args.flag_delimiter_left)
+        .checkutf8(false)
+        .no_headers(args.flag_no_headers_left);
+
+    let rconfig_right = Config::new(&args.arg_input_right)
+        .delimiter(args.flag_delimiter_right)
+        .checkutf8(false)
+        .no_headers(args.flag_no_headers_right);
+
+    let primary_key_cols = args
+        .flag_primary_key_idx
+        .map(|s| {
+            s.split(',')
+                .map(|idx| idx.parse::<usize>())
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()
+        .map_err(|err| CliError::Other(err.to_string()))?
+        .unwrap_or_else(|| vec![0]);
+
+    let wtr = Config::new(&args.flag_output).writer()?;
+    let mut csv_rdr_left = rconfig_left.reader()?;
+    let mut csv_rdr_right = rconfig_right.reader()?;
+
+    let mut csv_diff_writer = CsvDiffWriter::new(wtr);
+    csv_diff_writer.write_headers(&mut csv_rdr_left, &mut csv_rdr_right)?;
+
+    let csv_diff = CsvByteDiffBuilder::new()
+        .primary_key_columns(primary_key_cols)
+        .build()
+        // TODO: proper error handling
+        .expect("can instantiate");
+
+    let diff_byte_records_iter = csv_diff.diff(csv_rdr_left.into(), csv_rdr_right.into());
+
+    Ok(csv_diff_writer.write_diff_byte_records(diff_byte_records_iter)?)
+}
+
+struct CsvDiffWriter<W: Write> {
+    csv_writer: csv::Writer<W>,
+}
+
+impl<W: Write> CsvDiffWriter<W> {
+    pub fn new(csv_writer: csv::Writer<W>) -> Self {
+        Self { csv_writer }
+    }
+
+    pub fn write_headers<R: Read>(
+        &mut self,
+        rdr_left: &mut csv::Reader<R>,
+        rdr_right: &mut csv::Reader<R>,
+    ) -> csv::Result<()> {
+        match (rdr_left.has_headers(), rdr_right.has_headers()) {
+            (true, true) => {
+                let rdr_bh = rdr_left.byte_headers()?;
+
+                rdr_bh.write_diffresult_header(&mut self.csv_writer)?;
+                // we also read the headers from the right CSV, so that both readers end up
+                // before the actual records. Otherwise, it would lead to errors when we
+                // diff the CSVs, because the header of one CSV would have been read and the other not.
+                let _ = rdr_right.byte_headers()?;
+            }
+            (true, false) => {
+                let rdr_bh = rdr_left.byte_headers()?;
+
+                rdr_bh.write_diffresult_header(&mut self.csv_writer)?;
+            }
+            (false, true) => {
+                let rdr_bh = rdr_right.byte_headers()?;
+
+                rdr_bh.write_diffresult_header(&mut self.csv_writer)?;
+            }
+            (false, false) => {
+                // nothing to do, because there are no headers
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn write_diff_byte_records(
+        &mut self,
+        diff_byte_records: impl IntoIterator<Item = csv::Result<DiffByteRecord>>,
+    ) -> io::Result<()> {
+        for dbr in diff_byte_records {
+            self.write_diff_byte_record(dbr?)?;
+        }
+        Ok(self.csv_writer.flush()?)
+    }
+
+    fn write_diff_byte_record(&mut self, diff_byte_record: DiffByteRecord) -> csv::Result<()> {
+        match &diff_byte_record {
+            DiffByteRecord::Add(add) => {
+                let mut vec = vec![&b"+"[..]];
+                vec.extend(add.byte_record());
+                self.csv_writer.write_record(vec)
+            }
+            DiffByteRecord::Modify {
+                delete,
+                add,
+                // TODO: this should be used in the future to highlight the column where differences occur
+                field_indices: _field_indices,
+            } => {
+                let mut vec_del = vec![&b"-"[..]];
+                vec_del.extend(delete.byte_record());
+                self.csv_writer.write_record(vec_del)?;
+
+                let mut vec_add = vec![&b"+"[..]];
+                vec_add.extend(add.byte_record());
+                self.csv_writer.write_record(vec_add)
+            }
+            DiffByteRecord::Delete(del) => {
+                let mut vec = vec![&b"-"[..]];
+                vec.extend(del.byte_record());
+                self.csv_writer.write_record(vec)
+            }
+        }
+    }
+}
+
+trait WriteDiffResultHeader {
+    fn write_diffresult_header<W: Write>(&self, csv_writer: &mut csv::Writer<W>)
+        -> csv::Result<()>;
+}
+
+impl WriteDiffResultHeader for csv::ByteRecord {
+    fn write_diffresult_header<W: Write>(
+        &self,
+        csv_writer: &mut csv::Writer<W>,
+    ) -> csv::Result<()> {
+        if !self.is_empty() {
+            let mut new_header = vec![&b"diffresult"[..]];
+            new_header.extend(self);
+            csv_writer.write_record(new_header)?;
+        }
+        Ok(())
+    }
+}

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -68,15 +68,15 @@ type BoxedReader = csv::Reader<Box<dyn io::Read + 'static>>;
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input:       Option<String>,
-    arg_selection:   SelectColumns,
-    flag_output:     Option<String>,
+    arg_input: Option<String>,
+    arg_selection: SelectColumns,
+    flag_output: Option<String>,
     flag_no_headers: bool,
-    flag_delimiter:  Option<Delimiter>,
-    flag_groupby:    Option<SelectColumns>,
-    flag_first:      bool,
-    flag_backfill:   bool,
-    flag_default:    Option<String>,
+    flag_delimiter: Option<Delimiter>,
+    flag_groupby: Option<SelectColumns>,
+    flag_first: bool,
+    flag_backfill: bool,
+    flag_default: Option<String>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -162,7 +162,7 @@ impl GroupKeyConstructor for GroupKeySelection {
 
 #[derive(Debug)]
 struct GroupValues {
-    map:     AHashMap<usize, ByteString>,
+    map: AHashMap<usize, ByteString>,
     default: Option<ByteString>,
 }
 
@@ -217,12 +217,12 @@ impl GroupMemorizer for GroupValues {
 }
 
 struct Filler {
-    grouper:       Grouper,
-    groupby:       GroupKeySelection,
-    select:        Selection,
-    buffer:        GroupBuffer,
-    first:         bool,
-    backfill:      bool,
+    grouper: Grouper,
+    groupby: GroupKeySelection,
+    select: Selection,
+    buffer: GroupBuffer,
+    first: bool,
+    backfill: bool,
     default_value: Option<ByteString>,
 }
 
@@ -306,11 +306,11 @@ impl Filler {
 }
 
 struct MapSelected<I, F> {
-    selection:       Vec<usize>,
+    selection: Vec<usize>,
     selection_index: usize,
-    index:           usize,
-    iterator:        I,
-    predicate:       F,
+    index: usize,
+    iterator: I,
+    predicate: F,
 }
 
 impl<I: iter::Iterator, F> iter::Iterator for MapSelected<I, F>

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -68,15 +68,15 @@ type BoxedReader = csv::Reader<Box<dyn io::Read + Send + 'static>>;
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input: Option<String>,
-    arg_selection: SelectColumns,
-    flag_output: Option<String>,
+    arg_input:       Option<String>,
+    arg_selection:   SelectColumns,
+    flag_output:     Option<String>,
     flag_no_headers: bool,
-    flag_delimiter: Option<Delimiter>,
-    flag_groupby: Option<SelectColumns>,
-    flag_first: bool,
-    flag_backfill: bool,
-    flag_default: Option<String>,
+    flag_delimiter:  Option<Delimiter>,
+    flag_groupby:    Option<SelectColumns>,
+    flag_first:      bool,
+    flag_backfill:   bool,
+    flag_default:    Option<String>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -162,7 +162,7 @@ impl GroupKeyConstructor for GroupKeySelection {
 
 #[derive(Debug)]
 struct GroupValues {
-    map: AHashMap<usize, ByteString>,
+    map:     AHashMap<usize, ByteString>,
     default: Option<ByteString>,
 }
 
@@ -217,12 +217,12 @@ impl GroupMemorizer for GroupValues {
 }
 
 struct Filler {
-    grouper: Grouper,
-    groupby: GroupKeySelection,
-    select: Selection,
-    buffer: GroupBuffer,
-    first: bool,
-    backfill: bool,
+    grouper:       Grouper,
+    groupby:       GroupKeySelection,
+    select:        Selection,
+    buffer:        GroupBuffer,
+    first:         bool,
+    backfill:      bool,
     default_value: Option<ByteString>,
 }
 
@@ -306,11 +306,11 @@ impl Filler {
 }
 
 struct MapSelected<I, F> {
-    selection: Vec<usize>,
+    selection:       Vec<usize>,
     selection_index: usize,
-    index: usize,
-    iterator: I,
-    predicate: F,
+    index:           usize,
+    iterator:        I,
+    predicate:       F,
 }
 
 impl<I: iter::Iterator, F> iter::Iterator for MapSelected<I, F>

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -64,7 +64,7 @@ use crate::{
 
 type ByteString = Vec<u8>;
 type BoxedWriter = csv::Writer<Box<dyn io::Write + 'static>>;
-type BoxedReader = csv::Reader<Box<dyn io::Read + 'static>>;
+type BoxedReader = csv::Reader<Box<dyn io::Read + Send + 'static>>;
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -8,6 +8,7 @@ pub mod behead;
 pub mod cat;
 pub mod count;
 pub mod dedup;
+pub mod diff;
 #[cfg(any(feature = "full", feature = "lite"))]
 pub mod enumerate;
 pub mod excel;

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,7 +285,7 @@ impl Config {
         Ok(self.from_writer(self.io_writer()?))
     }
 
-    pub fn reader(&self) -> io::Result<csv::Reader<Box<dyn io::Read + 'static>>> {
+    pub fn reader(&self) -> io::Result<csv::Reader<Box<dyn io::Read + Send + 'static>>> {
         Ok(self.from_reader(self.io_reader()?))
     }
 
@@ -454,7 +454,7 @@ impl Config {
         }
     }
 
-    pub fn io_reader(&self) -> io::Result<Box<dyn io::Read + 'static>> {
+    pub fn io_reader(&self) -> io::Result<Box<dyn io::Read + Send + 'static>> {
         Ok(match self.path {
             None => {
                 if self.checkutf8 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,23 +69,23 @@ impl<'de> Deserialize<'de> for Delimiter {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct Config {
-    path: Option<PathBuf>, // None implies <stdin>
-    idx_path: Option<PathBuf>,
-    select_columns: Option<SelectColumns>,
-    delimiter: u8,
-    pub no_headers: bool,
-    flexible: bool,
-    terminator: csv::Terminator,
-    pub quote: u8,
-    quote_style: csv::QuoteStyle,
-    double_quote: bool,
-    escape: Option<u8>,
-    quoting: bool,
+    path:              Option<PathBuf>, // None implies <stdin>
+    idx_path:          Option<PathBuf>,
+    select_columns:    Option<SelectColumns>,
+    delimiter:         u8,
+    pub no_headers:    bool,
+    flexible:          bool,
+    terminator:        csv::Terminator,
+    pub quote:         u8,
+    quote_style:       csv::QuoteStyle,
+    double_quote:      bool,
+    escape:            Option<u8>,
+    quoting:           bool,
     pub preamble_rows: u64,
-    trim: csv::Trim,
-    autoindex: bool,
-    checkutf8: bool,
-    prefer_dmy: bool,
+    trim:              csv::Trim,
+    autoindex:         bool,
+    checkutf8:         bool,
+    prefer_dmy:        bool,
 }
 
 // Empty trait as an alias for Seek and Read that avoids auto trait errors

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,23 +69,23 @@ impl<'de> Deserialize<'de> for Delimiter {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct Config {
-    path:              Option<PathBuf>, // None implies <stdin>
-    idx_path:          Option<PathBuf>,
-    select_columns:    Option<SelectColumns>,
-    delimiter:         u8,
-    pub no_headers:    bool,
-    flexible:          bool,
-    terminator:        csv::Terminator,
-    pub quote:         u8,
-    quote_style:       csv::QuoteStyle,
-    double_quote:      bool,
-    escape:            Option<u8>,
-    quoting:           bool,
+    path: Option<PathBuf>, // None implies <stdin>
+    idx_path: Option<PathBuf>,
+    select_columns: Option<SelectColumns>,
+    delimiter: u8,
+    pub no_headers: bool,
+    flexible: bool,
+    terminator: csv::Terminator,
+    pub quote: u8,
+    quote_style: csv::QuoteStyle,
+    double_quote: bool,
+    escape: Option<u8>,
+    quoting: bool,
     pub preamble_rows: u64,
-    trim:              csv::Trim,
-    autoindex:         bool,
-    checkutf8:         bool,
-    prefer_dmy:        bool,
+    trim: csv::Trim,
+    autoindex: bool,
+    checkutf8: bool,
+    prefer_dmy: bool,
 }
 
 // Empty trait as an alias for Seek and Read that avoids auto trait errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,10 +73,10 @@ Options:
 
 #[derive(Deserialize)]
 struct Args {
-    arg_command:    Option<Command>,
-    flag_list:      bool,
-    flag_envlist:   bool,
-    flag_update:    bool,
+    arg_command: Option<Command>,
+    flag_list: bool,
+    flag_envlist: bool,
+    flag_update: bool,
     flag_updatenow: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ fn main() -> QsvExitCode {
     cat         Concatenate by row or column
     count       Count records
     dedup       Remove redundant rows
+    diff        Create the difference between two CSVs
     enum        Add a new column enumerating CSV lines
     excel       Exports an Excel sheet to a CSV
     exclude     Excludes the records in one CSV from another
@@ -261,6 +262,7 @@ enum Command {
     Cat,
     Count,
     Dedup,
+    Diff,
     Enum,
     Excel,
     Exclude,
@@ -333,6 +335,7 @@ impl Command {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
             Command::Dedup => cmd::dedup::run(argv),
+            Command::Diff => cmd::diff::run(argv),
             Command::Enum => cmd::enumerate::run(argv),
             Command::Excel => cmd::excel::run(argv),
             Command::Exclude => cmd::exclude::run(argv),

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,10 +73,10 @@ Options:
 
 #[derive(Deserialize)]
 struct Args {
-    arg_command: Option<Command>,
-    flag_list: bool,
-    flag_envlist: bool,
-    flag_update: bool,
+    arg_command:    Option<Command>,
+    flag_list:      bool,
+    flag_envlist:   bool,
+    flag_update:    bool,
     flag_updatenow: bool,
 }
 


### PR DESCRIPTION
The following items need to be resolved first, before this PR can be merged:
- [x] ~add tests~ will be added later (`csv-diff` itself already has > 50 tests)
- [x] ~document the new `diff` command in the docs~ there is no docs.rs - this project has explicitly decided against it and rather relies on the self documenting "Usage" from `docopt` (see comment below by @jqnatividad)
- [x] wait for the next release of `csv-diff` - ~this PR currently depends on the top of the following branch in `csv-diff`:
https://gitlab.com/janriemer/csv-diff/-/tree/additions-for-qsv~ with 5fe674b this now depends on 0.1.0-beta.1 of `csv-diff`.

Nevertheless, we open this PR, even though it is not finished, so that we can get early feedback on the implementation.

Closes #547

## Note to maintainers regarding kind of merge to be performed
I'd like this PR to __not__ be squash-merged, as I've spent a significant amount of time splitting the commits into atomic chunks. Thank you for considering this. :heart: 

## What this PR implements

This implements the new command `diff` for diffing two CSVs.
Usage is as follows:

```
Usage:
    qsv diff [options] [\<input-left\>] [\<input-right\>]
    qsv diff --help

Common options:

    -h, --help                  Display this message
    -o, --output <file>         Write output to <file> instead of stdout.
    --no-headers-left           When set, the first row will be considered as part of
                                the left CSV to diff. (When not set, the
                                first row is the header row and will be skipped during
                                the diff. It will always appear in the output.)
    --no-headers-right          When set, the first row will be considered as part of
                                the right CSV to diff. (When not set, the
                                first row is the header row and will be skipped during
                                the diff. It will always appear in the output.)
    --delimiter-left <arg>      The field delimiter for reading CSV data on the left.
                                Must be a single character. (default: ,)
    --delimiter-right <arg>     The field delimiter for reading CSV data on the right.
                                Must be a single character. (default: ,)
    --primary-key-idx <arg...>  The column indices that uniquely identify a record
                                as a comma separated list of indices, e.g. 0,1,2.
                                (default: 0)
```

## Examples

Diff csv_left.csv with csv_right.csv with default options and write the result to stdout:

`qsv diff path/to/csv_left.csv path/to/csv_right.csv`

Diff csv_left.csv with csv_right.csv and treat the first and third columns as unique keys for identifying a record. The result is written to the new file diffresult.csv:

`qsv diff --primary-key-idx 0,2 -o path/to/diffresult.csv path/to/csv_left.csv path/to/csv_right.csv`

The output of the diff command can look like the following:
```
diffresult,GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs
-,4,4,twitter.com,com,436953,2075089,twitter.com,com,4,4,436735,2077023
+,4,4,joinmastodon.org,org,436953,2075089,joinmastodon.org,org,4,4,436735,2077023
-,18,14,maps.google.com,com,203146,708101,maps.google.com,com,18,14,203197,708631
-,1,1,google.com,com,492918,2427561,google.com,com,1,1,492881,2429667
-,23,17,docs.google.com,com,184531,539376,docs.google.com,com,23,17,184740,540129
+,19,1,goo.gl,gl,200037,649215,goo.gl,gl,19,1,200069,649539
-,20,15,plus.google.com,com,198766,712276,plus.google.com,com,20,15,198784,713207
-,15,11,play.google.com,com,216317,611475,play.google.com,com,15,11,216267,612046
```
The diff result can be seen in the first column:
- "-" means that the record was deleted in the file on the right (can be seen after the first two records in the example output)
- "+" means that the record was added in the file on the right
- consecutive "-", "+", where the key columns are equal means the record was modified in some columns that were not key columns (this can be seen in the first two rows of the example output)

The following is an svg recording of a terminal, in which this new command `diff` is executed and `time`d on the majestic million csv with some artificial changes introduced. The CSVs have 1,000,000 rows x 12 columns:
https://gist.githubusercontent.com/janriemer/0e86a236a7174af6faed1b981815a5ea/raw/2ab235a2bdd5798f2348d42da48fdda276fb5f0f/qsv_diff_recording.svg

## New dependency `csv-diff`

The actual operation of diffing two CSVs is provided by the external crate `csv-diff`, so this uses this new dependency:
https://crates.io/crates/csv-diff (see also 90a7035, where this dependency is introduced)

`csv-diff` uses a default feature where a rayon thread pool is used. As `qsv` doesn't use a global thread pool, this feature might be unnecessarily activated in `csv-diff`. In future iterations this default feature should be considered to be disabled, but for now we leave it as is to make things simple.

Please keep in mind that `csv-diff` is in an early stage of development, so the new `diff` command should be considered __experimental__ for now.

## :warning: Current limitations

### If both CSVs have headers, they __must not__ be in a different ordering
=> see also these issues in `csv-diff`:
    - https://gitlab.com/janriemer/csv-diff/-/issues/6
    - https://gitlab.com/janriemer/csv-diff/-/issues/3

Currently, there is __no error happening__ in `qsv`, when the above scenario occurs, so the __diffresult will be wrong__. Until the issue is not resolved in `csv-diff`, it _should_ be fairly easy to check this in `qsv` itself and raise an error, if this is happening.

### Currently does not support any kind of indexing
Some other commands in `qsv` support indexing, which the new `diff` command does not support. This is due to how the diff is implemented in the underlying crate `csv-diff`.
It will probably be __very difficult__ to integrate an index into `csv-diff`, because it's architecture doesn't allow it. Having said that, the new `diff` command is __very fast__ (~800ms for the majestic million csv dataset with 1,000,000 rows x 12 columns - see above).

With that, it is probably the fastest csv differ in the world! :rocket: 

## Future work/enhancements

Besides the work that is needed for resolving some of the current limitations, there are other possibilities for improvement:
- Regarding the new column _diffresult_ that shows the result of the diff
  - provide an option to specify a different header name, as this might collide with an already existing column that has this header name
  - provide an option to specify whether the column _diffresult_ should be the first or last column in the result of the diff
- for modified rows
  - provide an option for marking the values that are actually different
Example (note the [-value-] and [+value+]):
```
diffresult,GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs
-,4,4,[-twitter.com-],[-com-],436953,2075089,[-twitter.com-],[-com-],4,4,436735,2077023
+,4,4,[+joinmastodon.org+],[+org+],436953,2075089,[+joinmastodon.org+],[+org+],4,4,436735,2077023
```