### PR TITLE
add dotenv file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytecheck"
@@ -1542,6 +1542,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duckdb"
@@ -2571,9 +2577,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "local-channel"
@@ -3644,6 +3650,7 @@ dependencies = [
  "csv-index",
  "csvs_convert",
  "data-encoding",
+ "dotenvy",
  "dynfmt",
  "eudex",
  "ext-sort",
@@ -4162,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.13"
+version = "0.37.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
 dependencies = [
  "bitflags 1.3.2",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ csv-diff = "0.1.0-beta.4"
 csv-index = "0.1"
 csvs_convert = { version = "0.8", optional = true }
 data-encoding = { version = "2.3", optional = true }
+dotenvy = "0.15.7"
 dynfmt = { version = "0.1", default-features = false, features = [
     "curly",
 ], optional = true }

--- a/README.md
+++ b/README.md
@@ -363,6 +363,16 @@ Several dependencies also have environment variables that influence qsv's perfor
 > ℹ️ **NOTE:** To get a list of all active qsv-relevant environment variables, run `qsv --envlist`.
 Relevant env vars are defined as anything that starts with `QSV_` & `MIMALLOC_` & the proxy variables listed above.
 
+### .env File Support
+qsv support the use of `.env` files to set environment variables. The `.env` file is a simple text file that contains key-value pairs, one per line. 
+
+It processes `.env` files as follows:
+
+* If the `--env` option is specified, it will use the specified file (e.g. `--env production` will look for a file named `production.env` in the current working directory)
+* If the `--env` option is not specified, it will look for a file named `.env` in the current working directory.
+* If the `--env` option is not specified & an `.env` file is not found in the current working directory, it will look for an `.env` file with the same filestem as the binary in the directory where qsv binary is (e.g. if `qsv`/`qsvlite`/`qsvdp` is in `/usr/local/bin`, it will look for `/usr/loca/bin/qsv.env`, `/usr/local/bin/qsvlite.env` or `/usr/local/bin/qsvdp.env` respectively).
+* If no `.env` files are found, qsv will proceed with its default settings and the current  environment variables, which may include "QSV_" variables.
+
 ## Feature Flags
 
 `qsv` has several features:

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ Usage:
 
 Options:
     --list               List all commands available.
+    --env <profile>      Load environment variables from <profile>.env file.
     --envlist            List all qsv-relevant environment variables.
     -u, --update         Update qsv to the latest release from GitHub.
     -U, --updatenow      Update qsv to the latest release from GitHub without confirming.
@@ -83,6 +84,7 @@ struct Args {
     arg_command:    Option<Command>,
     flag_list:      bool,
     flag_envlist:   bool,
+    flag_env:       Option<String>,
     flag_update:    bool,
     flag_updatenow: bool,
 }
@@ -193,6 +195,11 @@ fn main() -> QsvExitCode {
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());
+
+    if util::load_envprofiles(args.flag_env).is_err() {
+        return QsvExitCode::Bad;
+    }
+
     if args.flag_list {
         wout!("Installed commands ({num_commands}):");
         wout!(

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -103,6 +103,7 @@ Usage:
 
 Options:
     --list               List all commands available.
+    --env <profile>      Load environment variables from <profile>.env file.
     --envlist            List all qsv-relevant environment variables.
     -u, --update         Check for the latest qsv release.
     -U, --updatenow      Update qsv to the latest release from GitHub without confirming.
@@ -118,6 +119,7 @@ struct Args {
     arg_command:    Option<Command>,
     flag_list:      bool,
     flag_envlist:   bool,
+    flag_env:       Option<String>,
     flag_update:    bool,
     flag_updatenow: bool,
 }
@@ -133,6 +135,11 @@ fn main() -> QsvExitCode {
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());
+
+    if util::load_envprofiles(args.flag_env).is_err() {
+        return QsvExitCode::Bad;
+    }
+
     if args.flag_list {
         wout!(concat!("Installed commands:", command_list!()));
         util::log_end(qsv_args, now);

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -82,6 +82,7 @@ Usage:
 
 Options:
     --list               List all commands available.
+    --env <profile>      Load environment variables from <profile>.env file.
     --envlist            List all qsv-relevant environment variables.
     -u, --update         Update qsv to the latest release from GitHub.
     -U, --updatenow      Update qsv to the latest release from GitHub without confirming.
@@ -98,6 +99,7 @@ struct Args {
     arg_command:    Option<Command>,
     flag_list:      bool,
     flag_envlist:   bool,
+    flag_env:       Option<String>,
     flag_update:    bool,
     flag_updatenow: bool,
 }
@@ -113,6 +115,11 @@ fn main() -> QsvExitCode {
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());
+
+    if util::load_envprofiles(args.flag_env).is_err() {
+        return QsvExitCode::Bad;
+    }
+
     if args.flag_list {
         wout!(concat!("Installed commands:", command_list!()));
         util::log_end(qsv_args, now);


### PR DESCRIPTION
qsv support the use of `.env` files to set environment variables. The `.env` file is a simple text file that contains key-value pairs, one per line. 

It processes `.env` files as follows:

* If the `--env` option is specified, it will use the specified file (e.g. `--env production` will look for a file named `production.env` in the current working directory)
* If the `--env` option is not specified, it will look for a file named `.env` in the current working directory.
* If the `--env` option is not specified & an `.env` file is not found in the current working directory, it will look for an `.env` file with the same filestem as the binary in the directory where qsv binary is (e.g. if `qsv`/`qsvlite`/`qsvdp` is in `/usr/local/bin`, it will look for `/usr/loca/bin/qsv.env`, `/usr/local/bin/qsvlite.env` or `/usr/local/bin/qsvdp.env` respectively).
* If no `.env` files are found, qsv will proceed with its default settings and the current  environment variables, which may include "QSV_" variables.