### PR TITLE
`joinp`: LazyFrame refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ parking_lot = { version = "0.12", features = ["hardware-lock-elision"] }
 polars = { version = "0.27", features = [
     "performant",
     "lazy",
+    "streaming",
     "cross_join",
     "semi_anti_join",
 ], optional = true }


### PR DESCRIPTION
- switch from DataFrames to LazyFrames for increased performance
- switch to using JoinBuilder for added flexibility
- turn on all optimizations for LazyFrames