### PR TITLE
`sniff`: add --delimiter option

### DIFF
--- a/resources/test/test_sniff_delimiter.csv
+++ b/resources/test/test_sniff_delimiter.csv
@@ -1,0 +1,11 @@
+field,type,sum,min,max,range,min_length,max_length,mean,stddev,variance,nullcount,sparsity,cardinality
+LatD,String,,   26,   50,,5,5,,,,0,0.0,25
+LatM,String,,    1,   59,,5,5,,,,0,0.0,51
+LatS,String,,    0,   59,,5,5,,,,0,0.0,10
+NS,String,," ""N"""," ""N""",,4,4,,,,0,0.0,1
+LonD,String,,     71,    123,,7,7,,,,0,0.0,44
+LonM,String,,    0,   58,,5,5,,,,0,0.0,53
+LonS,String,,    0,   59,,5,5,,,,0,0.0,10
+EW,String,," ""W"""," ""W""",,4,4,,,,0,0.0,1
+City,String,," ""Ravenna"""," ""Youngstown""",,7,21,,,,0,0.0,120
+State,String,, AL, WY,,3,4,,,,0,0.0,47

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -283,3 +283,17 @@ fn sniff_prefer_dmy() {
 
     assert_eq!(got, expected);
 }
+
+#[test]
+fn sniff_flaky_delimiter_guess() {
+    let wrk = Workdir::new("sniff_flaky_delimiter_guess");
+    let test_file = wrk.load_test_file("test_sniff_delimiter.csv");
+
+    let mut cmd = wrk.command("sniff");
+    cmd.arg("--delimiter").arg(",").arg(test_file);
+
+    // this should  ALWAYS succeed since we explicitly set the delimiter to ','
+    // about 40% OF the time for this specific file, the delimiter guesser will
+    // guess the wrong delimiter if we don't explicitly set it.
+    wrk.assert_success(&mut cmd);
+}


### PR DESCRIPTION
Specify this when the delimiter is known beforehand (e.g. in qsv data pipelines), as the delimiter guessing algorithm can sometimes be wrong if not enough delimiters are present in the sample.
