### PR TITLE
`diff`: implement option to sort by columns

### DIFF
--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -52,16 +52,16 @@ use crate::{
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input_left: Option<String>,
-    arg_input_right: Option<String>,
-    flag_output: Option<String>,
-    flag_jobs: Option<usize>,
-    flag_no_headers_left: bool,
+    arg_input_left:        Option<String>,
+    arg_input_right:       Option<String>,
+    flag_output:           Option<String>,
+    flag_jobs:             Option<usize>,
+    flag_no_headers_left:  bool,
     flag_no_headers_right: bool,
     flag_delimiter_left:   Option<Delimiter>,
     flag_delimiter_right:  Option<Delimiter>,
     flag_key:              Option<String>,
-    flag_sort_columns: Option<String>,
+    flag_sort_columns:     Option<String>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -23,6 +23,13 @@ diff options:
     -k, --key <arg...>          The column indices that uniquely identify a record
                                 as a comma separated list of indices, e.g. 0,1,2.
                                 (default: 0)
+    --sort-columns <arg...>     The column indices by which the diff result should be
+                                sorted as a comma separated list of indices, e.g. 0,1,2.
+                                Records in the diff result that are marked as "modified"
+                                ("delete" and "add" records that have the same key,
+                                but have different content) will always be kept together
+                                in the sorted diff result and so won't be sorted
+                                independently from each other.
     -j, --jobs <arg>            The number of jobs to run in parallel.
                                 When not set, the number of jobs is set to the number
                                 of CPUs detected.
@@ -45,15 +52,16 @@ use crate::{
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input_left:        Option<String>,
-    arg_input_right:       Option<String>,
-    flag_output:           Option<String>,
-    flag_jobs:             Option<usize>,
-    flag_no_headers_left:  bool,
+    arg_input_left: Option<String>,
+    arg_input_right: Option<String>,
+    flag_output: Option<String>,
+    flag_jobs: Option<usize>,
+    flag_no_headers_left: bool,
     flag_no_headers_right: bool,
     flag_delimiter_left:   Option<Delimiter>,
     flag_delimiter_right:  Option<Delimiter>,
     flag_key:              Option<String>,
+    flag_sort_columns: Option<String>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -82,6 +90,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .map_err(|err| CliError::Other(err.to_string()))?,
     };
 
+    let sort_cols = args
+        .flag_sort_columns
+        .map(|s| {
+            s.split(',')
+                .map(str::parse::<usize>)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| CliError::Other(err.to_string()))
+        })
+        .transpose()?;
+
     let wtr = Config::new(&args.flag_output).writer()?;
     let mut csv_rdr_left = rconfig_left.reader()?;
     let mut csv_rdr_right = rconfig_right.reader()?;
@@ -102,7 +120,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .diff(csv_rdr_left.into(), csv_rdr_right.into())
         .try_to_diff_byte_records()?;
 
-    diff_byte_records.sort_by_line();
+    match sort_cols {
+        Some(sort_cols) => {
+            diff_byte_records
+                .sort_by_columns(sort_cols)
+                .map_err(|e| CliError::Other(e.to_string()))?;
+        }
+        None => {
+            diff_byte_records.sort_by_line();
+        }
+    }
 
     Ok(csv_diff_writer.write_diff_byte_records(diff_byte_records)?)
 }

--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -122,3 +122,45 @@ diffresult,case_enquiry_id,open_dt,target_dt,closed_dt,ontime,case_status,closur
         "#.trim().to_string()
     }
 }
+
+#[test]
+fn diff_sort_diff_result_by_first_column() {
+    let wrk = Workdir::new("diff");
+    let test_file = wrk.load_test_file("boston311-100.csv");
+    let test_file2 = wrk.load_test_file("boston311-100-diff.csv");
+
+    let mut cmd = wrk.command("diff");
+    cmd.arg("--sort-columns")
+        .arg("0")
+        .arg(test_file)
+        .arg(test_file2);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    let diff_result_file_name = "diff_result_original_left_diff_right_sort_columns.csv";
+
+    wrk.create(diff_result_file_name, got);
+
+    let mut cmd = wrk.command("select");
+    // select all columns
+    cmd.arg("1-").arg(diff_result_file_name);
+
+    let actual: String = wrk.stdout(&mut cmd);
+    let expected = create_expected_diff_result_when_sorting_by_first_column();
+
+    assert_eq!(dos2unix(&actual), dos2unix(&expected));
+
+    fn create_expected_diff_result_when_sorting_by_first_column() -> String {
+        r#"
+diffresult,case_enquiry_id,open_dt,target_dt,closed_dt,ontime,case_status,closure_reason,case_title,subject,reason,type,queue,department,submittedphoto,closedphoto,location,fire_district,pwd_district,city_council_district,police_district,neighborhood,neighborhood_services_district,ward,precinct,location_street_name,location_zipcode,latitude,longitude,source
+-,101004113747,2022-01-01 23:46:09,2022-01-17 08:30:00,2022-01-02 11:03:10,ONTIME,Closed,Case Closed. Closed date : Sun Jan 02 11:03:10 EST 2022 Noted Case noted. Duplicate case. Posts already marked for contractor to repair.  ,Street Light Outages,Public Works Department,Street Lights,Street Light Outages,PWDx_Street Light Outages,PWDx,https://311.boston.gov/media/boston/report/photos/61d12e0705bbcf180c29cfc2/report.jpg,,103 N Beacon St  Brighton  MA  02135,11,04,9,D14,Brighton,15,22,2205,103 N Beacon St,02135,42.3549,-71.143,Citizens Connect App
++,101004113747,2022-01-01 23:46:09,2022-01-17 08:30:00,2022-01-02 11:04:10,ONTIME,Closed,Case Closed. Closed date : Sun Jan 02 11:03:10 EST 2022 Noted Case noted. Duplicate case. Posts already marked for contractor to repair.  ,Street Light Outages,Public Works Department,Street Lights,Street Light Outages,PWDx_Street Light Outages,PWDx,https://311.boston.gov/media/boston/report/photos/61d12e0705bbcf180c29cfc2/report.jpg,,103 N Beacon St  Brighton  MA  02135,11,04,9,D14,Brighton,15,22,2205,103 N Beacon St,02135,42.3549,-71.143,Citizens Connect App
+-,101004114069,2022-01-02 14:11:49,2022-01-05 08:30:00,2022-01-03 06:52:40,ONTIME,Closed,Case Closed. Closed date : Mon Jan 03 06:52:40 EST 2022 Resolved No violation found at this time  today is trash day.  ,Improper Storage of Trash (Barrels),Public Works Department,Code Enforcement,Improper Storage of Trash (Barrels),PWDx_Code Enforcement,PWDx,https://311.boston.gov/media/boston/report/photos/61d1f8e905bbcf180c2a3d7f/report.jpg,,22 Henchman St  Boston  MA  02109,3,1B,1,A1,Downtown / Financial District,3,Ward 3,0302,22 Henchman St,02109,42.3674,-71.0537,Citizens Connect App
++,101004114069,2022-01-02 14:11:49,2022-01-05 08:30:00,2022-01-03 06:52:40,ONTIME,Closed,Case Closed. Closed date : Mon Jan 03 06:52:40 EST 2022 Resolved No violation found at this time today is trash day.  ,Improper Storage of Trash (Barrels),Public Works Department,Code Enforcement,Improper Storage of Trash (Barrels),PWDx_Code Enforcement,PWDx,https://311.boston.gov/media/boston/report/photos/61d1f8e905bbcf180c2a3d7f/report.jpg,,22 Henchman St  Boston  MA  02109,3,1B,1,A1,Downtown / Financial District,3,Ward 3,0302,22 Henchman St,02109,42.3674,-71.0537,Citizens Connect App
+-,101004114152,2022-01-02 16:18:30,2022-01-10 08:30:00,2022-01-02 16:32:54,ONTIME,Closed,Case Closed. Closed date : Sun Jan 02 16:32:54 EST 2022 Noted This not not a city park  ,Litter / Ground Maintenance - Wellington Green (BPRD),Parks & Recreation Department,Park Maintenance & Safety,Ground Maintenance,PARK_Maintenance_Ground Maintenance,PARK,https://311.boston.gov/media/boston/report/photos/61d2169605bbcf180c2a4d65/photo_20220102_161627.jpg,,563 Columbus Ave  Roxbury  MA  02118,4,1C,7,D4,South End,6,Ward 4,0404,563 Columbus Ave,02118,42.3412,-71.0815,Citizens Connect App
++,101004114152,2022-01-02 16:18:30,2022-01-10 08:30:00,2022-01-02 16:32:54,ONTIME,Closed,Case Closed. Closed date : Sun Jan 02 16:32:54 EST 2022 Noted This not not a city park  ,Litter/Ground Maintenance - Wellington Green (BPRD),Parks & Recreation Department,Park Maintenance & Safety,Ground Maintenance,PARK_Maintenance_Ground Maintenance,PARK,https://311.boston.gov/media/boston/report/photos/61d2169605bbcf180c2a4d65/photo_20220102_161627.jpg,,563 Columbus Ave  Roxbury  MA  02118,4,1C,7,D4,South End,6,Ward 4,0404,563 Columbus Ave,02118,42.3412,-71.0815,Citizens Connect App
+-,101004114377,2022-01-03 07:50:09,2022-01-04 08:30:00,2022-01-03 10:35:57,ONTIME,Closed,Case Closed. Closed date : 2022-01-03 10:35:57.797 Case Resolved Vehicles mere moved will check again  ,Parking Enforcement,Transportation - Traffic Division,Enforcement & Abandoned Vehicles,Parking Enforcement,BTDT_Parking Enforcement,BTDT,,,618 E Sixth St  South Boston  MA  02127,6,05,2,C6,South Boston / South Boston Waterfront,5,Ward 6,0606,618 E Sixth St,02127,42.3332,-71.0357,Citizens Connect App
++,101004114377,2022-01-03 07:50:09,2022-01-04 08:30:00,2022-01-03 10:35:57,ONTIME,Closed,Case Closed. Closed date : 2022-01-03 10:35:57.797 Case Resolved Vehicles mere moved will check again sir ,Parking Enforcement,Transportation - Traffic Division,Enforcement & Abandoned Vehicles,Parking Enforcement,BTDT_Parking Enforcement,BTDT,,,618 E Sixth St  South Boston  MA  02127,6,05,2,C6,South Boston / South Boston Waterfront,5,Ward 6,0606,618 E Sixth St,02127,42.3332,-71.0357,Citizens Connect App
+        "#.trim().to_string()
+    }
+}


### PR DESCRIPTION
## What this implements
This implements the option for `diff` to sort by multiple columns.

Example (where the first column is the key):

left.csv
```
id1,a,c
id2,1,a
id3,2,6
id4,b,_
```
right.csv
```
id1,a,a
id7,1,b
id8,2,5
id4,a,_
```

```
qsv diff --sort-columns 1,2 left.csv right.csv
```

This will sort the resulting diff by column with index 1 (and 2, if the field of two diff records compare as equal). The comparison is done based on `&[u8]` (which is the content of a field as a byte slice).

Based on the above example, the sorted diffresult looks like this:
```
-,id2,1,a
+,id7,1,b
+,id8,2,5
-,id3,2,6
-,id1,a,c
+,id1,a,a
-,id4,b,_
+,id4,a,_
```
Currently, comparison against records of type `Modify` are done against the `delete` record of the `Modify` record. If this comparison is equal, it will fall back to comparing it with the `add` record of the `Modify` record
(also see https://gitlab.com/janriemer/csv-diff/-/blob/27b80a9f42183667b431df2b91dacfa4b8f457d1/src/diff_result.rs#L1166-1187).

## Current limitations
Note that modified records (-+ records with the same key) __are always kept together__, which makes the result not fully sorted between those pairs. This is a current limitation of the underlying library `csv-diff`. This limitation _might_ be resolved in the future (also see https://gitlab.com/janriemer/csv-diff/-/issues/14).   
This limitation can also be seen as an advantage, though, because one can more easily see the related record of the one modified row.

## When this operation can fail
Note that sorting by column can fail, if one provides an index that is out of bounds.

----------------------------

Depends on #826 
Closes https://github.com/jqnatividad/qsv/issues/714