### PR TITLE
Standard timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ We still do this to prevent OOM panics, but it's not as conservative as the defa
 | `QSV_REDIS_MAX_POOL_SIZE` | the maximum Redis connection pool size. (default: 20). |
 | `QSV_REDIS_TTL_SECONDS` | set time-to-live of Redis cached values (default (seconds): 2419200 (28 days)). |
 | `QSV_REDIS_TTL_REFRESH`| if set, enables cache hits to refresh TTL of cached values. |
+| `QSV_TIMEOUT`| for commands with a --timeout option (`fetch`, `fetchpost`, `luau`, `sniff` and `validate`), the number of seconds before a web request times out (default: 30). |
 
 Several dependencies also have environment variables that influence qsv's performance & behavior:
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -222,7 +222,7 @@ struct Args {
     flag_jqlfile:      Option<String>,
     flag_pretty:       bool,
     flag_rate_limit:   u32,
-    flag_timeout:      u64,
+    flag_timeout:      u16,
     flag_http_header:  Vec<String>,
     flag_max_retries:  u8,
     flag_max_errors:   u64,
@@ -307,13 +307,9 @@ static JQL_GROUPS: once_cell::sync::OnceCell<Vec<jql::Group>> = OnceCell::new();
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    if args.flag_timeout > 3_600 {
-        return fail!("Timeout cannot be more than 3,600 seconds (1 hour).");
-    } else if args.flag_timeout == 0 {
-        return fail!("Timeout cannot be zero.");
-    }
-    info!("TIMEOUT: {} secs", args.flag_timeout);
-    TIMEOUT_SECS.set(args.flag_timeout).unwrap();
+    TIMEOUT_SECS
+        .set(util::timeout_secs(args.flag_timeout)?)
+        .unwrap();
 
     if args.flag_redis {
         // check if redis connection is valid

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -132,7 +132,7 @@ Fetch options:
                                default of 10.
                                [default: 0 ]
     --timeout <seconds>        Timeout for each URL request.
-                               [default: 15 ]
+                               [default: 30 ]
     -H, --http-header <k:v>    Append custom header(s) to the HTTP header. Pass multiple key-value pairs
                                by adding this option multiple times, once for each pair. The key and value 
                                should be separated by a colon.

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -213,7 +213,7 @@ struct Args {
     flag_jqlfile:     Option<String>,
     flag_pretty:      bool,
     flag_rate_limit:  u32,
-    flag_timeout:     u64,
+    flag_timeout:     u16,
     flag_http_header: Vec<String>,
     flag_compress:    bool,
     flag_max_retries: u8,
@@ -295,13 +295,9 @@ static JQL_GROUPS: once_cell::sync::OnceCell<Vec<jql::Group>> = OnceCell::new();
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    if args.flag_timeout > 3_600 {
-        return fail!("Timeout cannot be more than 3,600 seconds (1 hour).");
-    } else if args.flag_timeout == 0 {
-        return fail!("Timeout cannot be zero.");
-    }
-    info!("TIMEOUT: {} secs", args.flag_timeout);
-    TIMEOUT_FP_SECS.set(args.flag_timeout).unwrap();
+    TIMEOUT_FP_SECS
+        .set(util::timeout_secs(args.flag_timeout)?)
+        .unwrap();
 
     if args.flag_redis {
         // check if redis connection is valid

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -118,7 +118,7 @@ Fetchpost options:
                                default of 10.
                                [default: 0 ]
     --timeout <seconds>        Timeout for each URL request.
-                               [default: 15 ]
+                               [default: 30 ]
     -H, --http-header <k:v>    Append custom header(s) to the HTTP header. Pass multiple key-value pairs
                                by adding this option multiple times, once for each pair. The key and value 
                                should be separated by a colon.

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -170,7 +170,7 @@ Luau options:
                              [default: 100]
     --timeout <seconds>      Timeout for downloading lookup_tables using
                              the qsv_register_lookup() helper function.
-                             [default: 15]
+                             [default: 30]
     --ckan-api <url>         The URL of the CKAN API to use for downloading lookup_table
                              resources using the qsv_register_lookup() helper function
                              with the "ckan://" scheme.

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -285,13 +285,11 @@ static TIMEOUT_SECS: AtomicU16 = AtomicU16::new(15);
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    if args.flag_timeout > 3_600 {
-        return fail!("Timeout cannot be more than 3,600 seconds (1 hour).");
-    } else if args.flag_timeout == 0 {
-        return fail!("Timeout cannot be zero.");
-    }
-    info!("TIMEOUT: {} secs", args.flag_timeout);
-    TIMEOUT_SECS.store(args.flag_timeout, Ordering::Relaxed);
+    // safety: its safe since flag_timeout is a u16
+    TIMEOUT_SECS.store(
+        util::timeout_secs(args.flag_timeout)?.try_into().unwrap(),
+        Ordering::Relaxed,
+    );
 
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -88,7 +88,7 @@ struct Args {
     flag_pretty_json:    bool,
     flag_delimiter:      Option<Delimiter>,
     flag_progressbar:    bool,
-    flag_timeout:        u64,
+    flag_timeout:        u16,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -243,7 +243,9 @@ async fn get_file_to_sniff(args: &Args) -> CliResult<SniffFileStruct> {
 
                 let res = client
                     .get(url.clone())
-                    .timeout(Duration::from_secs(args.flag_timeout))
+                    .timeout(Duration::from_secs(
+                        util::timeout_secs(args.flag_timeout).unwrap_or(30),
+                    ))
                     .send()
                     .await
                     .or(Err(format!("Failed to GET from '{url}'")))?;

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -111,13 +111,10 @@ struct RFC4180Struct {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    if args.flag_timeout > 3_600 {
-        return fail!("Timeout cannot be more than 3,600 seconds (1 hour).");
-    } else if args.flag_timeout == 0 {
-        return fail!("Timeout cannot be zero.");
-    }
-    info!("TIMEOUT: {} secs", args.flag_timeout);
-    TIMEOUT_SECS.store(args.flag_timeout, Ordering::Relaxed);
+    TIMEOUT_SECS.store(
+        util::timeout_secs(args.flag_timeout)? as u16,
+        Ordering::Relaxed,
+    );
 
     #[cfg(any(feature = "full", feature = "lite"))]
     let mut rconfig = Config::new(&args.arg_input)

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -33,7 +33,7 @@ Validate options:
                                before running in parallel.
                                [default: 50000]
     --timeout <seconds>        Timeout for downloading json-schemas.
-                               [default: 15]
+                               [default: 30]
 
 Common options:
     -h, --help                 Display this message

--- a/src/util.rs
+++ b/src/util.rs
@@ -83,6 +83,21 @@ pub fn njobs(flag_jobs: Option<usize>) -> usize {
     })
 }
 
+pub fn timeout_secs(timeout_option: u16) -> Result<u64, String> {
+    let timeout = match env::var("QSV_TIMEOUT") {
+        Ok(val) => val.parse::<u16>().unwrap_or(30_u16),
+        Err(_) => timeout_option,
+    };
+
+    if timeout > 3600 {
+        return fail!("Timeout cannot be more than 3,600 seconds (1 hour)");
+    } else if timeout == 0 {
+        return fail!("Timeout cannot be zero.");
+    }
+    log::info!("TIMEOUT: {timeout}");
+    Ok(timeout as u64)
+}
+
 pub fn version() -> String {
     let mut enabled_features = String::new();
 


### PR DESCRIPTION
standardize timeouts across qsv commands that have a --timeout option (`fetch`, `fetch post`, `luau`, `sniff` & `validate`); add QSV_TIMEOUT environment variable