### PR TITLE
`dedup`: fix unstable dedup results caused by using `par_sort_unstable_by`

### DIFF
--- a/resources/test/dedup-by-id-test-expected.csv
+++ b/resources/test/dedup-by-id-test-expected.csv
@@ -1,0 +1,29 @@
+index,id,name,lastmod
+15,Q101580075,Walter Chávez Cruz,2022-01-01
+16,Q102104551,Nuria Esparch,2022-01-01
+17,Q107709552,Walter Ayala Gonzales,2022-01-01
+38,Q107709599,Juan Carrasco Millones,2022-10-01
+18,Q110782031,José Luis Gavidia,2022-01-01
+37,Q113612528,Richard Tineo Quispe,2022-08-26
+20,Q113624484,Carlos Bergamino Cruz,2022-08-26
+21,Q113624485,Walter Ledesma Rebaza,2022-08-26
+39,Q114228964,Daniel Barragán Coloma,2022-10-01
+31,Q25930834,Cosme Mariano González Fernández,2022-08-26
+32,Q26195791,Jorge Nieto Montesinos,2022-08-26
+30,Q2917191,Pedro Cateriano Bellido,2022-08-26
+23,Q29917691,Aurelio Loret de Mola Böhme,2022-08-26
+41,Q4392555,Rafael Rey,2022-12-13
+33,Q47254068,Jorge Kisic Wagner,2022-08-26
+40,Q4771421,Ántero Flores-Aráoz Esparza,2022-12-13
+7,Q5218182,Daniel Mora Zevallos,2022-01-01
+22,Q5240770,David Waisman Rjavinsthi,2022-08-26
+26,Q533296,Allan Wagner Tizón,2022-08-26
+24,Q5411209,Roberto Chiabra León,2022-08-26
+42,Q5663401,Alberto Otárola Peñaranda,2022-12-15
+29,Q5945915,José Antonio Urquizo Maggia,2022-08-26
+25,Q5996160,Marciano Rengifo Ruiz,2022-08-26
+6,Q6123933,Jaime Thorne León,2022-01-01
+11,Q64825295,José Modesto Huerta Torres,2022-01-01
+34,Q65179569,Jorge Moscoso Flores,2022-08-26
+35,Q74706825,Walter Martos Ruiz,2022-08-26
+43,Q99968423,Jorge Luis Chávez Cresta,2022-12-30

--- a/resources/test/dedup-test.csv
+++ b/resources/test/dedup-test.csv
@@ -1,0 +1,45 @@
+index,id,name,lastmod
+0,Q5240770,David Waisman,2022-01-01
+1,Q29917691,Aurelio Loret de Mola,2022-01-01
+2,Q5411209,Roberto Chiabra,2022-01-01
+3,Q5996160,Marciano Rengifo,2022-01-01
+4,Q4771421,Ántero Flores-Aráoz,2022-01-01
+5,Q4392555,Rafael Rey,2022-01-01
+6,Q6123933,Jaime Thorne León,2022-01-01
+7,Q5218182,Daniel Mora Zevallos,2022-01-01
+8,Q5663401,Alberto Otárola Peñaranda,2022-01-01
+9,Q5945915,Jose Urquizo Maggia,2022-01-01
+10,Q47254068,Jorge Kisic,2022-01-01
+11,Q64825295,José Modesto Huerta Torres,2022-01-01
+12,Q65179569,Jorge Moscoso,2022-01-01
+13,Q74706825,Walter Martos,2022-01-01
+14,Q99968423,Jorge Luis Chavez Cresta,2022-01-01
+15,Q101580075,Walter Chávez Cruz,2022-01-01
+16,Q102104551,Nuria Esparch,2022-01-01
+17,Q107709552,Walter Ayala Gonzales,2022-01-01
+18,Q110782031,José Luis Gavidia,2022-01-01
+19,Q5663401,Alberto Otárola Peñaranda,2022-01-01
+20,Q113624484,Carlos Bergamino Cruz,2022-08-26
+21,Q113624485,Walter Ledesma Rebaza,2022-08-26
+22,Q5240770,David Waisman Rjavinsthi,2022-08-26
+23,Q29917691,Aurelio Loret de Mola Böhme,2022-08-26
+24,Q5411209,Roberto Chiabra León,2022-08-26
+25,Q5996160,Marciano Rengifo Ruiz,2022-08-26
+26,Q533296,Allan Wagner Tizón,2022-08-26
+27,Q4771421,Ántero Flores Aráoz Esparza,2022-08-26
+28,Q5663401,Luis Alberto Otárola Peñaranda,2022-08-26
+29,Q5945915,José Antonio Urquizo Maggia,2022-08-26
+30,Q2917191,Pedro Cateriano Bellido,2022-08-26
+31,Q25930834,Cosme Mariano González Fernández,2022-08-26
+32,Q26195791,Jorge Nieto Montesinos,2022-08-26
+33,Q47254068,Jorge Kisic Wagner,2022-08-26
+34,Q65179569,Jorge Moscoso Flores,2022-08-26
+35,Q74706825,Walter Martos Ruiz,2022-08-26
+36,Q99968423,Jorge Luis Chávez Cresta,2022-08-26
+37,Q113612528,Richard Tineo Quispe,2022-08-26
+38,Q107709599,Juan Carrasco Millones,2022-10-01
+39,Q114228964,Daniel Barragán Coloma,2022-10-01
+40,Q4771421,Ántero Flores-Aráoz Esparza,2022-12-13
+41,Q4392555,Rafael Rey,2022-12-13
+42,Q5663401,Alberto Otárola Peñaranda,2022-12-15
+43,Q99968423,Jorge Luis Chávez Cresta,2022-12-30

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -143,7 +143,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         util::njobs(args.flag_jobs);
 
         let mut all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;
-        all.par_sort_unstable_by(|r1, r2| {
+        all.par_sort_by(|r1, r2| {
             let a = sel.select(r1);
             let b = sel.select(r2);
             iter_cmp(a, b)

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -72,6 +72,20 @@ fn dedup_select() {
 }
 
 #[test]
+fn dedup_select_issue774() {
+    let wrk = Workdir::new("dedup_select_issue774");
+    let test_file = wrk.load_test_file("dedup-test.csv");
+
+    let mut cmd = wrk.command("dedup");
+    cmd.args(["-s", "id"]).arg(test_file);
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = wrk.load_test_resource("dedup-by-id-test-expected.csv");
+
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn dedup_sorted() {
     let wrk = Workdir::new("dedup_sorted");
     wrk.create(


### PR DESCRIPTION
When `dedup` was parallelized with rayon, I chose to use [`par_sort_unstable_by`](https://docs.rs/rayon/latest/rayon/slice/trait.ParallelSliceMut.html#method.par_sort_unstable_by) to as it doesn't allocate.

However,  `par_sort_unstable_by` may also reorder equal elements, which is exactly the problem reported in #774.

Changed to use [`par_sort_by`](https://docs.rs/rayon/latest/rayon/slice/trait.ParallelSliceMut.html#method.par_sort_by) instead.