### PR TITLE
`extsort`: refactor

### DIFF
--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -1,18 +1,17 @@
 static USAGE: &str = r#"
 Sort an arbitrarily large CSV/text file using a multithreaded external sort algorithm.
 
-This command does not work with <stdin>/<stdout>. Valid input, and output
-files are expected.
-
-Also, this command is not specific to CSV data, it sorts any text file on a 
+This command is not specific to CSV data, it sorts any text file on a 
 line-by-line basis. If sorting a non-CSV file, be sure to set --no-headers, 
 otherwise, the first line will not be included in the external sort.
 
 Usage:
-    qsv extsort [options] <input> <output>
+    qsv extsort [options] [<input>] [<output>]
     qsv extsort --help
 
 External sort option:
+    --memory-limit <arg>   The maximum amount of memory to buffer the on-disk hash table.
+                           This is a percentage of total memory. [default: 10]
     -j, --jobs <arg>       The number of jobs to run in parallel.
                            When not set, the number of jobs is set to the
                            number of CPUs detected.
@@ -27,7 +26,7 @@ Common options:
 
 use std::{
     fs,
-    io::{self, prelude::*},
+    io::{self, prelude::*, stdin, stdout},
     path,
 };
 
@@ -35,14 +34,15 @@ use ext_sort::{buffer::mem::MemoryLimitedBufferBuilder, ExternalSorter, External
 use serde::Deserialize;
 use sysinfo::{System, SystemExt};
 
-use crate::{util, CliResult};
+use crate::{config, util, CliResult};
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input:       String,
-    arg_output:      String,
-    flag_jobs:       Option<usize>,
-    flag_no_headers: bool,
+    arg_input:         Option<String>,
+    arg_output:        Option<String>,
+    flag_jobs:         Option<usize>,
+    flag_memory_limit: Option<u8>,
+    flag_no_headers:   bool,
 }
 
 const MEMORY_LIMITED_BUFFER: u64 = 100 * 1_000_000; // 100 MB
@@ -51,27 +51,40 @@ const RW_BUFFER_CAPACITY: usize = 1_000_000; // 1 MB
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    // buffer to use for sorting in memory,
-    // use 10% of total memory if we can detect it, otherwise
-    // set it to MEMORY_LIMITED_BUFFER
+    // memory buffer to use for external merge sort,
+    // if we can detect the total memory, use 10% of it by default
+    // and up to --memory-limit (capped at 50%),
+    // otherwise, if we cannot detect the free memory use a default of 100 MB
     let mem_limited_buffer = if System::IS_SUPPORTED {
         let mut sys = System::new_all();
         sys.refresh_memory();
-        (sys.total_memory() * 1000) / 10 // 10 percent of total memory
+        (sys.total_memory() * 1000) / u8::min(args.flag_memory_limit.unwrap_or(10), 50) as u64
     } else {
         MEMORY_LIMITED_BUFFER
     };
     log::info!("{mem_limited_buffer} bytes used for in memory mergesort buffer...");
 
-    let mut input_reader = io::BufReader::new(match fs::File::open(&args.arg_input) {
-        Ok(f) => f,
-        Err(e) => return fail_clierror!("Cannot read input file {e}"),
-    });
+    let mut input_reader: Box<dyn BufRead> = match &args.arg_input {
+        Some(input_path) => {
+            let file = fs::File::open(input_path)?;
+            Box::new(io::BufReader::with_capacity(
+                config::DEFAULT_RDR_BUFFER_CAPACITY,
+                file,
+            ))
+        }
+        None => Box::new(io::BufReader::new(stdin().lock())),
+    };
 
-    let mut output_writer = io::BufWriter::new(match fs::File::create(&args.arg_output) {
-        Ok(f) => f,
-        Err(e) => return fail_clierror!("Cannot create output file: {e}"),
-    });
+    let mut output_writer: Box<dyn Write> = match &args.arg_output {
+        Some(output_path) => Box::new(io::BufWriter::with_capacity(
+            RW_BUFFER_CAPACITY,
+            fs::File::create(output_path)?,
+        )),
+        None => Box::new(io::BufWriter::with_capacity(
+            RW_BUFFER_CAPACITY,
+            stdout().lock(),
+        )),
+    };
 
     let sorter: ExternalSorter<String, io::Error, MemoryLimitedBufferBuilder> =
         match ExternalSorterBuilder::new()


### PR DESCRIPTION
- align options with `extdedup`
- can now use stdin and stdout
- expose `--memory-limit` option similar to `extdedup`