### PR TITLE
new `extdedup` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ log = "0.4"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 mlua = { version = "0.8", features = ["luau"], optional = true }
 num_cpus = "1"
+odht = "0.3"
 once_cell = { version = "1.17", features = ["parking_lot"] }
 parking_lot = { version = "0.12", features = ["hardware-lock-elision"] }
 pyo3 = { version = "0.18", features = ["auto-initialize"], optional = true }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 </div>
 
-> ℹ️ **NOTE:** qsv is a fork of the popular [xsv](https://github.com/BurntSushi/xsv) utility, merging several pending PRs [since xsv 0.13.0's May 2018 release](https://github.com/BurntSushi/xsv/issues/267). On top of xsv's 20 commands, it adds numerous new features; 30 additional commands; 6 `apply` subcommands & 35 operations; and 5 `to` subcommands (for a total of 96).
+> ℹ️ **NOTE:** qsv is a fork of the popular [xsv](https://github.com/BurntSushi/xsv) utility, merging several pending PRs [since xsv 0.13.0's May 2018 release](https://github.com/BurntSushi/xsv/issues/267). On top of xsv's 20 commands, it adds numerous new features; 31 additional commands; 6 `apply` subcommands & 35 operations; and 5 `to` subcommands (for a total of 97).
 See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for more details.
 
 ## Available commands
@@ -32,12 +32,13 @@ See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for mor
 | [behead](/src/cmd/behead.rs#L2) | Drop headers from a CSV.  |
 | [cat](/src/cmd/cat.rs#L2) | Concatenate CSV files by row or by column. |
 | [count](/src/cmd/count.rs#L2)<br>📇 | Count the rows in a CSV file. (Instantaneous with an index.) |
-| [dedup](/src/cmd/dedup.rs#L2)<br>🗜️🚀 | Remove duplicate rows (See also `extsort`, `sort` & `sortcheck` commands). |
+| [dedup](/src/cmd/dedup.rs#L2)<br>🗜️🚀 | Remove duplicate rows (See also `extdedup`, `extsort`, `sort` & `sortcheck` commands). |
 | [diff](/src/cmd/diff.rs#L2)<br>🚀 | Find the difference between two CSVs with ludicrous speed!<br/>e.g. *compare two CSVs with 1M rows x 9 columns in under 600ms!* |
 | [enum](/src/cmd/enumerate.rs#L2) | Add a new column enumerating rows by adding a column of incremental or uuid identifiers. Can also be used to copy a column or fill a new column with a constant value.  |
 | [excel](/src/cmd/excel.rs#L2) | Exports a specified Excel/ODS sheet to a CSV file. |
 | [exclude](/src/cmd/exclude.rs#L2)<br>📇 | Removes a set of CSV data from another set based on the specified columns.  |
 | [explode](/src/cmd/explode.rs#L2) | Explode rows into multiple ones by splitting a column value based on the given separator.  |
+| [extdedup](/src/cmd/extdedup.rs#L2)<br> | Remove duplicate rows from an arbitrarily large CSV/text file using a memory-mapped, on-disk hash table. Unlike the 'dedup' command, this command does not load the entire file into memory nor does it sort the deduped file. |
 | [extsort](/src/cmd/extsort.rs#L2)<br>🚀 | Sort an arbitrarily large CSV/text file using a multithreaded [external merge sort](https://en.wikipedia.org/wiki/External_sorting) algorithm. |
 | [fetch](/src/cmd/fetch.rs#L3)<br>❇️🧠 | Fetches data from web services for every row using **HTTP Get**. Comes with [HTTP/2](https://http2-explained.haxx.se/en/part1) [adaptive flow control](https://medium.com/coderscorner/http-2-flow-control-77e54f7fd518), [jql](https://github.com/yamafaktory/jql#%EF%B8%8F-usage) JSON query language support, dynamic throttling ([RateLimit](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html)) & caching with optional [Redis](https://redis.io/) support for persistent caching. |
 | [fetchpost](/src/cmd/fetchpost.rs#L3)<br>❇️🧠 | Similar to `fetch`, but uses **HTTP Post**. ([HTTP GET vs POST methods](https://www.geeksforgeeks.org/difference-between-http-get-and-post-methods/)) |

--- a/src/cmd/extdedup.rs
+++ b/src/cmd/extdedup.rs
@@ -1,0 +1,149 @@
+static USAGE: &str = r#"
+Remove duplicate rows from an arbitrarily large CSV/text file using a memory-mapped,
+on-disk hash table.
+
+Unlike the 'dedup' command, this command does not load the entire file into memory
+to sort the CSV first before deduping it. 
+
+This allows it to run in constant memory and the output will retain the input sort order.
+
+Also, this command is not specific to CSV data, it deduplicates any text file on a 
+line-by-line basis.
+
+A duplicate count will be sent to <stderr>.
+
+Usage:
+    qsv extdedup [options] [<input>] [<output>]
+    qsv extdedup --help
+
+extdedup options:
+    --no-output                Do not write deduplicated output to <output>.
+                               Use this if you only want to know the duplicate count.
+    -D, --dupes-output <file>  Write duplicates to <file>.
+    -H, --human-readable       Comma separate duplicate count.
+    --memory-limit <arg>       The maximum amount of memory to buffer the on-disk hash table.
+                               This is a percentage of total memory. (default: 10)
+                               Note that this is not a hard limit, the actual memory used
+                               may be slightly higher than this value.
+
+Common options:
+    -h, --help                 Display this message
+"#;
+
+use std::{
+    fs,
+    io::{self, prelude::*, stdin, stdout},
+};
+
+use serde::Deserialize;
+use sysinfo::{System, SystemExt};
+use thousands::Separable;
+
+use crate::{config, odhtcache, util, CliResult};
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input:           Option<String>,
+    arg_output:          Option<String>,
+    flag_no_output:      bool,
+    flag_dupes_output:   Option<String>,
+    flag_human_readable: bool,
+    flag_memory_limit:   Option<u8>,
+}
+
+const MEMORY_LIMITED_BUFFER: u64 = 100 * 1_000_000; // 100 MB
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    // memory buffer to use for on-disk hash table,
+    // if we can detect the total memory, use 10% of it by default
+    // and up to --memory-limit (capped at 50%),
+    // otherwise, if we cannot detect the free memory use a default of 100 MB
+    let mem_limited_buffer = if System::IS_SUPPORTED {
+        let mut sys = System::new_all();
+        sys.refresh_memory();
+        (sys.total_memory() * 1000) / u8::min(args.flag_memory_limit.unwrap_or(10), 50) as u64
+    } else {
+        MEMORY_LIMITED_BUFFER
+    };
+    log::info!("{mem_limited_buffer} bytes used for memory buffer for on-disk hash table...");
+
+    let input_reader: Box<dyn BufRead> = match &args.arg_input {
+        Some(input_path) => {
+            let file = fs::File::open(input_path)?;
+            Box::new(io::BufReader::with_capacity(
+                config::DEFAULT_RDR_BUFFER_CAPACITY,
+                file,
+            ))
+        }
+        None => Box::new(io::BufReader::new(stdin().lock())),
+    };
+
+    let mut output_writer: Box<dyn Write> = match &args.arg_output {
+        Some(output_path) => Box::new(io::BufWriter::with_capacity(
+            config::DEFAULT_WTR_BUFFER_CAPACITY,
+            fs::File::create(output_path)?,
+        )),
+        None => Box::new(io::BufWriter::with_capacity(
+            config::DEFAULT_WTR_BUFFER_CAPACITY,
+            stdout().lock(),
+        )),
+    };
+
+    let mut write_dupes = false;
+    let mut dupes_writer = if let Some(dupes_output) = args.flag_dupes_output {
+        write_dupes = true;
+        io::BufWriter::with_capacity(
+            config::DEFAULT_WTR_BUFFER_CAPACITY,
+            fs::File::create(dupes_output)?,
+        )
+    } else {
+        io::BufWriter::with_capacity(
+            config::DEFAULT_WTR_BUFFER_CAPACITY,
+            fs::File::create("/dev/null")?,
+        )
+    };
+
+    let mut dedup_cache = odhtcache::Cache::new(mem_limited_buffer.try_into().unwrap());
+
+    let mut dupes_count = 0_u64;
+    for line in input_reader.lines() {
+        let line = line?;
+        if dedup_cache.contains(&line) {
+            dupes_count += 1;
+            if write_dupes {
+                dupes_writer.write_all(format!("{}\t{}\n", dupes_count, line).as_bytes())?;
+            }
+        } else {
+            dedup_cache.insert(&line.clone());
+            if args.flag_no_output {
+                continue;
+            }
+            output_writer.write_all(format!("{}\n", line).as_bytes())?;
+        }
+    }
+
+    dupes_writer.flush()?;
+    output_writer.flush()?;
+
+    eprintln!(
+        "{}",
+        if args.flag_human_readable {
+            dupes_count.separate_with_commas()
+        } else {
+            dupes_count.to_string()
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_extdedup_mem_check() {
+    // check to see if sysinfo return meminfo without segfaulting
+    let mut sys = System::new_all();
+    sys.refresh_memory();
+    let mem10percent = (sys.total_memory() * 1000) / 10; // 10 percent of total memory
+    assert!(mem10percent > 0);
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -16,6 +16,7 @@ pub mod excel;
 pub mod exclude;
 #[cfg(any(feature = "full", feature = "lite"))]
 pub mod explode;
+pub mod extdedup;
 #[cfg(any(feature = "full", feature = "lite"))]
 pub mod extsort;
 #[cfg(all(feature = "fetch", not(feature = "lite")))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 // rdr default is 8k in csv crate, we're doubling it
-const DEFAULT_RDR_BUFFER_CAPACITY: usize = 16 * (1 << 10);
+pub const DEFAULT_RDR_BUFFER_CAPACITY: usize = 16 * (1 << 10);
 // previous wtr default in xsv is 32k, we're doubling it
 pub const DEFAULT_WTR_BUFFER_CAPACITY: usize = 64 * (1 << 10);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ mod clitypes;
 mod cmd;
 mod config;
 mod index;
+mod odhtcache;
 mod select;
 mod util;
 
@@ -94,6 +95,7 @@ fn main() -> QsvExitCode {
     excel       Exports an Excel sheet to a CSV
     exclude     Excludes the records in one CSV from another
     explode     Explode rows based on some column separator
+    extdedup    Remove duplicates rows from an arbitrarily large text file
     extsort     Sort arbitrarily large text file\n",
     );
 
@@ -266,6 +268,7 @@ enum Command {
     Excel,
     Exclude,
     Explode,
+    ExtDedup,
     ExtSort,
     #[cfg(all(feature = "fetch", not(feature = "lite")))]
     Fetch,
@@ -339,6 +342,7 @@ impl Command {
             Command::Excel => cmd::excel::run(argv),
             Command::Exclude => cmd::exclude::run(argv),
             Command::Explode => cmd::explode::run(argv),
+            Command::ExtDedup => cmd::extdedup::run(argv),
             Command::ExtSort => cmd::extsort::run(argv),
             #[cfg(all(feature = "fetch", not(feature = "lite")))]
             Command::Fetch => cmd::fetch::run(argv),

--- a/src/odhtcache.rs
+++ b/src/odhtcache.rs
@@ -1,0 +1,160 @@
+// blatantly copied from https://github.com/race604/dedup/blob/master/src/cache.rs
+use std::collections::HashSet;
+
+use log::debug;
+use odht::{Config, FxHashFn, HashTableOwned};
+
+struct OdhtConfig;
+
+const CHUNK_SIZE: usize = 127;
+
+impl Config for OdhtConfig {
+    type Key = [u8; CHUNK_SIZE + 1];
+    type Value = bool;
+
+    type EncodedKey = [u8; CHUNK_SIZE + 1];
+    type EncodedValue = [u8; 1];
+
+    type H = FxHashFn;
+
+    #[inline]
+    fn encode_key(k: &Self::Key) -> Self::EncodedKey {
+        *k
+    }
+    #[inline]
+    fn encode_value(v: &Self::Value) -> Self::EncodedValue {
+        [if *v { 1 } else { 0 }; 1]
+    }
+    #[inline]
+    fn decode_key(k: &Self::EncodedKey) -> Self::Key {
+        *k
+    }
+    #[inline]
+    fn decode_value(v: &Self::EncodedValue) -> Self::Value {
+        v[0] == 1
+    }
+}
+
+pub struct Cache {
+    memo:       HashSet<String>,
+    disk:       Option<HashTableOwned<OdhtConfig>>,
+    memo_limit: usize,
+    memo_size:  usize,
+}
+
+impl Cache {
+    pub fn new(memo_limit: usize) -> Self {
+        Self {
+            memo:       HashSet::new(),
+            disk:       None,
+            memo_limit: if memo_limit == 0 {
+                usize::MAX
+            } else {
+                memo_limit
+            },
+            memo_size:  0,
+        }
+    }
+
+    pub fn insert(&mut self, item: &str) -> bool {
+        if self.memo_size >= self.memo_limit {
+            debug!("Memory cache is full, dump to disk");
+            self.dump_to_disk();
+        }
+
+        let mut res = self.memo.insert(item.to_owned());
+        if res {
+            self.memo_size = self.memo_size + item.len();
+            if self.disk.is_some() {
+                res = self.insert_on_disk(item);
+                debug!("Insert on disk: {}", res);
+            }
+        }
+
+        res
+    }
+
+    pub fn contains(&self, item: &str) -> bool {
+        if self.memo.contains(item) {
+            return true;
+        }
+
+        return if let Some(ref disk) = self.disk {
+            Cache::item_to_keys(item).all(|key| disk.contains_key(&key))
+        } else {
+            false
+        };
+    }
+
+    fn insert_on_disk(&mut self, item: &str) -> bool {
+        let disk = self.disk.get_or_insert_with(|| {
+            debug!("Create new disk cache");
+            HashTableOwned::<OdhtConfig>::with_capacity(1_000_000, 95)
+        });
+        let mut res = false;
+        for key in Cache::item_to_keys(item) {
+            res = disk.insert(&key, &true).is_none() || res;
+        }
+        res
+    }
+
+    fn item_to_keys<'a>(item: &'a str) -> impl Iterator<Item = [u8; CHUNK_SIZE + 1]> + 'a {
+        let res = item
+            .as_bytes()
+            .chunks(CHUNK_SIZE)
+            .into_iter()
+            .enumerate()
+            .map(|(i, chunk)| {
+                let mut key = [0 as u8; CHUNK_SIZE + 1];
+                key[CHUNK_SIZE] = i as u8;
+                key[..chunk.len()].copy_from_slice(chunk);
+                key
+            });
+        return res;
+    }
+
+    fn dump_to_disk(&mut self) {
+        let keys = self.memo.drain().collect::<Vec<_>>();
+        for key in keys {
+            self.insert_on_disk(&key);
+        }
+        self.memo_size = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{distributions::Alphanumeric, thread_rng, Rng};
+
+    use super::*;
+
+    #[test]
+    fn test_basic_cache() {
+        let mut cache = Cache::new(0);
+        assert!(cache.insert("hello"));
+        assert!(cache.insert("world"));
+
+        assert!(cache.contains("hello"));
+        assert!(cache.contains("world"));
+        assert!(!cache.contains("other"));
+    }
+
+    #[test]
+    fn test_limit_memory() {
+        let mut cache = Cache::new(1024);
+        for _ in 0..100 {
+            cache.insert(&rand_string(32));
+        }
+        assert!(cache.memo.len() < 100);
+        assert!(cache.disk.is_some());
+        assert!(cache.disk.unwrap().len() > 0);
+    }
+
+    fn rand_string(len: usize) -> String {
+        thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(len)
+            .map(char::from)
+            .collect()
+    }
+}


### PR DESCRIPTION
use an on-disk hash table for streaming `dedup`.

It also retains the original sort order of the input file as it does not need to sort the file first to dedup it.

implements #758 