### PR TITLE
Remove utf8 screening/unsafe from_utf8_unchecked and just use simdutf8 to do SIMD accelerated utf8 validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.17",
+ "time 0.3.19",
  "url",
 ]
 
@@ -874,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.17",
+ "time 0.3.19",
  "version_check",
 ]
 
@@ -890,7 +890,7 @@ dependencies = [
  "publicsuffix",
  "serde",
  "serde_json",
- "time 0.3.17",
+ "time 0.3.19",
  "url",
 ]
 
@@ -1964,7 +1964,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.17",
+ "time 0.3.19",
  "url",
  "uuid",
 ]
@@ -1981,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "kiddo"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a5c92307668140bf7d63a03a23e2da0b0453801fd54888c903cb7f723c293"
+checksum = "06ced2e69cfc5f22f86ccc9ce4ecff9f19917f3083a4bac0f402bdab034d73f1"
 dependencies = [
  "num-traits",
 ]
@@ -2962,6 +2962,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serial_test",
+ "simdutf8",
  "strsim 0.10.0",
  "strum",
  "strum_macros",
@@ -3628,6 +3629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "serde",
@@ -3923,9 +3930,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -4570,5 +4577,5 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "time 0.3.17",
+ "time 0.3.19",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ self_update = { version = "0.35", features = [
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_urlencoded = { version = "0.7", optional = true }
+simdutf8 = "0.1"
 strsim = { version = "0.10", optional = true }
 strum = "0.24"
 strum_macros = "0.24"

--- a/README.md
+++ b/README.md
@@ -205,11 +205,7 @@ Click [here](https://docs.rs/csv-core/latest/csv_core/struct.Reader.html#rfc-418
 
 ## **UTF-8 Encoding**
 
-The following commands require UTF-8 encoded input (of which ASCII is a subset) - `dedup`, `exclude`, `fetch`, `fetchpost`, `frequency`, `join`, `schema`, `sort`, `stats` & `validate`.
-
-For these commands, qsv checks if the input is UTF-8 encoded by scanning the first 8k & will abort if its not unless `QSV_SKIPUTF8_CHECK` is set. On Linux & macOS, UTF-8 encoding is the default.
-
-This was done to increase performance of these commands, as they make extensive use of `from_utf8_unchecked` so as not to pay the repetitive utf-8 validation penalty, no matter how small, even for already utf-8 encoded files.
+qsv require UTF-8 encoded input (of which ASCII is a subset).
 
 Should you need to re-encode CSV/TSV files, you can use the `input` command to transcode to UTF-8. It will replace all invalid UTF-8 sequences with `�`. Alternatively, there are several utilities you can use to do so on [Linux/macOS](https://stackoverflow.com/questions/805418/how-can-i-find-encoding-of-a-file-via-a-script-on-linux) & [Windows](https://superuser.com/questions/1163753/converting-text-file-to-utf-8-on-windows-command-prompt).
 
@@ -273,7 +269,6 @@ To prevent this, the `py` command processes CSVs in batches (default: 30,000 rec
 | `QSV_NO_UPDATE` | if set, prohibit self-update version check for the latest qsv release published on GitHub. |
 | `QSV_PREFER_DMY` | if set, date parsing will use DMY format. Otherwise, use MDY format (used with `apply datefmt`, `schema`, `sniff` & `stats` commands). |
 | `QSV_REGEX_UNICODE` | if set, makes `search`, `searchset` & `replace` commands unicode-aware. For increased performance, these commands are not unicode-aware by default & will ignore unicode values when matching & will abort when unicode characters are used in the regex. Note that the `apply operations regex_replace` operation is always unicode-aware. |
-| `QSV_SKIPUTF8_CHECK` | if set, skip UTF-8 encoding check. Otherwise, for several commands that require UTF-8 encoded input (see [UTF8-Encoding](#utf-8-encoding)), qsv scans the first 8k. |
 | `QSV_RDR_BUFFER_CAPACITY` | reader buffer size (default (bytes): 16384) |
 | `QSV_WTR_BUFFER_CAPACITY` | writer buffer size (default (bytes): 65536) |
 | `QSV_FREEMEMORY_HEADROOM_PCT` | the percentage of free available memory required when running qsv in "non-streaming" mode (i.e. the entire file needs to be loaded into memory). If the incoming file is greater than the available memory after the headroom is subtracted, qsv will not proceed. (default: (percent) 20 ) |

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -487,7 +487,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
-        // .checkutf8(false)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -53,6 +53,7 @@ use std::cmp;
 use csv::ByteRecord;
 use rayon::prelude::*;
 use serde::Deserialize;
+use simdutf8::basic::from_utf8;
 
 use crate::{
     cmd::sort::iter_cmp,
@@ -220,6 +221,6 @@ where
     X: Iterator<Item = &'a [u8]>,
 {
     xs.next()
-        .map(|bytes| unsafe { std::str::from_utf8_unchecked(bytes) })
+        .and_then(|bytes| from_utf8(bytes).ok())
         .map(str::to_lowercase)
 }

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -44,6 +44,7 @@ use std::{collections::hash_map::Entry, fmt, fs, io, str};
 use ahash::AHashMap;
 use byteorder::{BigEndian, WriteBytesExt};
 use serde::Deserialize;
+use simdutf8::basic::from_utf8;
 
 use crate::{
     config::{Config, Delimiter},
@@ -252,7 +253,7 @@ fn get_row_key(sel: &Selection, row: &csv::ByteRecord, casei: bool) -> Vec<ByteS
 
 #[inline]
 fn transform(bs: &[u8], casei: bool) -> ByteString {
-    let s = unsafe { str::from_utf8_unchecked(bs) };
+    let s = from_utf8(bs).unwrap_or_default();
     if casei {
         let norm: String = s
             .trim()

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -204,6 +204,7 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use simdutf8::basic::from_utf8;
 use url::Url;
 
 use crate::{
@@ -618,14 +619,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             // let's dynamically construct the URL with it
             record_vec.clear();
             for field in &record {
-                record_vec.push(unsafe { std::str::from_utf8_unchecked(field).to_owned() });
+                record_vec.push(from_utf8(field).unwrap_or_default().to_owned());
             }
             if let Ok(formatted) =
                 dynfmt::SimpleCurlyFormat.format(&dynfmt_url_template, &*record_vec)
             {
                 url = formatted.into_owned();
             }
-        } else if let Ok(s) = std::str::from_utf8(&record[column_index]) {
+        } else if let Ok(s) = from_utf8(&record[column_index]) {
             // we're not using a URL template,
             // just use the field as-is as the URL
             s.clone_into(&mut url);

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -196,6 +196,7 @@ use reqwest::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use serde_urlencoded;
+use simdutf8::basic::from_utf8;
 use url::Url;
 
 use crate::{
@@ -609,8 +610,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         form_body_jsonmap.clear();
         for col_idx in col_list.iter() {
             let header_key = String::from_utf8_lossy(headers.get(*col_idx).unwrap());
-            let value_string =
-                unsafe { std::str::from_utf8_unchecked(&record[*col_idx]).to_string() };
+            let value_string = from_utf8(&record[*col_idx]).unwrap_or_default().to_string();
             form_body_jsonmap.insert(
                 header_key.to_string(),
                 serde_json::Value::String(value_string),
@@ -622,7 +622,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         if literal_url_used {
             url = literal_url.clone();
-        } else if let Ok(s) = std::str::from_utf8(&record[column_index]) {
+        } else if let Ok(s) = from_utf8(&record[column_index]) {
             s.clone_into(&mut url);
         } else {
             url = String::new();

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -45,6 +45,7 @@ use std::cmp;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use rayon::prelude::*;
 use serde::Deserialize;
+use simdutf8::basic::from_utf8;
 
 use self::Number::{Float, Int};
 use crate::{
@@ -236,7 +237,7 @@ where
     X: Iterator<Item = &'a [u8]>,
 {
     xs.next()
-        .map(|bytes| unsafe { std::str::from_utf8_unchecked(bytes) })
+        .map(|bytes| from_utf8(bytes).unwrap())
         .and_then(|s| {
             if let Ok(i) = s.parse::<i64>() {
                 Some(Number::Int(i))

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -61,6 +61,7 @@ use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, value::Number, Map, Value};
+use simdutf8::basic::from_utf8;
 use thousands::Separable;
 
 use crate::{
@@ -503,9 +504,8 @@ fn do_json_validation(
     schema_json: &Value,
     schema_compiled: &JSONSchema,
 ) -> Option<String> {
-    // row number was added as last column. We use unsafe from_utf8_unchecked to
-    // skip UTF8 validation since we know its safe as we added it earlier
-    let row_number_string = unsafe { str::from_utf8_unchecked(record.get(headers_len).unwrap()) };
+    // row number was added as last column. We use can do unwrap safely since we know its there
+    let row_number_string = from_utf8(record.get(headers_len).unwrap()).unwrap();
 
     // debug!("instance[{row_number}]: {instance:?}");
     validate_json_instance(
@@ -553,9 +553,9 @@ fn to_json_instance(
     // iterate over each CSV field and convert to JSON type
     for (i, header) in headers.iter().enumerate() {
         // convert csv header to string
-        let header_string = unsafe { std::str::from_utf8_unchecked(header).to_string() };
+        let header_string = from_utf8(header).unwrap().to_string();
         // convert csv value to string; no trimming reqd as it's done on the record level beforehand
-        let value_string = unsafe { std::str::from_utf8_unchecked(&record[i]).to_string() };
+        let value_string = from_utf8(&record[i]).unwrap().to_string();
 
         // if value_string is empty, then just put an empty JSON String
         if value_string.is_empty() {


### PR DESCRIPTION
completes utf8 validation revamp.

Before, we did utf8-encoding screening by looking at first 8k of input so we can skip repetitive utf8 validation in some commands, particularly stats, using unsafe from_utf8_unchecked.

It ended up being more of a problem than its worth.

So we now still do UTF-8 validation, but instead of using the std from_utf8, we using SIMD-accelerated UTF8 validation using the simdutf8 crate, without having to use unsafe from_utf8_unchecked.