### PR TITLE
`apply`: add decimal separator --replacement option to thousands operation

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -24,7 +24,7 @@ number of transformed columns with the --rename option is the same. e.g.:
 
 $ qsv apply operations trim,upper col1,col2,col3 -r newcol1,newcol2,newcol3 file.csv
 
-It has 34 supported operations:
+It has 35 supported operations:
 
   * len: Return string length
   * lower: Transform to lowercase

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -22,7 +22,7 @@ applied in order:
 Operations support multi-column transformations. Just make sure the
 number of transformed columns with the --rename option is the same. e.g.:
 
-$ qsv apply operations trim,upper col1,col2,col3 -r newcol1,newcol2,newcol3 file.csv  
+$ qsv apply operations trim,upper col1,col2,col3 -r newcol1,newcol2,newcol3 file.csv
 
 It has 34 supported operations:
 
@@ -49,9 +49,9 @@ It has 34 supported operations:
       https://daringfireball.net/2008/05/title_case
   * censor: profanity filter. Add additional comma-delimited profanities with --comparand.
   * censor_check: check if profanity is detected (boolean).
-      Add additional comma-delimited profanities with -comparand. 
+      Add additional comma-delimited profanities with -comparand.
   * censor_count: count of profanities detected.
-      Add additional comma-delimited profanities with -comparand. 
+      Add additional comma-delimited profanities with -comparand.
   * thousands: Add thousands separator to numeric values.
       Specify the separator policy with --comparand (default: comma). The valid policies are:
       comma, dot, space, underscore, hex_four (place a space every four hex digits) and
@@ -93,7 +93,7 @@ Trim, then transform to uppercase the surname field and rename the column upperc
 
   $ qsv apply operations trim,upper surname -r uppercase_clean_surname file.csv
 
-Trim, then transform to uppercase the surname field and 
+Trim, then transform to uppercase the surname field and
 save it to a new column named uppercase_clean_surname.
 
   $ qsv apply operations trim,upper surname -c uppercase_clean_surname file.csv
@@ -101,7 +101,7 @@ save it to a new column named uppercase_clean_surname.
 Trim, then transform to uppercase the firstname and surname fields and
 rename the columns ufirstname and usurname.
 
-  $ qsv apply operations trim,upper firstname,surname -r ufirstname,usurname file.csv  
+  $ qsv apply operations trim,upper firstname,surname -r ufirstname,usurname file.csv
 
 Trim parentheses & brackets from the description field.
 
@@ -147,7 +147,7 @@ Replace empty cells in file.csv Measurement column with 'Unknown Measurement'.
 $ qsv apply emptyreplace --replacement 'Unknown Measurement' file.csv
 
 DATEFMT
-Formats a recognized date column to a specified format using <--formatstr>. 
+Formats a recognized date column to a specified format using <--formatstr>.
 See https://github.com/jqnatividad/belt/tree/main/dateparser#accepted-date-formats for
 recognized date formats.
 See https://docs.rs/chrono/latest/chrono/format/strftime/ for 
@@ -201,7 +201,7 @@ Create a new column 'FullName' from 'FirstName', 'MI', and 'LastName' columns:
 GEOCODE
 Geocodes to the nearest city center point given a location column
 [i.e. a column which contains a latitude, longitude WGS84 coordinate] against
-an embedded copy of the Geonames city database. 
+an embedded copy of the Geonames city database.
 
 The geocoded information is formatted based on --formatstr, returning
 it in 'city-state' format if not specified.
@@ -298,7 +298,7 @@ apply options:
                                 GEOCODE: the place format to use with the geocode subcommand.
                                   The available formats are:
                                   - 'city-state' (default) - e.g. Brooklyn, New York
-                                  - 'city-country' - Brooklyn, US 
+                                  - 'city-country' - Brooklyn, US
                                   - 'city-state-country' | 'city-admin1-country' - Brooklyn, New York US
                                   - 'city' - Brooklyn
                                   - 'county' | 'admin2' - Kings County

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1371,6 +1371,85 @@ fn apply_ops_thousands_indiancomma() {
 }
 
 #[test]
+fn apply_ops_thousands_eurostyle() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["number"],
+            svec!["123456789"],
+            svec!["123456789.12345678"],
+            svec!["123456789.0"],
+            svec!["123456789.123"],
+            svec!["12345123456789.123"],
+            svec!["0"],
+            svec!["5"],
+            svec!["not a number, should be ignored"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("thousands")
+        .arg("number")
+        .args(["--comparand", "dot"])
+        .args(["--replacement", ","])
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["number"],
+        svec!["123.456.789"],
+        svec!["123.456.789,12345678"],
+        svec!["123.456.789"],
+        svec!["123.456.789,123"],
+        svec!["12.345.123.456.789,123"],
+        svec!["0"],
+        svec!["5"],
+        svec!["not a number, should be ignored"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_ops_thousands_hexfour() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["number"],
+            svec!["123456789"],
+            svec!["123456789.12345678"],
+            svec!["123456789.0"],
+            svec!["123456789.123"],
+            svec!["12345123456789.123"],
+            svec!["0"],
+            svec!["5"],
+            svec!["not a number, should be ignored"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("thousands")
+        .arg("number")
+        .args(["--comparand", "hexfour"])
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["number"],
+        svec!["1 2345 6789"],
+        svec!["1 2345 6789.12345678"],
+        svec!["1 2345 6789"],
+        svec!["1 2345 6789.123"],
+        svec!["12 3451 2345 6789.123"],
+        svec!["0"],
+        svec!["5"],
+        svec!["not a number, should be ignored"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn apply_ops_currencytonum() {
     let wrk = Workdir::new("apply");
     wrk.create(


### PR DESCRIPTION
for "euro-style" separated number formatting (e.g. 1.234.567.890,12 instead of 1,234,567,890.12)