### PR TITLE
add `snappy` compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,6 +3640,7 @@ dependencies = [
  "serde_urlencoded",
  "serial_test",
  "simdutf8",
+ "snap",
  "strsim 0.10.0",
  "strum",
  "strum_macros",
@@ -4447,6 +4448,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ self_update = { version = "0.36", features = [
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_urlencoded = { version = "0.7", optional = true }
+snap = "1"
 strsim = { version = "0.10", optional = true }
 strum = "0.24"
 strum_macros = "0.24"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 </div>
 
-> ℹ️ **NOTE:** qsv is a fork of the popular [xsv](https://github.com/BurntSushi/xsv) utility, merging several pending PRs [since xsv 0.13.0's May 2018 release](https://github.com/BurntSushi/xsv/issues/267). On top of xsv's 20 commands, it adds numerous new features; 32 additional commands; 6 `apply` subcommands & 35 operations; 5 `to` subcommands; and 3 `cat` subcommands (for a total of 101).
+> ℹ️ **NOTE:** qsv is a fork of the popular [xsv](https://github.com/BurntSushi/xsv) utility, merging several pending PRs [since xsv 0.13.0's May 2018 release](https://github.com/BurntSushi/xsv/issues/267). On top of xsv's 20 commands, it adds numerous new features; 33 additional commands; 6 `apply` subcommands & 35 operations; 5 `to` subcommands; 3 `cat` subcommands; and 3 `snappy` subcommands (for a total of 104).
 See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for more details.
 
 ## Available commands
@@ -69,6 +69,7 @@ See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for mor
 | [searchset](/src/cmd/searchset.rs#L3) | **Run multiple regexes over a CSV in a single pass.** Applies the regexes to each field individually & shows only matching rows.  |
 | [select](/src/cmd/select.rs#L2) | Select, re-order, duplicate or drop columns.  |
 | [slice](/src/cmd/slice.rs#L2)<br>📇 | Slice rows from any part of a CSV. When an index is present, this only has to parse the rows in the slice (instead of all rows leading up to the start of the slice).  |
+| [snappy](/src/cmd/snappy.rs#L2)<br>📇 | Does streaming compression/decompression of the input using the [Snappy](https://google.github.io/snappy/) format. |
 | [sniff](/src/cmd/sniff.rs#L2) | Quickly sniff & infer CSV metadata (delimiter, header row, preamble rows, quote character, flexible, is_utf8, average record length, number of records, content length & estimated number of records if sniffing a CSV on a URL, number of fields, field names & data types). |
 | [sort](/src/cmd/sort.rs#L2)<br>🚀🗜️ | Sorts CSV data in alphabetical (with case-insensitive option), numerical, reverse, unique or random (with optional seed) order (See also `extsort` & `sortcheck` commands).  |
 | [sortcheck](/src/cmd/sortcheck.rs#L2)<br>📇 | Check if a CSV is sorted. With the --json options, also retrieve record count, sort breaks & duplicate count. |
@@ -200,6 +201,11 @@ The `schema` command produces a [JSON Schema Validation (Draft 7)](https://json-
 The `excel` command recognizes Excel & Open Document Spreadsheet(ODS) files (`.xls`, `.xlsx`, `.xlsm`, `.xlsb` & `.ods` files).
 
 The `to` command produces produces `.xlsx`, [Parquet](https://parquet.apache.org) & [Data Package](https://datahub.io/docs/data-packages/tabular) files, and populates [PostgreSQL](https://www.postgresql.org) and [SQLite](https://www.sqlite.org/index.html) databases.
+
+Finally, qsv supports the streaming Snappy compression format for CSV/TSV files with the `.sz` file extension (except the `index`, `sniff`, `extdedup` & `extsort` commands).
+If the input file has an extended CSV/TSV `.sz` extension (e.g nyc311.csv.sz/nyc311.tsv.sz/nyc311.tab.sz), qsv will automatically do streaming decompression as it reads it.
+Similarly, if the `--output` file has an extended CSV/TSV `.sz` extension, qsv will automatically do streaming compression as it writes it.
+Note however that snappy compressed files cannot be indexed, so index-accelerated commands like `stats` & `slice` will not be multi-threaded. Random access is also not supported.
 
 ## RFC 4180
 

--- a/src/cmd/extdedup.rs
+++ b/src/cmd/extdedup.rs
@@ -74,6 +74,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let input_reader: Box<dyn BufRead> = match &args.arg_input {
         Some(input_path) => {
+            if input_path.to_lowercase().ends_with(".sz") {
+                return fail_clierror!(
+                    "Input file cannot be a .sz file. Use 'qsv snappy decompress' first."
+                );
+            }
             let file = fs::File::open(input_path)?;
             Box::new(io::BufReader::with_capacity(
                 config::DEFAULT_RDR_BUFFER_CAPACITY,

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -66,6 +66,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut input_reader: Box<dyn BufRead> = match &args.arg_input {
         Some(input_path) => {
+            if input_path.to_lowercase().ends_with(".sz") {
+                return fail_clierror!(
+                    "Input file cannot be a .sz file. Use 'qsv snappy decompress' first."
+                );
+            }
             let file = fs::File::open(input_path)?;
             Box::new(io::BufReader::with_capacity(
                 config::DEFAULT_RDR_BUFFER_CAPACITY,
@@ -76,10 +81,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
 
     let mut output_writer: Box<dyn Write> = match &args.arg_output {
-        Some(output_path) => Box::new(io::BufWriter::with_capacity(
-            RW_BUFFER_CAPACITY,
-            fs::File::create(output_path)?,
-        )),
+        Some(output_path) => {
+            if output_path.to_lowercase().ends_with(".sz") {
+                return fail_clierror!(
+                    "Output file cannot be a .sz file. Compress it after sorting with 'qsv snappy \
+                     compress'."
+                );
+            }
+            Box::new(io::BufWriter::with_capacity(
+                RW_BUFFER_CAPACITY,
+                fs::File::create(output_path)?,
+            ))
+        }
         None => Box::new(io::BufWriter::with_capacity(
             RW_BUFFER_CAPACITY,
             stdout().lock(),

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -46,9 +46,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
     if args.arg_input.to_lowercase().ends_with(".sz") {
-        return fail_clierror!(
-            "Cannot index an a snappy file."
-        );
+        return fail_clierror!("Cannot index an a snappy file.");
     }
 
     let pidx = match args.flag_output {

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -45,6 +45,12 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
+    if args.arg_input.to_lowercase().ends_with(".sz") {
+        return fail_clierror!(
+            "Cannot index an a snappy file."
+        );
+    }
+
     let pidx = match args.flag_output {
         None => util::idx_path(Path::new(&args.arg_input)),
         Some(p) => PathBuf::from(&p),

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -1336,6 +1336,11 @@ fn create_index(arg_input: &Option<String>) -> Result<bool, CliError> {
         return Ok(false);
     };
 
+    if input.to_lowercase().ends_with(".sz") {
+        log::warn!("qsv_autoindex() does not work with snappy files.");
+        return Ok(false);
+    }
+
     let pidx = util::idx_path(Path::new(&input));
     debug!("Creating index file {pidx:?} for {input:?}.");
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -63,6 +63,7 @@ pub mod search;
 pub mod searchset;
 pub mod select;
 pub mod slice;
+pub mod snappy;
 pub mod sniff;
 pub mod sort;
 pub mod sortcheck;

--- a/src/cmd/snappy.rs
+++ b/src/cmd/snappy.rs
@@ -80,10 +80,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         compress(input_reader, output_writer)?;
     } else if args.cmd_decompress {
         decompress(input_reader, output_writer)?;
-    } else if args.cmd_check {
-        if !check(input_reader) {
-            return fail_clierror!("Not a snappy file.");
-        }
+    } else if args.cmd_check && !check(input_reader) {
+        return fail_clierror!("Not a snappy file.");
     }
 
     Ok(())

--- a/src/cmd/snappy.rs
+++ b/src/cmd/snappy.rs
@@ -1,0 +1,119 @@
+static USAGE: &str = r#"
+Does streaming compression/decompression of the input using the Snappy format.
+https://google.github.io/snappy/
+
+It has three subcommands:
+    compress:   Compress the input.
+    decompress: Decompress the input.
+    check:      Check if the input is a valid Snappy file. Returns exitcode 0 if valid,
+                exitcode 1 otherwise.
+
+Note that this command is not specific to CSV data, it can compress/decompress any file.
+
+For examples, see https://github.com/jqnatividad/qsv/blob/master/tests/test_snappy.rs.
+
+Usage:
+    qsv snappy compress [options] [<input>]
+    qsv snappy decompress [options] [<input>]
+    qsv snappy check [<input>]
+    qsv snappy --help
+
+snappy arguments:
+    <input>  The input file to compress/decompress. If not specified, stdin is used.
+
+Common options:
+    -h, --help           Display this message
+    -o, --output <file>  Write output to <output> instead of stdout.
+"#;
+
+use std::{
+    fs,
+    io::{self, stdin, stdout, BufRead, Read, Write},
+};
+
+use serde::Deserialize;
+use snap;
+
+use crate::{config, util, CliError, CliResult};
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input:      Option<String>,
+    flag_output:    Option<String>,
+    cmd_compress:   bool,
+    cmd_decompress: bool,
+    cmd_check:      bool,
+}
+
+impl From<snap::Error> for CliError {
+    fn from(err: snap::Error) -> CliError {
+        CliError::Other(format!("Snap error: {err:?}"))
+    }
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    let input_reader: Box<dyn BufRead> = match &args.arg_input {
+        Some(input_path) => {
+            let file = fs::File::open(input_path)?;
+            Box::new(io::BufReader::with_capacity(
+                config::DEFAULT_RDR_BUFFER_CAPACITY,
+                file,
+            ))
+        }
+        None => Box::new(io::BufReader::new(stdin().lock())),
+    };
+
+    let output_writer: Box<dyn Write> = match &args.flag_output {
+        Some(output_path) => Box::new(io::BufWriter::with_capacity(
+            config::DEFAULT_WTR_BUFFER_CAPACITY,
+            fs::File::create(output_path)?,
+        )),
+        None => Box::new(io::BufWriter::with_capacity(
+            config::DEFAULT_WTR_BUFFER_CAPACITY,
+            stdout().lock(),
+        )),
+    };
+
+    if args.cmd_compress {
+        compress(input_reader, output_writer)?;
+    } else if args.cmd_decompress {
+        decompress(input_reader, output_writer)?;
+    } else if args.cmd_check {
+        if !check(input_reader) {
+            return fail_clierror!("Not a snappy file.");
+        }
+    }
+
+    Ok(())
+}
+
+// streaming snappy compression
+fn compress<R: Read, W: Write>(mut src: R, dst: W) -> CliResult<()> {
+    let mut dst = snap::write::FrameEncoder::new(dst);
+    io::copy(&mut src, &mut dst)?;
+
+    Ok(())
+}
+
+// streaming snappy decompression
+fn decompress<R: Read, W: Write>(src: R, mut dst: W) -> CliResult<()> {
+    let mut src = snap::read::FrameDecoder::new(src);
+    io::copy(&mut src, &mut dst)?;
+
+    Ok(())
+}
+
+// check if a file is a valid snappy file
+fn check<R: Read>(src: R) -> bool {
+    let src = snap::read::FrameDecoder::new(src);
+
+    // read the first 50 or less bytes of a file
+    // the snap decoder will return an error if the file is not a valid snappy file
+    let mut buffer = Vec::with_capacity(51);
+    if src.take(50).read_to_end(&mut buffer).is_err() {
+        return false;
+    }
+    true
+}

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -226,6 +226,10 @@ async fn get_file_to_sniff(args: &Args) -> CliResult<SniffFileStruct> {
         match uri {
             // its a URL, download sample to temp file
             url if Url::parse(&url).is_ok() && url.starts_with("http") => {
+                if url.to_lowercase().ends_with(".sz") {
+                    return fail_clierror!("Cannot remotely sniff .sz files.");
+                }
+
                 let client = match Client::builder()
                     .user_agent(util::DEFAULT_USER_AGENT)
                     .brotli(true)
@@ -403,6 +407,12 @@ async fn get_file_to_sniff(args: &Args) -> CliResult<SniffFileStruct> {
             }
             // its a file, passthrough the path along with its size
             path => {
+                if path.to_lowercase().ends_with(".sz") {
+                    return fail_clierror!(
+                        "Cannot sniff .sz files. Use 'qsv snappy decompress' first."
+                    );
+                }
+
                 let metadata = fs::metadata(&path)
                     .map_err(|_| format!("Cannot get metadata for file '{path}'"))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ fn main() -> QsvExitCode {
     searchset   Search CSV data with a regex set
     select      Select, re-order, duplicate or drop columns
     slice       Slice records from CSV
+    snappy      Compress/decompress data using the Snappy algorithm
     sniff       Quickly sniff CSV metadata
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     sortcheck   Check if a CSV is sorted
@@ -318,6 +319,7 @@ enum Command {
     SearchSet,
     Select,
     Slice,
+    Snappy,
     Sniff,
     Sort,
     SortCheck,
@@ -398,6 +400,7 @@ impl Command {
             Command::SearchSet => cmd::searchset::run(argv),
             Command::Select => cmd::select::run(argv),
             Command::Slice => cmd::slice::run(argv),
+            Command::Snappy => cmd::snappy::run(argv),
             Command::Sniff => {
                 let rt = tokio::runtime::Runtime::new().unwrap();
                 rt.block_on(cmd::sniff::run(argv))

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -75,6 +75,7 @@ macro_rules! command_list {
     searchset   Search CSV data with a regex set
     select      Select, re-order, duplicate or drop columns
     slice       Slice records from CSV
+    snappy      Compress/decompress data using the Snappy algorithm
     sniff       Quickly sniff CSV metadata
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     sortcheck   Check if a CSV is sorted
@@ -225,6 +226,7 @@ enum Command {
     SearchSet,
     Select,
     Slice,
+    Snappy,
     Sniff,
     Sort,
     SortCheck,
@@ -272,6 +274,7 @@ impl Command {
             Command::SearchSet => cmd::searchset::run(argv),
             Command::Select => cmd::select::run(argv),
             Command::Slice => cmd::slice::run(argv),
+            Command::Snappy => cmd::snappy::run(argv),
             Command::Sniff => {
                 let rt = tokio::runtime::Runtime::new().unwrap();
                 rt.block_on(cmd::sniff::run(argv))

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -52,6 +52,7 @@ macro_rules! command_list {
     searchset   Search CSV data with a regex set
     select      Select, re-order, duplicate or drop columns
     slice       Slice records from CSV
+    snappy      Compress/decompress data using the Snappy algorithm
     sniff       Quickly sniff CSV metadata
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     sortcheck   Check if a CSV is sorted
@@ -216,6 +217,7 @@ enum Command {
     SearchSet,
     Select,
     Slice,
+    Snappy,
     Sniff,
     Sort,
     SortCheck,
@@ -278,6 +280,7 @@ impl Command {
             Command::SearchSet => cmd::searchset::run(argv),
             Command::Select => cmd::select::run(argv),
             Command::Slice => cmd::slice::run(argv),
+            Command::Snappy => cmd::snappy::run(argv),
             Command::Sniff => {
                 let rt = tokio::runtime::Runtime::new().unwrap();
                 rt.block_on(cmd::sniff::run(argv))

--- a/tests/test_snappy.rs
+++ b/tests/test_snappy.rs
@@ -1,0 +1,150 @@
+use std::path::Path;
+
+use crate::workdir::{is_same_file, Workdir};
+
+#[test]
+fn snappy_roundtrip() {
+    let wrk = Workdir::new("snappy_roundtrip");
+
+    let thedata = vec![
+        svec!["Col1", "Description"],
+        svec![
+            "1",
+            "The quick brown fox jumped over the lazy dog by the zigzag quarry site."
+        ],
+        svec!["2", "Mary had a little lamb"],
+        svec![
+            "3",
+            "I think that I shall never see a poem lovely as a tree."
+        ],
+        svec!["4", "I think, therefore I am."],
+        svec!["5", "I am a leaf on the wind."],
+        svec!["6", "Look at me, I'm the captain now."],
+        svec!["7", "Bazinga!"],
+        svec!["8", "I'm Batman."],
+    ];
+    wrk.create("in.csv", thedata.clone());
+
+    let out_file = wrk.path("out.csv.sz").to_string_lossy().to_string();
+    log::info!("out_file: {}", out_file);
+
+    let mut cmd = wrk.command("snappy");
+    cmd.arg("compress")
+        .arg("in.csv")
+        .args(["--output", &out_file]);
+
+    wrk.assert_success(&mut cmd);
+
+    let mut cmd2 = wrk.command("snappy");
+    cmd2.arg("decompress").arg(out_file);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd2);
+    assert_eq!(got, thedata);
+
+    wrk.assert_success(&mut cmd2);
+}
+
+#[test]
+fn snappy_decompress() {
+    let wrk = Workdir::new("snappy_decompress");
+
+    let test_file = wrk.load_test_file("boston311-100.csv.sz");
+
+    let mut cmd = wrk.command("snappy");
+    cmd.arg("decompress").arg(test_file);
+
+    let got: String = wrk.stdout(&mut cmd);
+
+    let expected = wrk.load_test_resource("boston311-100.csv");
+
+    assert_eq!(got, expected.trim_end());
+
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn snappy_compress() {
+    let wrk = Workdir::new("snappy_compress");
+
+    let test_file = wrk.load_test_file("boston311-100.csv");
+
+    let mut cmd = wrk.command("snappy");
+    cmd.arg("compress")
+        .arg(test_file)
+        .args(["--output", "out.csv.sz"]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got_path = wrk.path("out.csv.sz");
+    let expected = wrk.load_test_file("boston311-100.csv.sz");
+    let expected_path = Path::new(&expected);
+
+    assert!(is_same_file(&got_path, expected_path).unwrap());
+}
+
+#[test]
+fn snappy_check() {
+    let wrk = Workdir::new("snappy_check");
+
+    let test_file = wrk.load_test_file("boston311-100.csv.sz");
+
+    let mut cmd = wrk.command("snappy");
+    cmd.arg("check").arg(test_file);
+
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn snappy_check_invalid() {
+    let wrk = Workdir::new("snappy_check_invalid");
+
+    let test_file = wrk.load_test_file("boston311-100.csv");
+
+    let mut cmd = wrk.command("snappy");
+    cmd.arg("check").arg(test_file);
+
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn snappy_automatic_decompression() {
+    let wrk = Workdir::new("snappy_automatic_decompression");
+
+    let test_file = wrk.load_test_file("boston311-100.csv.sz");
+
+    let mut cmd = wrk.command("count");
+    cmd.arg(test_file);
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "100";
+    assert_eq!(got, expected);
+
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn snappy_automatic_compression() {
+    let wrk = Workdir::new("snappy_automatic_compression");
+
+    let test_file = wrk.load_test_file("boston311-100.csv");
+
+    let mut cmd = wrk.command("slice");
+    cmd.args(["--len", "50"])
+        .arg(test_file)
+        .args(["--output", "out.csv.sz"]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got_path = wrk.path("out.csv.sz");
+
+    let mut cmd2 = wrk.command("count");
+    cmd2.arg(got_path);
+
+    wrk.assert_success(&mut cmd2);
+
+    let got: String = wrk.stdout(&mut cmd2);
+    let expected = "50";
+    assert_eq!(got, expected);
+
+    wrk.assert_success(&mut cmd2);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -93,6 +93,7 @@ mod test_search;
 mod test_searchset;
 mod test_select;
 mod test_slice;
+mod test_snappy;
 mod test_sniff;
 mod test_sort;
 mod test_sortcheck;

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -272,3 +272,28 @@ fn create_dir_all<P: AsRef<Path>>(p: P) -> io::Result<()> {
     }
     Err(last_err.unwrap())
 }
+
+pub fn is_same_file(file1: &Path, file2: &Path) -> Result<bool, std::io::Error> {
+    use std::io::BufReader;
+
+    let f1 = File::open(file1)?;
+    let f2 = File::open(file2)?;
+
+    // Check if file sizes are different
+    if f1.metadata().unwrap().len() != f2.metadata().unwrap().len() {
+        return Ok(false);
+    }
+
+    // Use buf readers since they are much faster
+    let f1 = BufReader::new(f1);
+    let f2 = BufReader::new(f2);
+
+    // Do a byte to byte comparison of the two files
+    for (b1, b2) in f1.bytes().zip(f2.bytes()) {
+        if b1.unwrap() != b2.unwrap() {
+            return Ok(false);
+        }
+    }
+
+    return Ok(true);
+}


### PR DESCRIPTION
- snappy files are automatically compressed/decompressed on a streaming basis qsv-wide if the input/output files have an extended CSV/TSV ".sz" extension (e.g. data.csv.sz, data.tsv.sz, data.tab.sz)
- new `snappy` command with three subcommands - compress, decompress and check