### PR TITLE
`safenames`: refactor

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -528,7 +528,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             return fail!("dynfmt/calcconv subcommand requires headers.");
         }
         // first, get the fields used in the dynfmt template
-        let (safe_headers, _) = util::safe_header_names(&headers, false, false, &Vec::new(), "");
+        let (safe_headers, _) = util::safe_header_names(&headers, false, false, None, "");
         let formatstr_re: &'static Regex = crate::regex_once_cell!(r"\{(?P<key>\w+)?\}");
         for format_fields in formatstr_re.captures_iter(&args.flag_formatstr) {
             dynfmt_fields.push(format_fields.name("key").unwrap().as_str());

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -393,8 +393,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         dynfmt_url_template = url_template.to_string();
         // first, get the fields used in the url template
-        let (safe_headers, _) =
-            util::safe_header_names(&str_headers, false, false, &Vec::new(), "");
+        let (safe_headers, _) = util::safe_header_names(&str_headers, false, false, None, "");
         let formatstr_re: &'static Regex = regex_once_cell!(r"\{(?P<key>\w+)?\}");
         for format_fields in formatstr_re.captures_iter(url_template) {
             dynfmt_fields.push(format_fields.name("key").unwrap().as_str());

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -231,7 +231,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     // ensure col/header names are valid and safe python variables
-    let (header_vec, _) = util::safe_header_names(&headers, true, false, &Vec::new(), "");
+    let (header_vec, _) = util::safe_header_names(&headers, true, false, None, "_");
 
     // amortize memory allocation by reusing record
     #[allow(unused_assignments)]

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -530,7 +530,8 @@ fn py_format_header_with_invalid_chars() {
     cmd.arg("map")
         .arg("formatted")
         .arg(
-            "f'{qty_fruit_day} {_fruit} cost ${(float(unit_cost_usd) * float(qty_fruit_day)):.2f}'",
+            "f'{qty_fruit_day} {_1fruit} cost ${(float(unit_cost_usd) * \
+             float(qty_fruit_day)):.2f}'",
         )
         .arg("data.csv");
 


### PR DESCRIPTION
- better handling of headers that start with a digit, instead of replacing the digit with a _, prepend the unsafe prefix
- quoted identifiers are also considered unsafe, unless conditional mode is used
- verbose modes now also return a list of duplicate header names
- all modes now use the same safenames algorithm. better the verbose modes used a simpler one leading to inconsistencies between modes (resolves #753)
