### PR TITLE
`luau`: add support for "dathere://" lookup scheme

### DIFF
--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -1342,7 +1342,9 @@ fn setup_helpers(luau: &Lua, delimiter: Option<Delimiter>) -> Result<(), CliErro
     //       lookup_table_uri: The name of the CSV file to load. Note that it will use
     //                         the luau --delimiter option if specified.
     //                         This can be a file on the filesystem or on at a URL
-    //                         ("http" and "https" schemes supported)
+    //                         ("http", "https" and "dathere" schemes supported).
+    //                         The dathere scheme is used to access lookup-ready CSVs
+    //                         on https://github.com/dathere/qsv-lookup-tables.
     //                returns: Luau table of header names excluding the first header,
     //                         or Luau runtime error if the CSV could not be loaded
     //
@@ -1366,6 +1368,11 @@ fn setup_helpers(luau: &Lua, delimiter: Option<Delimiter>) -> Result<(), CliErro
         let lookup_name_str = lookup_name.as_str().unwrap_or_default();
         let lookup_table_uri = luau.from_value::<serde_json::Value>(args.pop_front().unwrap())?;
         let mut lookup_table_uri_string = lookup_table_uri.as_str().unwrap_or_default().to_string();
+
+        // if the lookup_table_uri starts with "dathere://", prepend the repo URL to the lookup table
+        if let Some(lookup_url) = lookup_table_uri_string.strip_prefix("dathere://") {
+            lookup_table_uri_string = format!("https://raw.githubusercontent.com/dathere/qsv-lookup-tables/main/lookup-tables/{lookup_url}");
+        }
 
         let lookup_on_url = lookup_table_uri_string.to_lowercase().starts_with("http");
 

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -531,6 +531,98 @@ END {
 }
 
 #[test]
+fn luau_register_lookup_table_on_dathere_url() {
+    let wrk = Workdir::new("luau_register_lookup_table_on_dathere_url");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["letter", "Amount"],
+            svec!["a", "13"],
+            svec!["b", "24"],
+            svec!["c", "72"],
+            svec!["d", "7"],
+        ],
+    );
+
+    wrk.create_from_string(
+        "testlookup.luau",
+        r#"
+BEGIN {
+    -- this is the BEGIN block, which is executed once at the beginning
+    -- where we typically initialize variables
+    running_total = 0;
+    grand_total = 0;
+    amount_array = {};
+    csv_indexed = qsv_autoindex();
+
+    us_states_lookup_headers = qsv_register_lookup("us_states", 
+      "dathere://us-states-example.csv")
+
+    -- note how we use the qsv_log function to log to the qsv log file
+    qsv_log("debug", " _INDEX:", _INDEX, " _ROWCOUNT:", _ROWCOUNT, " csv_indexed:", csv_indexed)
+    qsv_log("debug", "us_states_lookup_headers:", us_states_lookup_headers)
+    qsv_log("debug", "us_states lookup table:", us_states)
+    qsv_log("debug", "NY Capital:", us_states["NY"]["Capital"], " can be also: ", us_states.NY.Capital)
+    -- start from the end of the CSV file, set _INDEX to _LASTROW
+    _INDEX = _LASTROW;
+}!
+
+
+----------------------------------------------------------------------------
+-- this is the MAIN script, which is executed for the row specified by _INDEX
+-- As we are doing random access, to exit this loop, we need to set 
+-- _INDEX to less than zero or greater than _LASTROW
+
+amount_with_nytax = Amount + Amount * (us_states.NY["Sales Tax (2023)"] / 100);
+amount_array[_INDEX] = amount_with_nytax;
+running_total = running_total + amount_with_nytax;
+
+qsv_log("warn", "logging from Luau script! running_total:", running_total, " _INDEX:", _INDEX)
+
+-- we modify _INDEX to do random access on the CSV file, in this case going backwards
+-- the MAIN script ends when _INDEX is less than zero or greater than _LASTROW
+_INDEX = _INDEX - 1;
+
+-- running_total is the value we "map" to the "Running Total" column of each row
+return running_total;
+
+
+----------------------------------------------------------------------------
+END {
+    -- and this is the END block, which is executed once at the end
+    -- note how we use the _ROWCOUNT special variable to get the number of rows
+    min_amount = math.min(unpack(amount_array));
+    max_amount = math.max(unpack(amount_array));
+    grand_total = running_total;
+    return `Min/Max: {min_amount}/{max_amount} Grand total of {_ROWCOUNT} rows: {grand_total}`;
+}!
+"#);
+
+    let mut cmd = wrk.command("luau");
+    cmd.arg("map")
+        .arg("Running Total")
+        .arg("-x")
+        .arg("file:testlookup.luau")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "Amount", "Running Total"],
+        svec!["d", "7", "7.28"],
+        svec!["c", "72", "82.16"],
+        svec!["b", "24", "107.12"],
+        svec!["a", "13", "120.64"],
+    ];
+    assert_eq!(got, expected);
+
+    let end = wrk.output_stderr(&mut cmd);
+    let expected_end = "Min/Max: 7.28/74.88 Grand total of 4 rows: 120.64\n".to_string();
+    assert_eq!(end, expected_end);
+
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
 fn luau_qsv_break() {
     let wrk = Workdir::new("luau_qsv_break");
     wrk.create(


### PR DESCRIPTION
download prepared lookup tables from https://github.com/dathere/qsv-lookup-tables repo
by simply using the "dathere://" scheme.  For example:

```
qsv_register_lookup("us-states", "dathere://us-states-example.csv")
```