### PR TITLE
`luau`:  added `qsv_writefile` helper function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ reqwest = { version = "0.11", features = [
 reverse_geocoder = { version = "3", optional = true }
 rust_decimal = "1.29"
 ryu = "1"
+sanitise-file-name = { version = "1.0", optional = true }
 self_update = { version = "0.36", features = [
     "archive-zip",
     "compression-zip-deflate",
@@ -236,7 +237,7 @@ fetch = [
 ]
 foreach = []
 generate = ["test-data-generation"]
-luau = ["mlua"]
+luau = ["mlua", "sanitise-file-name"]
 python = ["pyo3"]
 to = ["csvs_convert"]
 lite = []

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -704,6 +704,38 @@ END {
 }
 
 #[test]
+fn luau_writefile() {
+    let wrk = Workdir::new("luau_writefile");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["metric_name", "target_score"],
+            svec!["POTHOLE ON-TIME %", "0.6"],
+            svec!["ON-TIME PERMIT REVIEWS", "0.6"],
+            svec!["BFD RESPONSE TIME", "0.6"],
+            svec!["BPS ATTENDANCE", "0.6"],
+        ],
+    );
+
+    wrk.create_from_string(
+        "testwrite.luau",
+        r#"
+qsv_writefile("c:\windows\testfile.txt", `{metric_name} new target: {target_score * 2}\n`)
+return target_score * 2;
+"#,
+    );
+
+    let mut cmd = wrk.command("luau");
+    cmd.arg("map")
+        .arg("new_target")
+        .arg("-x")
+        .arg("file:testwrite.luau")
+        .arg("data.csv");
+
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
 fn luau_qsv_break() {
     let wrk = Workdir::new("luau_qsv_break");
     wrk.create(


### PR DESCRIPTION
this is a helper function that can be called from the BEGIN, MAIN & END scripts to write to a file. The file will be created if it does not exist. The file will be appended to if it already exists. The filename will be sanitized and will be written to the current working directory. The file will be closed after the write is complete.
    
      qsv_writefile(filename: string, data: string)
           filename: the name of the file to write to
         stringdata: the string to write to the file. Note that a newline will not be added
                     automatically.
            returns: A Luau runtime error is returned if the file cannot be opened or written.
    