### PR TITLE
`stats`: `--typesonly` still require --infer-dates

### DIFF
--- a/resources/test/boston311-100-typesonly-withdates-stats.csv
+++ b/resources/test/boston311-100-typesonly-withdates-stats.csv
@@ -1,8 +1,8 @@
 field,type
 case_enquiry_id,Integer
-open_dt,String
-target_dt,String
-closed_dt,String
+open_dt,DateTime
+target_dt,DateTime
+closed_dt,DateTime
 ontime,String
 case_status,String
 closure_reason,String

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -56,7 +56,8 @@ stats options:
                               into 'qsv stats' will disable the use of indexing.
     --everything              Show all statistics available.
     --typesonly               Infer data types only and do not compute statistics.
-                              Automatically turns on --infer-dates for all columns.
+                              Note that if you want to infer dates, you'll still need to use
+                              the --infer-dates and --dates-whitelist options.
     --mode                    Show the mode/s & antimode/s. Multimodal-aware.
                               This requires loading all CSV data in memory.
     --cardinality             Show the cardinality.
@@ -173,8 +174,6 @@ static DMY_PREFERENCE: AtomicBool = AtomicBool::new(false);
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: Args = util::get_args(USAGE, argv)?;
     if args.flag_typesonly {
-        args.flag_infer_dates = true;
-        args.flag_dates_whitelist = String::from("all");
         args.flag_everything = false;
         args.flag_mode = false;
         args.flag_cardinality = false;

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -707,6 +707,25 @@ fn stats_typesonly() {
 }
 
 #[test]
+fn stats_typesonly_with_dates() {
+    let wrk = Workdir::new("stats_typesonly_with_dates");
+    let test_file = wrk.load_test_file("boston311-100.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--typesonly")
+        .arg("--infer-dates")
+        .arg("--dates-whitelist")
+        .arg("all")
+        .arg(test_file);
+
+    let got: String = wrk.stdout(&mut cmd);
+
+    let expected = wrk.load_test_resource("boston311-100-typesonly-withdates-stats.csv");
+
+    assert_eq!(got, expected.replace("\r\n", "\n").trim_end());
+}
+
+#[test]
 fn stats_leading_zero_handling() {
     let wrk = Workdir::new("stats");
 


### PR DESCRIPTION
instead of automatically turning on --infer-dates for all fields. Give the user the option to fine-tune type inference.