### PR TITLE
User agent environment variable; standardized user agent processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Otherwise, the default memory check heuristic (NORMAL mode) will only check if t
 | `QSV_REDIS_TTL_SECONDS` | set time-to-live of Redis cached values (default (seconds): 2419200 (28 days)). |
 | `QSV_REDIS_TTL_REFRESH`| if set, enables cache hits to refresh TTL of cached values. |
 | `QSV_TIMEOUT`| for commands with a --timeout option (`fetch`, `fetchpost`, `luau`, `sniff` and `validate`), the number of seconds before a web request times out (default: 30). |
-| `QSV_USER_AGENT`| for commands with a --user-agent option (`fetch`, `fetchpost`, `luau`, `sniff` and `validate`), the user-agent to use when interfacing with web servers. (default: QSV_BINARY_NAME/QSV_VERSION - e.g. qsv/0.99.1). |
+| `QSV_USER_AGENT`| the user-agent to use when interfacing with web servers. Try to follow the syntax [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent).<br>(default: QSV_BINARY_VARIANT/QSV_VERSION (TARGET-TRIPLE; https://github.com/jqnatividad/qsv) - e.g.<br>`qsv/0.99.1 (x86_64-unknown-linux; https://github.com/jqnatividad/qsv)`).|
 
 Several dependencies also have environment variables that influence qsv's performance & behavior:
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -414,15 +414,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
     info!("RATE LIMIT: {rate_limit}");
 
-    let user_agent = match args.flag_user_agent {
-        Some(ua) => match HeaderValue::from_str(ua.as_str()) {
-            Ok(_) => ua,
-            Err(e) => return fail_clierror!("Invalid user-agent value: {e}"),
-        },
-        None => util::DEFAULT_USER_AGENT.to_string(),
-    };
-    info!("USER-AGENT: {user_agent}");
-
     let http_headers: HeaderMap = {
         let mut map = HeaderMap::with_capacity(args.flag_http_header.len() + 1);
         for header in args.flag_http_header {
@@ -463,7 +454,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let client_timeout = time::Duration::from_secs(*TIMEOUT_SECS.get().unwrap_or(&30));
     let client = Client::builder()
-        .user_agent(user_agent)
+        .user_agent(util::set_user_agent(args.flag_user_agent)?)
         .default_headers(http_headers)
         .cookie_store(args.flag_cookies)
         .brotli(true)

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -394,15 +394,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
     info!("RATE LIMIT: {rate_limit}");
 
-    let user_agent = match args.flag_user_agent {
-        Some(ua) => match HeaderValue::from_str(ua.as_str()) {
-            Ok(_) => ua,
-            Err(e) => return fail_clierror!("Invalid user-agent value: {e}"),
-        },
-        None => util::DEFAULT_USER_AGENT.to_string(),
-    };
-    info!("USER-AGENT: {user_agent}");
-
     let http_headers: HeaderMap = {
         let mut map = HeaderMap::with_capacity(args.flag_http_header.len() + 1);
         for header in args.flag_http_header {
@@ -453,7 +444,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let client_timeout = time::Duration::from_secs(*TIMEOUT_FP_SECS.get().unwrap_or(&30));
     let client = Client::builder()
-        .user_agent(user_agent)
+        .user_agent(util::set_user_agent(args.flag_user_agent)?)
         .default_headers(http_headers)
         .cookie_store(args.flag_cookies)
         .brotli(true)

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -2084,7 +2084,9 @@ fn setup_helpers(
                 let client_timeout = std::time::Duration::from_secs(TIMEOUT_SECS.load(Ordering::Relaxed) as u64);
 
                 let client = match Client::builder()
-                    .user_agent(util::DEFAULT_USER_AGENT)
+                    // safety: we're using a validated QSV_USER_AGENT or if it's not set,
+                    // the default user agent                    
+                    .user_agent(util::set_user_agent(None).unwrap())
                     .brotli(true)
                     .gzip(true)
                     .deflate(true)

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -911,7 +911,9 @@ fn load_json(uri: &str) -> Result<String, String> {
                 std::time::Duration::from_secs(TIMEOUT_SECS.load(Ordering::Relaxed) as u64);
 
             let client = match Client::builder()
-                .user_agent(util::DEFAULT_USER_AGENT)
+                // safety: we're using a validated QSV_USER_AGENT or if it's not set,
+                // the default user agent
+                .user_agent(util::set_user_agent(None).unwrap())
                 .brotli(true)
                 .gzip(true)
                 .deflate(true)


### PR DESCRIPTION
- new env_var QSV_USER_AGENT
- there is now a standard `set_user_agent()` helper fn
- `fetch` & `fetchpost` now uses `set_user_agent()` instead of custom ua processing code. They will use QSV_USER_AGENT unless their `--user-agent` options are used
- `luau` & `validate` will also use QSV_USER_AGENT env var if set
- self-update still uses the default user agent, and not the custom user-agent 