### PR TITLE
`apply`: add round operation; also refactored thousands operation

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -928,3 +928,23 @@ impl ColumnNameParser {
         name
     }
 }
+
+pub fn round_num(dec_f64: f64, places: u32) -> String {
+    use rust_decimal::prelude::*;
+
+    // use from_f64_retain, so we have all the excess bits before rounding with
+    // round_dp_with_strategy as from_f64 will prematurely round when it drops the excess bits
+    let Some(dec_num) = Decimal::from_f64_retain(dec_f64) else {
+        let msg = format!(r#"Failed to convert to decimal "{dec_f64}""#);
+        log::error!("{msg}");
+        return msg;
+    };
+
+    // round using Midpoint Nearest Even Rounding Strategy AKA "Bankers Rounding."
+    // https://docs.rs/rust_decimal/latest/rust_decimal/enum.RoundingStrategy.html#variant.MidpointNearestEven
+    // we also normalize to remove trailing zeroes and to change -0.0 to 0.0.
+    dec_num
+        .round_dp_with_strategy(places, RoundingStrategy::MidpointNearestEven)
+        .normalize()
+        .to_string()
+}

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1316,7 +1316,7 @@ fn apply_ops_thousands_space() {
     cmd.arg("operations")
         .arg("thousands")
         .arg("number")
-        .args(["--comparand", "space"])
+        .args(["--formatstr", "space"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1353,7 +1353,7 @@ fn apply_ops_thousands_indiancomma() {
     cmd.arg("operations")
         .arg("thousands")
         .arg("number")
-        .args(["--comparand", "indiancomma"])
+        .args(["--formatstr", "indiancomma"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1391,7 +1391,7 @@ fn apply_ops_thousands_eurostyle() {
     cmd.arg("operations")
         .arg("thousands")
         .arg("number")
-        .args(["--comparand", "dot"])
+        .args(["--formatstr", "dot"])
         .args(["--replacement", ","])
         .arg("data.csv");
 
@@ -1431,7 +1431,7 @@ fn apply_ops_thousands_hexfour() {
     cmd.arg("operations")
         .arg("thousands")
         .arg("number")
-        .args(["--comparand", "hexfour"])
+        .args(["--formatstr", "hexfour"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1442,6 +1442,85 @@ fn apply_ops_thousands_hexfour() {
         svec!["1 2345 6789"],
         svec!["1 2345 6789.123"],
         svec!["12 3451 2345 6789.123"],
+        svec!["0"],
+        svec!["5"],
+        svec!["not a number, should be ignored"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_ops_round() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["number"],
+            svec!["123456789"],
+            svec!["123456789.12345678"],
+            svec!["123456789.0"],
+            svec!["123456789.123"],
+            svec!["123456789.12398"],
+            svec!["0"],
+            svec!["5"],
+            svec!["not a number, should be ignored"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("round")
+        .arg("number")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["number"],
+        svec!["123456789"],
+        svec!["123456789.123"],
+        svec!["123456789"],
+        svec!["123456789.123"],
+        svec!["123456789.124"],
+        svec!["0"],
+        svec!["5"],
+        svec!["not a number, should be ignored"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_ops_round_5places() {
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["number"],
+            svec!["123456789"],
+            svec!["123456789.12345678"],
+            svec!["123456789.0"],
+            svec!["123456789.123"],
+            svec!["123456789.1239876"],
+            svec!["123456789.1239844"],
+            svec!["0"],
+            svec!["5"],
+            svec!["not a number, should be ignored"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("round")
+        .args(["--formatstr", "5"])
+        .arg("number")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["number"],
+        svec!["123456789"],
+        svec!["123456789.12346"],
+        svec!["123456789"],
+        svec!["123456789.123"],
+        svec!["123456789.12399"],
+        svec!["123456789.12398"],
         svec!["0"],
         svec!["5"],
         svec!["not a number, should be ignored"],


### PR DESCRIPTION
resolves #750 

Also refactored thousands operation to use the more appropriate `--formatstr` option instead of the `--comparand` option to specify the "format" of the thousands separator policy.

Also changed `validate_operations` args from &String to non-allocating &str.