### PR TITLE
Simpler dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,10 +368,16 @@ qsv support the use of `.env` files to set environment variables. The `.env` fil
 
 It processes `.env` files as follows:
 
-* If the `--env` option is specified, it will use the specified file (e.g. `--env production` will look for a file named `production.env` in the current working directory)
-* If the `--env` option is not specified, it will look for a file named `.env` in the current working directory.
-* If the `--env` option is not specified & an `.env` file is not found in the current working directory, it will look for an `.env` file with the same filestem as the binary in the directory where qsv binary is (e.g. if `qsv`/`qsvlite`/`qsvdp` is in `/usr/local/bin`, it will look for `/usr/loca/bin/qsv.env`, `/usr/local/bin/qsvlite.env` or `/usr/local/bin/qsvdp.env` respectively).
-* If no `.env` files are found, qsv will proceed with its default settings and the current  environment variables, which may include "QSV_" variables.
+* Upon invocation, qsv will look for a file named `.env` in the current working directory. If one is found, it will be processed.
+* If no `.env` file is not found in the current working directory, qsv will next look for an `.env` file with the same filestem as the binary in the directory where the binary is (e.g. if `qsv`/`qsvlite`/`qsvdp` is in `/usr/local/bin`, it will look for `/usr/loca/bin/qsv.env`, `/usr/local/bin/qsvlite.env` or `/usr/local/bin/qsvdp.env` respectively).
+* If no `.env` files are found, qsv will proceed with its default settings and the current environment variables, which may include "QSV_" variables.
+
+When processing `.env` files, qsv will:
+* overwrite any existing environment variables with the same name
+* where multiple declarations of the same variable exist, the last one will be used
+* ignore any lines that start with `#` (comments)
+
+To facilitate the use of `.env` files, a `dotenv.template` file is included in the qsv distribution. This file contains all the environment variables that qsv recognizes, along with their default values. You can copy this file to `.env` and modify it to suit your needs.
 
 ## Feature Flags
 

--- a/dotenv.template
+++ b/dotenv.template
@@ -1,0 +1,132 @@
+# this is .env template
+# Customize this and copy it as an `.env` file to the directory where you want
+# qsv to set the environment variables specified.
+# You can also copy the customized file to the directory where the qsv binary
+# variant is stored and name it to the variant name for which you want the 
+# environment variables settings to be the default (e.g. if qsv is in
+# /usr/local/bin, copy the file to /usr/local/bin/qsv.env)
+
+# single ascii character to use as delimiter.  Overrides `--delimeter` option.
+# Defaults to "," (comma) for CSV files & "\t" (tab) for TSV files when not set.
+# Note that this will also set the delimiter for qsv's output to stdout.
+# However, using the `--output` option, regardless of this environment variable,
+# will automatically change the delimiter used in the generated file based on
+# the file extension - i.e. comma for `.csv`, tab for `.tsv` & `.tab` files.
+# QSV_DEFAULT_DELIMITER = , 
+
+# if set, the delimiter is automatically detected. Overrides QSV_DEFAULT_DELIMITER
+# and `--delimiter` option. Note that this does not work with stdin.
+# QSV_SNIFF_DELIMITER = 1
+
+# if set, the first row will **NOT** be interpreted as headers.
+# Supersedes QSV_TOGGLE_HEADERS.
+# QSV_NO_HEADERS = 1
+
+# if set to `1`, toggles header setting - i.e. inverts qsv header behavior,
+# with no headers being the default, & setting `--no-headers` will actually
+# mean headers will not be ignored.
+# QSV_TOGGLE_HEADERS = 1 
+
+# if set, automatically create an index when none is detected.
+# Also automatically updates stale indices.
+# QSV_AUTOINDEX = 1
+
+# The directory to use for caching downloaded lookup_table resources using
+# the `luau` qsv_register_lookup() helper function.
+# QSV_CACHE_DIR = .
+
+# The CKAN Action API endpoint to use with the `luau` qsv_register_lookup()
+# helper function when using the "ckan://" scheme.
+# QSV_CKAN_API = https://<your_ckan_site_url>/api/3/action
+
+# The CKAN token to use with the `luau` qsv_register_lookup() helper function
+# when using the "ckan://" scheme. Only required to access private resources.
+# QSV_CKAN_TOKEN = YOUR_CKAN_API_TOKEN
+
+# set to an ascii character. If set, any lines(including the header) that start
+# with this character are ignored.
+# QSV_COMMENT_CHAR = #
+
+# number of jobs to use for multithreaded commands (currently `apply`, `dedup`,
+# `extsort`, `frequency`, `schema`, `sort`, `split`, `stats`, `to`, `tojsonl` &
+# `validate`). If not set, max_jobs is set to the detected number of logical 
+# processors.  See PERFORMANCE-Multithreading section for more info.
+# QSV_MAX_JOBS = 8
+
+# if set, prohibit self-update version check for the latest qsv release 
+# published on GitHub.
+# QSV_NO_UPDATE = 1
+
+# if set, date parsing will use DMY format. Otherwise, use MDY format
+# (used with `apply datefmt`, `schema`, `sniff` & `stats` commands).
+# QSV_PREFER_DMY = 1
+
+# if set, makes `search`, `searchset` & `replace` commands unicode-aware.
+# For increased performance, these commands are not unicode-aware by default &
+# will ignore unicode values when matching & will abort when unicode characters
+# are used in the regex. Note that the `apply operations regex_replace`
+# operation is always unicode-aware.
+# QSV_REGEX_UNICODE = 1
+
+# reader buffer size (default (bytes): 16384)
+# QSV_RDR_BUFFER_CAPACITY = 16384
+
+# writer buffer size (default (bytes): 65536)
+# QSV_WTR_BUFFER_CAPACITY = 65536
+
+# the percentage of free available memory required when running qsv in
+# "non-streaming" mode (i.e. the entire file needs to be loaded into memory).
+# If the incoming file is greater than the available memory (free memory + 
+# free swap) after the headroom is subtracted, qsv will not proceed.
+# (default: (percent) 20 )
+# QSV_FREEMEMORY_HEADROOM_PCT = 20
+
+# if set, check if input file size < AVAILABLE memory - HEADROOM (CONSERVATIVE mode)
+# when running in "non-streaming" mode. Otherwise, qsv will only check if the
+# input file size < TOTAL memory - HEADROOM (NORMAL mode). This is done to prevent
+# Out-of-Memory errors.
+# QSV_MEMORY_CHECK = 1
+
+# desired level (default - off; `error`, `warn`, `info`, `trace`, `debug`).
+# QSV_LOG_LEVEL = debug
+
+# when logging is enabled, the directory where the log files will be stored.
+# If the specified directory does not exist, qsv will attempt to create it.
+# If not set, the log files are created in the directory where qsv was started.
+# See Logging docs for more info.
+# QSV_LOG_DIR = /tmp
+
+# if set, log messages are written directly to disk, without buffering.
+# Otherwise, log messages are buffered before being written to the log file
+# (8k buffer, flushing every second).
+# See https://docs.rs/flexi_logger/latest/flexi_logger/enum.WriteMode.html for details.
+# QSV_LOG_UNBUFFERED = 1
+
+# if set, enable the --progressbar option on the `apply`, `fetch`, `fetchpost`,
+# `foreach`, `luau`, `py`, `replace`, `search`, `searchset`, `sortcheck` &
+# `validate` commands.
+# QSV_PROGRESSBAR = 1
+
+# the `fetch` command can use [Redis](https://redis.io/) to cache responses.
+# Set to connect to the desired Redis instance. (default: `redis:127.0.0.1:6379/1`).
+# For more info on valid Redis connection string formats, 
+# click https://docs.rs/redis/latest/redis/#connection-parameters.
+# QSV_REDIS_CONNSTR = redis:127.0.0.1:6379/1
+
+# the `fetchpost` command can also use Redis to cache responses
+# (default: `redis:127.0.0.1:6379/2`). Note that `fetchpost` connects to
+# database 2, as opposed to `fetch` which connects to database 1.
+# QSV_FP_REDIS_CONNSTR = redis:127.0.0.1:6379/2
+
+# the maximum Redis connection pool size. (default: 20).
+# QSV_REDIS_MAX_POOL_SIZE = 20
+
+# set time-to-live of Redis cached values (default (seconds): 2419200 (28 days)).
+# QSV_REDIS_TTL_SECONDS = 2419200
+
+# if set, enables cache hits to refresh TTL of cached values.
+# QSV_REDIS_TTL_REFRESH = 1
+
+# for commands with a --timeout option (`fetch`, `fetchpost`, `luau`, `sniff` &
+# `validate`), the number of seconds before a web request times out (default: 30).
+# QSV_TIMEOUT = 30

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,6 @@ Usage:
 
 Options:
     --list               List all commands available.
-    --env <profile>      Load environment variables from <profile>.env file.
     --envlist            List all qsv-relevant environment variables.
     -u, --update         Update qsv to the latest release from GitHub.
     -U, --updatenow      Update qsv to the latest release from GitHub without confirming.
@@ -84,7 +83,6 @@ struct Args {
     arg_command:    Option<Command>,
     flag_list:      bool,
     flag_envlist:   bool,
-    flag_env:       Option<String>,
     flag_update:    bool,
     flag_updatenow: bool,
 }
@@ -196,7 +194,7 @@ fn main() -> QsvExitCode {
         })
         .unwrap_or_else(|e| e.exit());
 
-    if util::load_envprofiles(args.flag_env).is_err() {
+    if util::load_dotenv().is_err() {
         return QsvExitCode::Bad;
     }
 

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -103,7 +103,6 @@ Usage:
 
 Options:
     --list               List all commands available.
-    --env <profile>      Load environment variables from <profile>.env file.
     --envlist            List all qsv-relevant environment variables.
     -u, --update         Check for the latest qsv release.
     -U, --updatenow      Update qsv to the latest release from GitHub without confirming.
@@ -119,7 +118,6 @@ struct Args {
     arg_command:    Option<Command>,
     flag_list:      bool,
     flag_envlist:   bool,
-    flag_env:       Option<String>,
     flag_update:    bool,
     flag_updatenow: bool,
 }
@@ -136,7 +134,7 @@ fn main() -> QsvExitCode {
         })
         .unwrap_or_else(|e| e.exit());
 
-    if util::load_envprofiles(args.flag_env).is_err() {
+    if util::load_dotenv().is_err() {
         return QsvExitCode::Bad;
     }
 

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -82,7 +82,6 @@ Usage:
 
 Options:
     --list               List all commands available.
-    --env <profile>      Load environment variables from <profile>.env file.
     --envlist            List all qsv-relevant environment variables.
     -u, --update         Update qsv to the latest release from GitHub.
     -U, --updatenow      Update qsv to the latest release from GitHub without confirming.
@@ -99,7 +98,6 @@ struct Args {
     arg_command:    Option<Command>,
     flag_list:      bool,
     flag_envlist:   bool,
-    flag_env:       Option<String>,
     flag_update:    bool,
     flag_updatenow: bool,
 }
@@ -116,7 +114,7 @@ fn main() -> QsvExitCode {
         })
         .unwrap_or_else(|e| e.exit());
 
-    if util::load_envprofiles(args.flag_env).is_err() {
+    if util::load_dotenv().is_err() {
         return QsvExitCode::Bad;
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1118,7 +1118,7 @@ pub fn transform(bs: &[u8], casei: bool) -> ByteString {
     }
 }
 
-pub fn load_envprofiles(env: Option<String>) -> Result<(), String> {
+pub fn load_dotenv() -> CliResult<()> {
     // If the user specified an env file using the --env option, use it.
     // Otherwise, use the default .env file in the current directory.
     // If there is no .env file in the current directory, check if there is
@@ -1126,61 +1126,48 @@ pub fn load_envprofiles(env: Option<String>) -> Result<(), String> {
     // If there is, use that. Failing that, qsv proceeds with its default settings and
     // whatever manually set environment variables are present.
 
-    let qsv_binary_path = std::env::current_exe().unwrap();
-
-    let qsv_dir = qsv_binary_path.parent().unwrap();
-
-    let qsv_binary_filestem = qsv_binary_path
-        .file_stem()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .to_string();
-
-    let mut qsv_binary_envprofile = qsv_dir.to_path_buf();
-    qsv_binary_envprofile.set_file_name(format!("{qsv_binary_filestem}.env"));
-
-    if let Some(profile) = env {
-        // the --env option was used, specifying a profile
-        log::info!("Using environment file: {profile}.env");
-        if let Err(e) = dotenvy::from_filename_override(format!("{}.env", profile.clone())) {
-            let emsg = format!("Cannot process {profile}.env file: {e}");
-            log::error!("{emsg}");
-            return Err(emsg);
-        }
+    // check if there is an .env file in the current directory
+    if dotenvy::dotenv_override().is_ok() {
+        log::info!(
+            "Using .env file in current directory: {}",
+            std::env::current_dir()?.display()
+        );
     } else {
-        // the --env option was not used
-        // now check if there is an .env file in the current directory
-        match dotenvy::from_filename_override(".env") {
-            Ok(_) => {
-                log::info!("Using .env file in current directory.");
+        // no .env file in the current directory or it was invalid
+        // now check if there is an .env file with the same name as the executable
+        // in the same directory as the executable
+        let qsv_binary_path = std::env::current_exe()?;
+
+        let qsv_dir = qsv_binary_path.parent().unwrap();
+
+        let qsv_binary_filestem = qsv_binary_path
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let mut qsv_binary_envprofile = qsv_dir.to_path_buf();
+        qsv_binary_envprofile.set_file_name(format!("{qsv_binary_filestem}.env"));
+
+        if std::path::Path::new(&qsv_binary_envprofile).exists() {
+            log::info!(
+                "Using binary environment file: {}",
+                qsv_binary_envprofile.display()
+            );
+            if let Err(e) = dotenvy::from_filename_override(qsv_binary_envprofile.clone()) {
+                return fail_clierror!(
+                    "Cannot process {} file: {e}",
+                    qsv_binary_envprofile.display()
+                );
             }
-            Err(_) => {
-                // no .env file in the current directory or it was invalid
-                // now check if there is an .env file with the same name as the executable
-                // in the same directory as the executable
-                if std::path::Path::new(&qsv_binary_envprofile).exists() {
-                    log::info!(
-                        "Using binary environment file: {}",
-                        qsv_binary_envprofile.display()
-                    );
-                    if let Err(e) = dotenvy::from_filename_override(qsv_binary_envprofile.clone()) {
-                        let emsg = format!(
-                            "Cannot process {} file: {e}",
-                            qsv_binary_envprofile.display()
-                        );
-                        log::error!("{emsg}");
-                        return Err(emsg);
-                    }
-                } else {
-                    // there is no binary .env file, just use the default settings
-                    // and whatever manually set environment variables are present
-                    log::info!(
-                        "No valid .env file found. Proceeding with default settings and current \
-                         environment variable settings."
-                    );
-                }
-            }
+        } else {
+            // there is no binary .env file, just use the default settings
+            // and whatever manually set environment variables are present
+            log::info!(
+                "No valid .env file found. Proceeding with default settings and current \
+                 environment variable settings."
+            );
         }
     }
 


### PR DESCRIPTION
Simplify dotenv processing
- remove --env option
- process .env file in a standard way
- add qsv binary variant .env file to set qsv binary variant defaults