### PR TITLE
`schema` & `stats`: stats now has a `--stats-binout` option which `schema` takes advantage of

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,6 +672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,6 +3619,7 @@ dependencies = [
  "actix-web",
  "ahash 0.8.3",
  "assert-json-diff",
+ "bincode",
  "byteorder",
  "bytes",
  "cached",
@@ -3725,12 +3735,13 @@ dependencies = [
 
 [[package]]
 name = "qsv-stats"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ab048a69b1ab56c24db6dec5a8e6dd39673bb83bf01c547ce33d9fc83e76f6"
+checksum = "1e2f71e4cea87bbf8d97e2c1f938029d26729440c210a8ba786b532afac418d6"
 dependencies = [
  "ahash 0.8.3",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ panic    = "abort"
 
 [dependencies]
 ahash = "0.8"
+bincode = "1.3.3"
 byteorder = "1.4"
 bytes = "1"
 cached = { version = "0.43", default-features = false, features = [
@@ -134,7 +135,7 @@ polars = { version = "0.28", features = [
 pyo3 = { version = "0.18", features = ["auto-initialize"], optional = true }
 qsv-dateparser = "0.7"
 qsv_docopt = "1.2"
-qsv-stats = "0.7"
+qsv-stats = "0.8"
 qsv_currency = { version = "0.6", optional = true }
 qsv-sniffer = { version = "0.8", default-features = false, features = [
     "runtime-dispatch-simd",

--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -26,7 +26,8 @@ macro_rules! werr {
     ($($arg:tt)*) => ({
         use std::io::Write;
         use log::error;
-        error!("{}", $($arg)*);
+        let error = format!($($arg)*);
+        error!("{error}");
         (writeln!(&mut ::std::io::stderr(), $($arg)*)).unwrap();
     });
 }


### PR DESCRIPTION
Now that `stats` does result caching, `--stats-binout` option now also saves result in binary format.  This allows other commands to load the precomputed stats, without having to parse the CSV.

This will allow other qsv commands, starting with `schema` to bypass recomputing stats when they are already available in the cache.