### PR TITLE
`input`: add  --comment option

### DIFF
--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -38,6 +38,8 @@ input options:
     --skip-lastlines <arg>   The number of epilogue lines to skip.
     --trim-headers           Trim leading & trailing whitespace & quotes from header values.
     --trim-fields            Trim leading & trailing whitespace from field values.
+    --comment <char>         The comment character to use. When set, lines
+                             starting with this character will be skipped.
 
 Common options:
     -h, --help               Display this message
@@ -67,6 +69,7 @@ struct Args {
     flag_auto_skip:      bool,
     flag_trim_headers:   bool,
     flag_trim_fields:    bool,
+    flag_comment:        Option<char>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -82,10 +85,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if args.flag_auto_skip {
         std::env::set_var("QSV_SNIFF_PREAMBLE", "1");
     }
+
+    let mut comment_char: Option<u8> = None;
+    if let Some(char) = args.flag_comment {
+        comment_char = Some(char as u8);
+    }
+
     let mut rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)
         .no_headers(true)
         .quote(args.flag_quote.as_byte())
+        .comment(comment_char)
         .trim(trim_setting);
     if args.flag_auto_skip {
         std::env::remove_var("QSV_SNIFF_PREAMBLE");

--- a/tests/test_input.rs
+++ b/tests/test_input.rs
@@ -1,6 +1,37 @@
 use crate::workdir::Workdir;
 
 #[test]
+fn test_input_comment() {
+    let wrk = Workdir::new("input_comment");
+    wrk.create(
+        "preamble.csv",
+        vec![
+            svec!["# test file to see how skiplines work", ""],
+            svec!["# this is another comment before the header", ""],
+            svec!["# DATA DICTIONARY", ""],
+            svec!["# column1 - alphabetic; id of the column", ""],
+            svec!["# column2 - numeric; just a number", ""],
+            svec!["column1", "column2"],
+            svec!["a", "1"],
+            svec!["c", "3"],
+            svec!["# comment here too!", "5"],
+            svec!["e", "5"],
+        ],
+    );
+    let mut cmd = wrk.command("input");
+    cmd.arg("--comment").arg("#").arg("preamble.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["column1", "column2"],
+        svec!["a", "1"],
+        svec!["c", "3"],
+        svec!["e", "5"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn test_input_skiplines() {
     let wrk = Workdir::new("input_skiplines");
     wrk.create(


### PR DESCRIPTION
so you can specify the comment char not just thru QSV_COMMENT_CHAR env_var