### PR TITLE
`--version` now returns max input file size when running in "non-streaming" mode, and memory info

### DIFF
--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -137,7 +137,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     } else {
         // we're loading the entire file into memory, we need to check avail mem
         if let Some(path) = rconfig.path.clone() {
-            util::mem_file_check(&path)?;
+            util::mem_file_check(&path, false)?;
         }
 
         // set RAYON_NUM_THREADS for parallel sort

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -80,7 +80,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // we're loading the entire file into memory, we need to check avail mem
     if let Some(path) = rconfig.path.clone() {
-        util::mem_file_check(&path)?;
+        util::mem_file_check(&path, false)?;
     }
 
     let mut wtr = Config::new(&args.flag_output).writer()?;

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -112,7 +112,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
 
     // we're loading the entire file into memory, we need to check avail mem
-    util::mem_file_check(&std::path::PathBuf::from(&input_path))?;
+    util::mem_file_check(&std::path::PathBuf::from(&input_path), false)?;
 
     // we can do this directly here, since args is mutable and
     // Config has not been created yet at this point

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -83,7 +83,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // we're loading the entire file into memory, we need to check avail mem
     if let Some(path) = rconfig.path.clone() {
-        util::mem_file_check(&path)?;
+        util::mem_file_check(&path, false)?;
     }
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -218,7 +218,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             || args.flag_quartiles
             || args.flag_mad
         {
-            util::mem_file_check(&path)?;
+            util::mem_file_check(&path, false)?;
         }
     }
 

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -61,7 +61,7 @@ impl Args {
     fn in_memory_transpose(&self) -> CliResult<()> {
         // we're loading the entire file into memory, we need to check avail mem
         if let Some(path) = self.rconfig().path {
-            util::mem_file_check(&path)?;
+            util::mem_file_check(&path, false)?;
         }
 
         let mut rdr = self.rconfig().reader()?;


### PR DESCRIPTION
- when qsv is running in "non-streaming" mode (i.e. entire input file is loaded into memory), it checks the QSV_FREEMEMORY_HEADROOM_PCT heuristic to calculate the maximum allowable file size. 
- this heuristic was introduced to prevent Out-Of-Memory panics, as qsv won't even attempt to process a file if its too large per the heuristic
- We now show the "non-streaming" max input file size  with `--version` option.
- we also show current free memory, and total memory.

