### PR TITLE
show --update error on stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,12 +198,12 @@ sponsored by datHere - Data Infrastructure Engineering
         return QsvExitCode::Good;
     }
     if args.flag_update || args.flag_updatenow {
-        let update_checked = util::qsv_check_for_update(false, args.flag_updatenow);
         util::log_end(qsv_args, now);
-        if update_checked.is_ok() {
-            return QsvExitCode::Good;
+        if let Err(e) = util::qsv_check_for_update(false, args.flag_updatenow) {
+            eprintln!("{e}");
+            return QsvExitCode::Bad;
         }
-        return QsvExitCode::Bad;
+        return QsvExitCode::Good;
     }
     match args.arg_command {
         None => {
@@ -362,7 +362,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update(true, false);
+                util::qsv_check_for_update(true, false)?;
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -137,12 +137,12 @@ fn main() -> QsvExitCode {
         return QsvExitCode::Good;
     }
     if args.flag_update || args.flag_updatenow {
-        let update_checked = util::qsv_check_for_update(false, args.flag_updatenow);
         util::log_end(qsv_args, now);
-        if update_checked.is_ok() {
-            return QsvExitCode::Good;
+        if let Err(e) = util::qsv_check_for_update(false, args.flag_updatenow) {
+            eprintln!("{e}");
+            return QsvExitCode::Bad;
         }
-        return QsvExitCode::Bad;
+        return QsvExitCode::Good;
     }
     match args.arg_command {
         None => {
@@ -249,7 +249,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update(true, false);
+                util::qsv_check_for_update(true, false)?;
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -116,12 +116,12 @@ fn main() -> QsvExitCode {
         return QsvExitCode::Good;
     }
     if args.flag_update || args.flag_updatenow {
-        let update_checked = util::qsv_check_for_update(false, args.flag_updatenow);
         util::log_end(qsv_args, now);
-        if update_checked.is_ok() {
-            return QsvExitCode::Good;
+        if let Err(e) = util::qsv_check_for_update(false, args.flag_updatenow) {
+            eprintln!("{e}");
+            return QsvExitCode::Bad;
         }
-        return QsvExitCode::Bad;
+        return QsvExitCode::Good;
     }
     match args.arg_command {
         None => {
@@ -251,7 +251,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}");
-                _ = util::qsv_check_for_update(true, false);
+                util::qsv_check_for_update(true, false)?;
                 Ok(())
             }
             Command::Index => cmd::index::run(argv),


### PR DESCRIPTION
it was just logging the error to the logfile, also show on stderr.

With every qsv release, it seems that we're hitting the GitHub rate-limit more, so showing error to stderr will be more apparent & helpful than just logging the rate limit message.