### PR TITLE
`input`: `--trim-headers` option also removes excess quotes

### DIFF
--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -31,7 +31,7 @@ input options:
                              skips them. Takes precedence over --skip-lines option.
                              Does not work with <stdin>.
     --skip-lastlines <arg>   The number of epilog lines to skip.
-    --trim-headers           Trim leading & trailing whitespace from header values.
+    --trim-headers           Trim leading & trailing whitespace & quotes from header values.
     --trim-fields            Trim leading & trailing whitespace from field values.
 
 Common options:
@@ -141,7 +141,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         row.trim();
 
         for field in row.iter() {
-            str_row.push_field(&String::from_utf8_lossy(field));
+            // we also trim excess quotes from the header, to be consistent with safenames
+            str_row.push_field(String::from_utf8_lossy(field).trim_matches('"'));
         }
         wtr.write_record(&str_row)?;
     }

--- a/tests/test_input.rs
+++ b/tests/test_input.rs
@@ -258,3 +258,130 @@ fn test_input_both_skip_flexible() {
     ];
     assert_eq!(got, expected);
 }
+
+#[test]
+fn input_noheadertrim() {
+    let wrk = Workdir::new("input_noheadertrim");
+
+    // headers taken from malformed CSV example - cities.csv at
+    // https://people.sc.fsu.edu/~jburkardt/data/csv/csv.html
+    wrk.create(
+        "data.csv",
+        vec![
+            svec![
+                "\"LatD\"",
+                "\"LatM\"",
+                "\"LatS\"",
+                "\"NS\"",
+                "\"LonD\"",
+                "\"LonM\"",
+                "\"LonS\"",
+                "\"EW\"",
+                "\"City\"",
+                "\"State\""
+            ],
+            svec![
+                "41",
+                "5",
+                "59",
+                "N",
+                "80",
+                "39",
+                "0",
+                "W",
+                "Youngstown",
+                "OH"
+            ],
+        ],
+    );
+
+    let mut cmd = wrk.command("input");
+    cmd.arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![
+            "\"LatD\"",
+            "\"LatM\"",
+            "\"LatS\"",
+            "\"NS\"",
+            "\"LonD\"",
+            "\"LonM\"",
+            "\"LonS\"",
+            "\"EW\"",
+            "\"City\"",
+            "\"State\""
+        ],
+        svec![
+            "41",
+            "5",
+            "59",
+            "N",
+            "80",
+            "39",
+            "0",
+            "W",
+            "Youngstown",
+            "OH"
+        ],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn input_headertrim() {
+    let wrk = Workdir::new("input_headertrim");
+
+    // headers taken from malformed CSV example - cities.csv at
+    // https://people.sc.fsu.edu/~jburkardt/data/csv/csv.html
+    wrk.create(
+        "data.csv",
+        vec![
+            svec![
+                "\"LatD\"",
+                "\"LatM\"",
+                "\"LatS\"",
+                "\"NS\"",
+                "\"LonD\"",
+                "\"LonM\"",
+                "\"LonS\"",
+                "\"EW\"",
+                "\"City\"",
+                "\"State\""
+            ],
+            svec![
+                "41",
+                "5",
+                "59",
+                "N",
+                "80",
+                "39",
+                "0",
+                "W",
+                "Youngstown",
+                "OH"
+            ],
+        ],
+    );
+
+    let mut cmd = wrk.command("input");
+    cmd.arg("--trim-headers").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["LatD", "LatM", "LatS", "NS", "LonD", "LonM", "LonS", "EW", "City", "State"],
+        svec![
+            "41",
+            "5",
+            "59",
+            "N",
+            "80",
+            "39",
+            "0",
+            "W",
+            "Youngstown",
+            "OH"
+        ],
+    ];
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
to be consistent with `safenames` and `headers`