### PR TITLE
add `--quiet` option

### DIFF
--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -45,6 +45,7 @@ Common options:
                                appear as the header row in the output.
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character. (default: ,)
+    -Q, --quiet                Do not print duplicate count to stderr.
 "#;
 
 use std::cmp;
@@ -71,6 +72,7 @@ struct Args {
     flag_delimiter:      Option<Delimiter>,
     flag_human_readable: bool,
     flag_jobs:           Option<usize>,
+    flag_quiet:          bool,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -173,6 +175,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     dupewtr.flush()?;
+    wtr.flush()?;
+
+    if args.flag_quiet {
+        return Ok(());
+    }
 
     if args.flag_human_readable {
         use thousands::Separable;
@@ -182,7 +189,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         eprintln!("{dupe_count}");
     }
 
-    Ok(wtr.flush()?)
+    Ok(())
 }
 
 /// Try comparing `a` and `b` ignoring the case

--- a/src/cmd/extdedup.rs
+++ b/src/cmd/extdedup.rs
@@ -29,6 +29,7 @@ extdedup options:
 
 Common options:
     -h, --help                 Display this message
+    -Q, --quiet                Do not print duplicate count to stderr.
 "#;
 
 use std::{
@@ -50,6 +51,7 @@ struct Args {
     flag_dupes_output:   Option<String>,
     flag_human_readable: bool,
     flag_memory_limit:   Option<u8>,
+    flag_quiet:          bool,
 }
 
 const MEMORY_LIMITED_BUFFER: u64 = 100 * 1_000_000; // 100 MB
@@ -143,6 +145,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     dupes_writer.flush()?;
     output_writer.flush()?;
+
+    if args.flag_quiet {
+        return Ok(());
+    }
 
     eprintln!(
         "{}",

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -49,7 +49,7 @@ The main-script is evaluated on a per row basis.
 With "luau map", if the main-script is invalid for a row, "<ERROR>" is returned for that row.
 With "luau filter", if the main-script is invalid for a row, that row is not filtered.
 
-If any row has an invalid result, an exitcode of 1 is returned along with an error count to stderr.
+If any row has an invalid result, an exitcode of 1 is returned and an error count is logged.
 
 There are also special variables - "_idx" that is zero during the prologue, and set to the current 
 row number during the main script; and "_rowcount" which is zero during the prologue and the main script,

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -78,7 +78,7 @@ Some usage examples:
   With "py map", if the expression is invalid for a record, "<ERROR>" is returned for that record.
   With "py filter", if the expression is invalid for a record, that record is not filtered.
 
-  If any record has an invalid result, an exitcode of 1 is returned along with an error count to stderr.
+  If any record has an invalid result, an exitcode of 1 is returned and an error count is logged.
 
 For more extensive examples, see https://github.com/jqnatividad/qsv/blob/master/tests/test_py.rs.
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -46,6 +46,7 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
+    -Q, --quiet            Do not print number of replacements to stderr.
 
 "#;
 
@@ -77,6 +78,7 @@ struct Args {
     flag_size_limit:     usize,
     flag_dfa_size_limit: usize,
     flag_progressbar:    bool,
+    flag_quiet:          bool,
 }
 
 const NULL_VALUE: &str = "<NULL>";
@@ -191,7 +193,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         util::finish_progress(&progress);
     }
 
-    eprintln!("{total_match_ctr}");
+    if !args.flag_quiet {
+        eprintln!("{total_match_ctr}");
+    }
     if total_match_ctr == 0 {
         return Err(CliError::NoMatch());
     }

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -56,6 +56,7 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
+    -Q, --quiet            Do not return number of matches to stderr.
 "#;
 
 use std::env;
@@ -90,6 +91,7 @@ struct Args {
     flag_quick:          bool,
     flag_count:          bool,
     flag_progressbar:    bool,
+    flag_quiet:          bool,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -194,14 +196,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     if args.flag_count && !args.flag_quick {
-        eprintln!("{match_ctr}");
+        if !args.flag_quiet {
+            eprintln!("{match_ctr}");
+        }
         info!("matches: {match_ctr}");
     }
 
     if match_ctr == 0 {
         return Err(CliError::NoMatch());
     } else if args.flag_quick {
-        eprintln!("{row_ctr}");
+        if !args.flag_quiet {
+            eprintln!("{row_ctr}");
+        }
         info!("quick search first match at {row_ctr}");
     }
 

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -73,6 +73,7 @@ Common options:
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character. (default: ,)
     -p, --progressbar          Show progress bars. Not valid for stdin.
+    -Q, --quiet                Do not return number of matches to stderr.
 "#;
 
 use std::{
@@ -115,6 +116,7 @@ struct Args {
     flag_count:             bool,
     flag_json:              bool,
     flag_progressbar:       bool,
+    flag_quiet:             bool,
 }
 
 fn read_regexset(filename: &String) -> io::Result<Vec<String>> {
@@ -306,14 +308,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         eprintln!("{json}");
     } else {
         if args.flag_count && !args.flag_quick {
-            eprintln!("{match_row_ctr}");
+            if !args.flag_quiet {
+                eprintln!("{match_row_ctr}");
+            }
             info!("matches: {match_row_ctr}");
         }
 
         if match_row_ctr == 0 {
             return Err(CliError::NoMatch());
         } else if args.flag_quick {
-            eprintln!("{row_ctr}");
+            if !args.flag_quiet {
+                eprintln!("{row_ctr}");
+            }
             info!("quick searchset first match at {row_ctr}");
         }
     }


### PR DESCRIPTION
To resolve #766, we added a `-Q, --quiet` option to `dedup`, so it doesn't return the dupe count to stderr.

For consistency, we also added it to `extdedup`, `replace`, `search` and `searchset` - commands that all return counts (dupes, replacements & matches respectively) to stderr.