### PR TITLE
`headers`: trim quote and space with `--trim` option

### DIFF
--- a/src/cmd/headers.rs
+++ b/src/cmd/headers.rs
@@ -19,6 +19,7 @@ headers options:
                            input is given.
     --intersect            Shows the intersection of all headers in all of
                            the inputs given.
+    --trim                 Trim space & quote characters from header name.
 
 Common options:
     -h, --help             Display this message
@@ -38,6 +39,7 @@ struct Args {
     arg_input:       Vec<String>,
     flag_just_names: bool,
     flag_intersect:  bool,
+    flag_trim:       bool,
     flag_delimiter:  Option<Delimiter>,
 }
 
@@ -65,7 +67,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         if num_inputs == 1 && !args.flag_just_names {
             write!(&mut wtr, "{}\t", i + 1)?;
         }
-        wtr.write_all(&header)?;
+        if args.flag_trim {
+            wtr.write_all(
+                std::string::String::from_utf8_lossy(&header)
+                    .trim_matches(|c| c == '"' || c == ' ')
+                    .as_bytes(),
+            )?;
+        } else {
+            wtr.write_all(&header)?;
+        }
         wtr.write_all(b"\n")?;
     }
     wtr.flush()?;

--- a/tests/test_headers.rs
+++ b/tests/test_headers.rs
@@ -40,6 +40,112 @@ h2";
 }
 
 #[test]
+fn headers_notrim() {
+    let wrk = Workdir::new("headers_notrim");
+
+    // headers taken from malformed CSV example - cities.csv at
+    // https://people.sc.fsu.edu/~jburkardt/data/csv/csv.html
+    wrk.create(
+        "data.csv",
+        vec![
+            svec![
+                "\"LatD\"",
+                "\"LatM\"",
+                "\"LatS\"",
+                "\"NS\"",
+                "\"LonD\"",
+                "\"LonM\"",
+                "\"LonS\"",
+                "\"EW\"",
+                "\"City\"",
+                "\"State\""
+            ],
+            svec![
+                "41",
+                "5",
+                "59",
+                "N",
+                "80",
+                "39",
+                "0",
+                "W",
+                "Youngstown",
+                "OH"
+            ],
+        ],
+    );
+
+    let mut cmd = wrk.command("headers");
+    cmd.arg("data.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"1   "LatD"
+2   "LatM"
+3   "LatS"
+4   "NS"
+5   "LonD"
+6   "LonM"
+7   "LonS"
+8   "EW"
+9   "City"
+10  "State""#;
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn headers_trim() {
+    let wrk = Workdir::new("headers_trim");
+
+    // headers taken from malformed CSV example - cities.csv at
+    // https://people.sc.fsu.edu/~jburkardt/data/csv/csv.html
+    wrk.create(
+        "data.csv",
+        vec![
+            svec![
+                "\"LatD\"",
+                "\"LatM\"",
+                "\"LatS\"",
+                "\"NS\"",
+                "\"LonD\"",
+                "\"LonM\"",
+                "\"LonS\"",
+                "\"EW\"",
+                "\"City\"",
+                "\"State\""
+            ],
+            svec![
+                "41",
+                "5",
+                "59",
+                "N",
+                "80",
+                "39",
+                "0",
+                "W",
+                "Youngstown",
+                "OH"
+            ],
+        ],
+    );
+
+    let mut cmd = wrk.command("headers");
+    cmd.arg("--trim").arg("data.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"1   LatD
+2   LatM
+3   LatS
+4   NS
+5   LonD
+6   LonM
+7   LonS
+8   EW
+9   City
+10  State"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn headers_multiple() {
     let (wrk, mut cmd) = setup("headers_multiple");
     cmd.arg("in2.csv");


### PR DESCRIPTION
Unfortunately, when googling for "example CSV", one of the top-ranking results is https://people.sc.fsu.edu/~jburkardt/data/csv/csv.html which has all malformed CSVs, with headers with confusing leading/trailing spacing and quoting.

It still parses, but the resulting headers have excess space/quote characters that are valid, but "look" wrong.

The `--trim` option trims these excess space/quote characters so they "look" right.
