### PR TITLE
Out-of-memory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ To prevent this, the `py` command processes CSVs in batches (default: 30,000 rec
 | `QSV_SKIPUTF8_CHECK` | if set, skip UTF-8 encoding check. Otherwise, for several commands that require UTF-8 encoded input (see [UTF8-Encoding](#utf-8-encoding)), qsv scans the first 8k. |
 | `QSV_RDR_BUFFER_CAPACITY` | reader buffer size (default (bytes): 16384) |
 | `QSV_WTR_BUFFER_CAPACITY` | writer buffer size (default (bytes): 65536) |
+| `QSV_FREEMEMORY_HEADROOM_PCT` | the percentage of free available memory required when running qsv in "non-streaming" mode (i.e. the entire file needs to be loaded into memory). If the incoming file is greater than the available memory after the headroom is subtracted, qsv will not proceed. (default: (percent) 20 ) |
 | `QSV_LOG_LEVEL` | desired level (default - off; `error`, `warn`, `info`, `trace`, `debug`). |
 | `QSV_LOG_DIR` | when logging is enabled, the directory where the log files will be stored. If the specified directory does not exist, qsv will attempt to create it. If not set, the log files are created in the directory where qsv was started. See [Logging](docs/Logging.md#logging) for more info. |
 | `QSV_PROGRESSBAR` | if set, enable the --progressbar option on the `apply`, `fetch`, `fetchpost`, `foreach`, `luau`, `py`, `replace`, `search`, `searchset`, `sortcheck` & `validate` commands.  |

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -132,6 +132,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }
         }
     } else {
+        // we're loading the entire file into memory, we need to check avail mem
+        if let Some(path) = rconfig.path.clone() {
+            util::mem_file_check(&path)?;
+        }
+
         util::njobs(args.flag_jobs);
 
         let mut all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -81,6 +81,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .checkutf8(false)
         .select(args.flag_select);
 
+    // we're loading the entire file into memory, we need to check avail mem
+    if let Some(path) = rconfig.path.clone() {
+        util::mem_file_check(&path)?;
+    }
+
     let mut rdr = rconfig.reader()?;
 
     let headers = rdr.byte_headers()?.clone();

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -206,6 +206,20 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut wtr = Config::new(&args.flag_output).writer()?;
     let fconfig = args.rconfig();
     let record_count = RECORD_COUNT.get_or_init(|| util::count_rows(&fconfig).unwrap());
+
+    if let Some(path) = fconfig.path.clone() {
+        // we're loading the entire file into memory, we need to check avail mem
+        if args.flag_everything
+            || args.flag_mode
+            || args.flag_cardinality
+            || args.flag_median
+            || args.flag_quartiles
+            || args.flag_mad
+        {
+            util::mem_file_check(&path)?;
+        }
+    }
+
     log::info!("scanning {record_count} records...");
     let (headers, stats) = match fconfig.indexed()? {
         None => args.sequential_stats(&args.flag_dates_whitelist),

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -59,6 +59,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
 impl Args {
     fn in_memory_transpose(&self) -> CliResult<()> {
+        // we're loading the entire file into memory, we need to check avail mem
+        if let Some(path) = self.rconfig().path {
+            util::mem_file_check(&path)?;
+        }
+
         let mut rdr = self.rconfig().reader()?;
         let mut wtr = self.wconfig().writer()?;
         let nrows = rdr.byte_headers()?.len();

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for Delimiter {
 }
 
 pub struct Config {
-    path:              Option<PathBuf>, // None implies <stdin>
+    pub path:          Option<PathBuf>, // None implies <stdin>
     idx_path:          Option<PathBuf>,
     select_columns:    Option<SelectColumns>,
     delimiter:         u8,


### PR DESCRIPTION
When qsv is executed in "non-streaming" mode (i.e. the entire file is loaded into memory), it checks the available memory at startup and ensures that a free memory headroom of 20 percent is still available AFTER subtracting the filesize of the incoming file.

resolves #178 