### PR TITLE
`luau`: added `qsv_autoindex()` helper function

### DIFF
--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -442,6 +442,98 @@ END {
 }
 
 #[test]
+fn luau_aggregation_with_embedded_begin_end_using_file_random_access_with_qsv_autoindex() {
+    let wrk = Workdir::new("luau_embedded_qsv_index");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["letter", "Amount"],
+            svec!["a", "13"],
+            svec!["b", "24"],
+            svec!["c", "72"],
+            svec!["d", "7"],
+        ],
+    );
+
+    wrk.create_from_string(
+        "testbeginend.luau",
+        r#"
+BEGIN {
+    -- this is the BEGIN block, which is executed once at the beginning
+    -- where we typically initialize variables
+    running_total = 0;
+    grand_total = 0;
+    amount_array = {};
+
+    -- here we call qsv_autoindex() to create/update an index if required 
+    -- so we can do random access on the CSV with the _INDEX special variable
+    -- qsv_autoindex() should only be called from the BEGIN block
+    csv_indexed = qsv_autoindex();
+
+    -- note how we use the qsv_log function to log to the qsv log file
+    qsv_log("debug", " _INDEX:", _INDEX, " _ROWCOUNT:", _ROWCOUNT, " csv_indexed:", csv_indexed)
+
+    -- start from the end of the CSV file, set _INDEX to _LASTROW
+    _INDEX = _LASTROW;
+}!
+
+
+----------------------------------------------------------------------------
+-- this is the MAIN script, which is executed for the row specified by _INDEX
+-- As we are doing random access, to exit this loop, we need to set 
+-- _INDEX to less than zero or greater than _LASTROW
+
+amount_array[_INDEX] = Amount;
+running_total = running_total + Amount;
+grand_total = grand_total + running_total;
+
+qsv_log("warn", "logging from Luau script! running_total:", running_total, " _INDEX:", _INDEX)
+
+-- we modify _INDEX to do random access on the CSV file, in this case going backwards
+-- the MAIN script ends when _INDEX is less than zero or greater than _LASTROW
+_INDEX = _INDEX - 1;
+
+-- running_total is the value we "map" to the "Running Total" column of each row
+return running_total;
+
+
+----------------------------------------------------------------------------
+END {
+    -- and this is the END block, which is executed once at the end
+    -- note how we use the _ROWCOUNT special variable to get the number of rows
+    min_amount = math.min(unpack(amount_array));
+    max_amount = math.max(unpack(amount_array));
+    return ("Min/Max: " .. min_amount .. "/" .. max_amount ..
+       " Grand total of " .. _ROWCOUNT .. " rows: " .. grand_total);
+}!
+"#,
+    );
+
+    let mut cmd = wrk.command("luau");
+    cmd.arg("map")
+        .arg("Running Total")
+        .arg("-x")
+        .arg("file:testbeginend.luau")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "Amount", "Running Total"],
+        svec!["d", "7", "7"],
+        svec!["c", "72", "79"],
+        svec!["b", "24", "103"],
+        svec!["a", "13", "116"],
+    ];
+    assert_eq!(got, expected);
+
+    let end = wrk.output_stderr(&mut cmd);
+    let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 305\n".to_string();
+    assert_eq!(end, expected_end);
+
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
 fn luau_aggregation_with_embedded_begin_end_using_file_random_access_multiple_columns() {
     let wrk = Workdir::new("luau_embedded_multiple_columns");
     wrk.create_indexed(


### PR DESCRIPTION
This allows users to create/update an index from the BEGIN block of a Luau script if they want to run `luau` in random access mode.

Previously, an index had to be created manually beforehand.