### PR TITLE
`cat`: new `rowskey` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
+ "time 0.1.43",
  "wasm-bindgen",
  "winapi",
 ]
@@ -2918,6 +2918,7 @@ dependencies = [
  "governor",
  "grex",
  "hashbrown 0.13.2",
+ "indexmap",
  "indicatif",
  "itertools",
  "itoa",
@@ -3027,7 +3028,7 @@ dependencies = [
  "mach",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -3885,12 +3886,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -4280,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ flexi_logger = { version = "0.25", features = [
 governor = { version = "0.5", optional = true }
 grex = { version = "1.4", default-features = false }
 hashbrown = { version = "0.13", optional = true }
+indexmap = "1.9"
 indicatif = "0.17"
 itertools = "0.10"
 itoa = "1"

--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -6,14 +6,27 @@ the inputs given. The number of rows in the result is always equivalent to
 the minimum number of rows across all given CSV data. (This behavior can be
 reversed with the '--pad' flag.)
 
-When concatenating by row, all CSV data must have the same number of columns.
-If you need to rearrange the columns or fix the lengths of records, use the
-'select' or 'fixlengths' commands. Also, only the headers of the *first* CSV
-data given are used. Headers in subsequent inputs are ignored. (This behavior
-can be disabled with --no-headers.)
+Concatenating by rows can be done in two ways:
+
+'rows' subcommand: 
+   All CSV data must have the same number of columns and in the same order. 
+   If you need to rearrange the columns or fix the lengths of records, use the
+   'select' or 'fixlengths' commands. Also, only the headers of the *first* CSV
+   data given are used. Headers in subsequent inputs are ignored. (This behavior
+   can be disabled with --no-headers.)
+
+'rowskey' subcommand:
+   CSV data can have different numbers of columns and in different orders. All
+   columns are written in insertion order. Does not work with --no-headers, as
+   the column header names are used as keys. Nor does it work with stdin, as 
+   input files are scanned twice - once for collecting all the column names, and
+   the second time for writing the output.
+
+For examples, see https://github.com/jqnatividad/qsv/blob/master/tests/test_cat.rs.
 
 Usage:
     qsv cat rows    [options] [<input>...]
+    qsv cat rowskey [options] [<input>...]
     qsv cat columns [options] [<input>...]
     qsv cat --help
 
@@ -32,6 +45,7 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
+use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
 
 use crate::{
@@ -42,6 +56,7 @@ use crate::{
 #[derive(Deserialize)]
 struct Args {
     cmd_rows:        bool,
+    cmd_rowskey:     bool,
     cmd_columns:     bool,
     arg_input:       Vec<String>,
     flag_pad:        bool,
@@ -54,6 +69,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     if args.cmd_rows {
         args.cat_rows()
+    } else if args.cmd_rowskey {
+        args.cat_rowskey()
     } else if args.cmd_columns {
         args.cat_columns()
     } else {
@@ -77,6 +94,74 @@ impl Args {
             }
             while rdr.read_byte_record(&mut row)? {
                 wtr.write_byte_record(&row)?;
+            }
+        }
+        wtr.flush().map_err(From::from)
+    }
+
+    fn cat_rowskey(&self) -> CliResult<()> {
+        if self.flag_no_headers {
+            return fail_clierror!(
+                "cat rowskey does not support --no-headers, as we column headers as keys."
+            );
+        }
+        let mut columns_global: IndexSet<Box<[u8]>> = IndexSet::with_capacity(32);
+
+        // First pass, add all columns to an IndexSet
+        for conf in &self.configs()? {
+            if conf.is_stdin() {
+                return fail_clierror!(
+                    "cat rowskey does not support stdin, as we need to scan files twice."
+                );
+            }
+            let mut rdr = conf.reader()?;
+            let h = rdr.byte_headers()?;
+            for field in h {
+                let fi = field.to_vec().into_boxed_slice();
+                columns_global.insert(fi);
+            }
+        }
+        let num_columns_global = columns_global.len();
+
+        // Second pass, write all columns to a new file
+        let mut wtr = Config::new(&self.flag_output).writer()?;
+        for c in &columns_global {
+            wtr.write_field(c)?;
+        }
+        wtr.write_byte_record(&csv::ByteRecord::new())?;
+
+        for conf in self.configs()? {
+            let mut rdr = conf.reader()?;
+            let h = rdr.byte_headers()?;
+
+            let mut columns_of_this_file = IndexMap::with_capacity(num_columns_global);
+
+            for (n, field) in h.iter().enumerate() {
+                let fi = field.to_vec().into_boxed_slice();
+                if columns_of_this_file.contains_key(&fi) {
+                    wwarn!(
+                        "Duplicate column `{}` name in file `{:?}`.",
+                        String::from_utf8_lossy(&fi),
+                        conf.path,
+                    );
+                }
+                columns_of_this_file.insert(fi, n);
+            }
+
+            for row in rdr.byte_records() {
+                let row = row?;
+                for c in &columns_global {
+                    if let Some(idx) = columns_of_this_file.get(c) {
+                        if let Some(d) = row.get(*idx) {
+                            wtr.write_field(d)?;
+                        } else {
+                            wtr.write_field(b"")?;
+                        }
+                    } else {
+                        wtr.write_field(b"")?;
+                    }
+                }
+                wtr.write_byte_record(&csv::ByteRecord::new())?;
             }
         }
         wtr.flush().map_err(From::from)

--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -100,6 +100,7 @@ impl Args {
     }
 
     fn cat_rowskey(&self) -> CliResult<()> {
+        // this algorithm is largely inspired by https://github.com/vi/csvcatrow by @vi
         if self.flag_no_headers {
             return fail_clierror!(
                 "cat rowskey does not support --no-headers, as we column headers as keys."

--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -69,6 +69,108 @@ fn cat_rows_headers() {
 }
 
 #[test]
+fn cat_rowskey() {
+    let wrk = Workdir::new("cat_rowskey");
+    wrk.create(
+        "in1.csv",
+        vec![
+            svec!["a", "b", "c"],
+            svec!["1", "2", "3"],
+            svec!["2", "3", "4"],
+        ],
+    );
+
+    wrk.create(
+        "in2.csv",
+        vec![
+            svec!["c", "a", "b"],
+            svec!["3", "1", "2"],
+            svec!["4", "2", "3"],
+        ],
+    );
+
+    wrk.create(
+        "in3.csv",
+        vec![
+            svec!["a", "b", "d", "c"],
+            svec!["1", "2", "4", "3"],
+            svec!["2", "3", "5", "4"],
+            svec!["z", "y", "w", "x"],
+        ],
+    );
+
+    let mut cmd = wrk.command("cat");
+    cmd.arg("rowskey")
+        .arg("in1.csv")
+        .arg("in2.csv")
+        .arg("in3.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["a", "b", "c", "d"],
+        svec!["1", "2", "3", ""],
+        svec!["2", "3", "4", ""],
+        svec!["1", "2", "3", ""],
+        svec!["2", "3", "4", ""],
+        svec!["1", "2", "3", "4"],
+        svec!["2", "3", "4", "5"],
+        svec!["z", "y", "x", "w"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn cat_rowskey_insertion_order() {
+    let wrk = Workdir::new("cat_rowskey_insertion_order");
+    wrk.create(
+        "in1.csv",
+        vec![
+            svec!["j", "b", "c"],
+            svec!["1", "2", "3"],
+            svec!["2", "3", "4"],
+        ],
+    );
+
+    wrk.create(
+        "in2.csv",
+        vec![
+            svec!["c", "j", "b"],
+            svec!["3", "1", "2"],
+            svec!["4", "2", "3"],
+        ],
+    );
+
+    wrk.create(
+        "in3.csv",
+        vec![
+            svec!["j", "b", "d", "c"],
+            svec!["1", "2", "4", "3"],
+            svec!["2", "3", "5", "4"],
+            svec!["z", "y", "w", "x"],
+        ],
+    );
+
+    let mut cmd = wrk.command("cat");
+    cmd.arg("rowskey")
+        .arg("in1.csv")
+        .arg("in2.csv")
+        .arg("in3.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["j", "b", "c", "d"],
+        svec!["1", "2", "3", ""],
+        svec!["2", "3", "4", ""],
+        svec!["1", "2", "3", ""],
+        svec!["2", "3", "4", ""],
+        svec!["1", "2", "3", "4"],
+        svec!["2", "3", "4", "5"],
+        svec!["z", "y", "x", "w"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn prop_cat_cols() {
     fn p(rows1: CsvData, rows2: CsvData) -> TestResult {
         let got: Vec<Vec<String>> = run_cat(


### PR DESCRIPTION
Added a new `rowskey` subcommand, that is largely inspired by @vi's [csvcatrow](https://github.com/vi/csvcatrow)

resolves #787 and #527