### PR TITLE
`sniff`: short-circuit sniffing a remote file when we already know its not a CSV

### DIFF
--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -384,6 +384,9 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                 #[allow(unused_assignments)]
                 let mut chunk = Bytes::new(); // amortize the allocation
 
+                let mut shortcircuit_flag = false;
+                let mut firstchunk = Bytes::new();
+
                 // download chunks until we have the desired sample size
                 while let Some(item) = stream.next().await {
                     chunk = item.or(Err("Error while downloading file".to_string()))?;
@@ -391,6 +394,21 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                     file.write_all(&chunk)
                         .map_err(|_| "Error while writing to file".to_string())?;
                     let chunk_len = chunk.len();
+
+                    // on linux, we can short-circuit downloading
+                    // by checking the file type from the first chunk
+                    #[cfg(all(target_os = "linux", feature = "magic"))]
+                    if downloaded == 0 && !snappy_flag && chunk_len >= util::FIRST_CHUNK_BUFFER_SIZE
+                    {
+                        let mime = util::sniff_filetype_from_buffer(&chunk)?;
+                        if !mime.starts_with("text/") && mime != "application/csv" {
+                            shortcircuit_flag = true;
+                            downloaded = chunk_len;
+                            firstchunk = chunk.clone();
+                            break;
+                        }
+                    }
+
                     downloaded = min(downloaded + chunk_len, total_size);
                     if show_progress {
                         progress.inc(chunk_len as u64);
@@ -431,7 +449,7 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
 
                 // keep the temporary file around so we can sniff it later
                 // we'll delete it when we're done
-                let (_file, path) = wtr_file
+                let (mut tmp_file, path) = wtr_file
                     .keep()
                     .or(Err("Cannot keep temporary file".to_string()))?;
 
@@ -443,11 +461,19 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                     // before we can sniff it
                     wtr_file_path =
                         util::decompress_snappy_file(&file.path().to_path_buf(), tmpdir)?;
+                } else if shortcircuit_flag {
+                    // on linux, we can short-circuit downloading by checking the file type
+                    // from the first chunk. If the file is not a CSV file, we just write
+                    // the first chunk to a file and return
+                    wtr_file_path = path.display().to_string();
+                    tmp_file.write_all(&firstchunk)?;
+                    tmp_file.flush()?;
                 } else {
-                    // we downloaded a non-snappy file. Rewrite it so we only have the exact
-                    // sample size and truncate potentially incomplete lines. We streamed the
-                    // download and the downloaded file may be more than the sample size, and the
-                    // final line may be incomplete.
+                    // we downloaded a non-snappy file and it might be a CSV file.
+                    // Rewrite it so we only have the exact sample size and truncate potentially
+                    // incomplete lines. We do this coz we streamed the download and the downloaded
+                    // file may be more than the sample size, and the final line
+                    // may be incomplete.
                     wtr_file_path = path.display().to_string();
                     let mut wtr = Config::new(&Some(wtr_file_path.clone()))
                         .no_headers(false)

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -384,7 +384,11 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                 #[allow(unused_assignments)]
                 let mut chunk = Bytes::new(); // amortize the allocation
 
+                // on linux, we can short-circuit downloading by
+                // checking the file type from the first chunk
+                #[allow(unused_mut)]
                 let mut shortcircuit_flag = false;
+                #[allow(unused_mut)]
                 let mut firstchunk = Bytes::new();
 
                 // download chunks until we have the desired sample size

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,6 +35,7 @@ const DEFAULT_FREEMEMORY_HEADROOM_PCT: u8 = 20;
 
 static ROW_COUNT: once_cell::sync::OnceCell<u64> = OnceCell::new();
 
+#[cfg(all(target_os = "linux", feature = "magic"))]
 pub const FIRST_CHUNK_BUFFER_SIZE: usize = 1024;
 
 pub type ByteString = Vec<u8>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,6 +35,8 @@ const DEFAULT_FREEMEMORY_HEADROOM_PCT: u8 = 20;
 
 static ROW_COUNT: once_cell::sync::OnceCell<u64> = OnceCell::new();
 
+pub const FIRST_CHUNK_BUFFER_SIZE: usize = 1024;
+
 pub type ByteString = Vec<u8>;
 
 #[inline]
@@ -1278,6 +1280,24 @@ pub fn get_filetype(path: &str) -> Result<String, CliError> {
     cookie.load::<&str>(&[])?;
 
     let mime = cookie.file(path)?;
+
+    Ok(mime)
+}
+
+/// find out what kind of file we have using magic
+/// by sampling the FIRST_CHUNK_BUFFER_SIZE bytes of the file
+#[cfg(all(target_os = "linux", feature = "magic"))]
+pub fn sniff_filetype_from_buffer(in_buffer: &bytes::Bytes) -> Result<String, CliError> {
+    // We just want the mime type
+    let cookie = magic::Cookie::open(magic::CookieFlags::MIME_TYPE)?;
+
+    // Load libmagic's default database
+    cookie.load::<&str>(&[])?;
+
+    let mut buffer_wrk = bytes::BytesMut::with_capacity(FIRST_CHUNK_BUFFER_SIZE);
+    let buffer_len = std::cmp::min(in_buffer.len(), FIRST_CHUNK_BUFFER_SIZE);
+    buffer_wrk.extend_from_slice(&in_buffer[0..buffer_len]);
+    let mime = cookie.buffer(&buffer_wrk)?;
 
     Ok(mime)
 }

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -76,13 +76,14 @@ fn sniff_url_notcsv() {
     let wrk = Workdir::new("sniff_url_notcsv");
 
     let mut cmd = wrk.command("sniff");
-    cmd.arg("https://github.com/jqnatividad/qsv/raw/master/resources/test/excel-xls.xls");
+    cmd.arg("https://github.com/jqnatividad/qsv/raw/master/resources/test/excel-xlsx.xlsx");
 
     #[cfg(all(target_os = "linux", feature = "magic"))]
     {
         let got_error = wrk.output_stderr(&mut cmd);
 
-        let expected = "File is not a CSV file. Detected mime type: application/octet-stream";
+        let expected = "File is not a CSV file. Detected mime type: \
+                        application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
         assert_eq!(
             dos2unix(&got_error).trim_end(),
             dos2unix(expected).trim_end()


### PR DESCRIPTION
this allows us to quickly check the filetype of a remote file being inspected from the first download chunk.
We can short-circuit downloading if we already know its not a CSV