### PR TITLE
`py`:  `col`, not  `row`

### DIFF
--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -293,7 +293,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 .getattr("QSVRow")?
                 .call1((headers.iter().collect::<Vec<&str>>(),))?;
 
-            batch_locals.set_item("row", py_row)?;
+            batch_locals.set_item("col", py_row)?;
 
             let error_result = intern!(py, "<ERROR>");
 

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -238,7 +238,7 @@ def celsius_to_fahrenheit(celsius):
 }
 
 #[test]
-fn py_map_row_positional() {
+fn py_map_col_positional() {
     let wrk = Workdir::new("py");
     wrk.create(
         "data.csv",
@@ -253,7 +253,7 @@ fn py_map_row_positional() {
     let mut cmd = wrk.command("py");
     cmd.arg("map")
         .arg("inc")
-        .arg("int(row[1]) + 1")
+        .arg("int(col[1]) + 1")
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -268,7 +268,7 @@ fn py_map_row_positional() {
 }
 
 #[test]
-fn py_map_row_by_key() {
+fn py_map_col_by_key() {
     let wrk = Workdir::new("py");
     wrk.create(
         "data.csv",
@@ -283,7 +283,7 @@ fn py_map_row_by_key() {
     let mut cmd = wrk.command("py");
     cmd.arg("map")
         .arg("inc")
-        .arg("int(row['number']) + 1")
+        .arg("int(col['number']) + 1")
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -298,7 +298,7 @@ fn py_map_row_by_key() {
 }
 
 #[test]
-fn py_map_row_by_attr() {
+fn py_map_col_by_attr() {
     let wrk = Workdir::new("py");
     wrk.create(
         "data.csv",
@@ -313,7 +313,7 @@ fn py_map_row_by_attr() {
     let mut cmd = wrk.command("py");
     cmd.arg("map")
         .arg("inc")
-        .arg("int(row.number) + 1")
+        .arg("int(col.number) + 1")
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -341,7 +341,7 @@ fn py_map_no_headers() {
     );
     let mut cmd = wrk.command("py");
     cmd.arg("map")
-        .arg("int(row[1]) + 1")
+        .arg("int(col[1]) + 1")
         .arg("--no-headers")
         .arg("data.csv");
 


### PR DESCRIPTION
the code was not behaving as documented in the usage text, it was setting the `row` keyword, not `col` as it should.

fixes #791 