### PR TITLE
use qsv_docopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,17 +1521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "docopt"
-version = "1.1.1"
-source = "git+https://github.com/jqnatividad/docopt.rs?branch=perf-clippy-2023#86cd3afc0b5dac9bb3fec6882beb8f9f4bb3a05d"
-dependencies = [
- "lazy_static",
- "regex",
- "serde",
- "strsim 0.10.0",
-]
-
-[[package]]
 name = "duckdb"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,7 +3503,6 @@ dependencies = [
  "csv-index",
  "csvs_convert",
  "data-encoding",
- "docopt",
  "dynfmt",
  "eudex",
  "ext-sort",
@@ -3548,6 +3536,7 @@ dependencies = [
  "qsv-sniffer",
  "qsv-stats",
  "qsv_currency",
+ "qsv_docopt",
  "quickcheck",
  "rand",
  "rayon",
@@ -3626,6 +3615,18 @@ checksum = "e34b3032b7942a4217f388aeac39a8b2f2d50405d6e21185d06c3c45d1e4ca9e"
 dependencies = [
  "num",
  "serde",
+]
+
+[[package]]
+name = "qsv_docopt"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "255f1adc730b5f797f665b93407ec754db6cbab94c798c531cf2d6ec4d257025"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "serde",
+ "strsim 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ csv-diff = "0.1.0-beta.4"
 csv-index = "0.1"
 csvs_convert = { version = "0.8", optional = true }
 data-encoding = { version = "2.3", optional = true }
-docopt = "1"
 dynfmt = { version = "0.1", default-features = false, features = [
     "curly",
 ], optional = true }
@@ -128,6 +127,7 @@ polars = { version = "0.27", features = [
 ], optional = true }
 pyo3 = { version = "0.18", features = ["auto-initialize"], optional = true }
 qsv-dateparser = "0.6"
+qsv_docopt = "1.2"
 qsv-stats = "0.7"
 qsv_currency = { version = "0.6", optional = true }
 qsv-sniffer = { version = "0.7", features = ["runtime-dispatch-simd"] }
@@ -190,7 +190,6 @@ quickcheck = { version = "1", default-features = false }
 serial_test = "1.0"
 
 [patch.crates-io]
-docopt    = { git = "https://github.com/jqnatividad/docopt.rs", branch = "perf-clippy-2023" }
 ext-sort  = { git = "https://github.com/jqnatividad/ext-sort-rs", branch = "perf-tweaks" }
 tabwriter = { git = "https://github.com/jqnatividad/tabwriter", branch = "tweaks-2023" }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@
 extern crate crossbeam_channel as channel;
 use std::{env, io, time::Instant};
 
+extern crate qsv_docopt as docopt;
 use docopt::Docopt;
 use serde::Deserialize;
 

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -36,6 +36,7 @@
 extern crate crossbeam_channel as channel;
 use std::{env, io, time::Instant};
 
+extern crate qsv_docopt as docopt;
 use docopt::Docopt;
 use serde::Deserialize;
 

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -1,6 +1,7 @@
 extern crate crossbeam_channel as channel;
 use std::{env, io, time::Instant};
 
+extern crate qsv_docopt as docopt;
 use docopt::Docopt;
 use serde::Deserialize;
 


### PR DESCRIPTION
as docopt.rs is no longer maintained, and we want to keep improving docopt, as qsv has fully embraced its self-documenting usage text syntax that neither clap nor structopt can provide.