### PR TITLE
add jemalloc support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "joinery"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +2942,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "itoa",
+ "jemallocator",
  "jql",
  "jsonschema",
  "jsonxf",
@@ -3626,9 +3647,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ indexmap = "1.9"
 indicatif = "0.17"
 itertools = "0.10"
 itoa = "1"
+jemallocator = { version = "0.5", optional = true }
 jsonschema = { version = "0.16", features = [
     "resolve-file",
     "resolve-http",

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,10 +37,27 @@ rustc --print target-features
 
 ## Memory Allocator
 
-By default, qsv uses an alternative allocator - [mimalloc](https://github.com/microsoft/mimalloc),
-a performance-oriented allocator from Microsoft.
-If you want to use the standard allocator, use the `--no-default-features` flag
-when installing/compiling qsv, e.g.:
+qsv supports three memory allocators: mimalloc, jemalloc and the standard allocator.
+
+By default, qsv uses [mimalloc](https://github.com/microsoft/mimalloc), a performance-oriented allocator from Microsoft.
+
+You can also use another alternative - the [jemalloc](https://jemalloc.net) allocator, which is the default Linux allocator used by the [Pola.rs](https://www.pola.rs) project for its python bindings, as benchmarks have shown that it [performs better than mimalloc on some platforms](https://docs.rs/polars/latest/polars/#custom-allocator).
+
+If you don't want to use mimalloc, use the `--no-default-features` flag when installing/compiling qsv, e.g.:
+
+### To use jemalloc
+
+```bash
+cargo install qsv --path . --no-default-features --features all_full,jemallocator
+```
+
+or
+
+```bash
+cargo build --release --no-default-features --features all_full,jemallocator
+```
+
+### To use the standard allocator
 
 ```bash
 cargo install qsv --path . --no-default-features --features all_full

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,10 @@ use crate::clitypes::{CliError, CliResult, QsvExitCode};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(feature = "jemallocator")]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 mod clitypes;
 mod cmd;
 mod config;

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -45,6 +45,10 @@ use crate::clitypes::{CliError, CliResult, QsvExitCode};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(feature = "jemallocator")]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 macro_rules! command_list {
     () => {
         "

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -10,6 +10,10 @@ use crate::clitypes::{CliError, CliResult, QsvExitCode};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(feature = "jemallocator")]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 macro_rules! command_list {
     () => {
         "

--- a/src/util.rs
+++ b/src/util.rs
@@ -136,9 +136,11 @@ pub fn version() -> String {
     let free_swap = sys.free_swap();
 
     #[cfg(feature = "mimalloc")]
-    let malloc_kind = "mimalloc".to_string();
-    #[cfg(not(feature = "mimalloc"))]
-    let malloc_kind = "standard".to_string();
+    let malloc_kind = "mimalloc";
+    #[cfg(feature = "jemallocator")]
+    let malloc_kind = "jemalloc";
+    #[cfg(not(any(feature = "mimalloc", feature = "jemallocator")))]
+    let malloc_kind = "standard";
     let (qsvtype, maj, min, pat, pre, rustversion) = (
         option_env!("CARGO_BIN_NAME"),
         option_env!("CARGO_PKG_VERSION_MAJOR"),


### PR DESCRIPTION
Allow users to use the jemalloc allocator if they want to, as mimalloc is not supported on some platforms, and sometimes jemalloc is faster/more memory-efficient for some workloads.

We'll continue to use mimalloc by default.