### PR TITLE
`sortcheck`: when a file is not sorted, dupecount is invalid. Set it to -1

### DIFF
--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -39,8 +39,8 @@ sort options:
                             Unsorted breaks count the number of times two consecutive
                             rows are unsorted (i.e. n row > n+1 row).
                             Dupe count is the number of times two consecutive
-                            rows are equal. Note that dupe count is INVALID and
-                            should be ignored if the file is not sorted.
+                            rows are equal. Note that dupe count does not apply
+                            if the file is not sorted and is set to -1.
     --pretty-json           Same as --json but in pretty JSON format.
 
 Common options:
@@ -87,7 +87,7 @@ struct SortCheckStruct {
     sorted:          bool,
     record_count:    u64,
     unsorted_breaks: u64,
-    dupe_count:      u64,
+    dupe_count:      i64,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -209,7 +209,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 record_count
             },
             unsorted_breaks,
-            dupe_count,
+            dupe_count: if sorted { dupe_count as i64 } else { -1 },
         };
         // it's OK to have unwrap here as we know sortcheck_struct is valid json
         if args.flag_pretty_json {

--- a/tests/test_sortcheck.rs
+++ b/tests/test_sortcheck.rs
@@ -152,7 +152,7 @@ fn sortcheck_simple_all_json() {
 
     assert_eq!(
         got_stdout,
-        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":2}
+        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":-1}
 "#
     );
     wrk.assert_err(&mut cmd);
@@ -185,7 +185,7 @@ fn sortcheck_simple_json() {
 
     assert_eq!(
         got_stdout,
-        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":2}
+        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":-1}
 "#
     );
     wrk.assert_err(&mut cmd);
@@ -221,7 +221,7 @@ fn sortcheck_simple_all_json_progressbar() {
 
     assert_eq!(
         got_stdout,
-        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":2}
+        r#"{"sorted":false,"record_count":9,"unsorted_breaks":2,"dupe_count":-1}
 "#
     );
     wrk.assert_err(&mut cmd);


### PR DESCRIPTION
Previously, we added a note saying so, but to make it more evident and apparent just by looking at dupecount, set dupecount to -1 if file is not sorted.