### PR TITLE
migrate from once_cell to std::sync::oncelock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,8 +3686,6 @@ dependencies = [
  "newline-converter",
  "num_cpus",
  "odht",
- "once_cell",
- "parking_lot 0.12.1",
  "polars",
  "postgres",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "parser-implementations"]
 license = "MIT OR Unlicense"
 autotests = false
 edition = "2021"
-rust-version = "1.69.0"
+rust-version = "1.70.0"
 autobins = false
 include = [
     "src/**/*",
@@ -125,8 +125,6 @@ mlua = { version = "0.9.0-beta.2", features = [
 ], optional = true }
 num_cpus = "1"
 odht = "0.3"
-once_cell = { version = "1.17", features = ["parking_lot"] }
-parking_lot = { version = "0.12", features = ["hardware-lock-elision"] }
 polars = { version = "0.30", features = [
     "lazy",
     "streaming",
@@ -264,7 +262,6 @@ nightly = [
     "regex/unstable",
     "rand/nightly",
     "rand/simd_support",
-    "parking_lot/nightly",
     "pyo3/nightly",
     "hashbrown/nightly",
 ]

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -214,11 +214,10 @@ Common options:
                                 Must be a single character. (default: ,)
 "#;
 
-use std::str::FromStr;
+use std::{str::FromStr, sync::OnceLock};
 
 use dynfmt::Format;
 use log::debug;
-use once_cell::sync::OnceCell;
 use qsv_dateparser::parse_with_preference;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
@@ -283,8 +282,8 @@ struct Args {
     flag_delimiter:      Option<Delimiter>,
 }
 
-static REGEX_REPLACE: OnceCell<Regex> = OnceCell::new();
-static ROUND_PLACES: OnceCell<u32> = OnceCell::new();
+static REGEX_REPLACE: OnceLock<Regex> = OnceLock::new();
+static ROUND_PLACES: OnceLock<u32> = OnceLock::new();
 
 // default number of decimal places to round to
 const DEFAULT_ROUND_PLACES: u32 = 3;

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -166,11 +166,13 @@ use std::{
     iter::repeat,
     path::{Path, PathBuf},
     str,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        OnceLock,
+    },
 };
 
 use itertools::Itertools;
-use once_cell::sync::OnceCell;
 use qsv_dateparser::parse_with_preference;
 use serde::{Deserialize, Serialize};
 use simdutf8::basic::from_utf8;
@@ -242,9 +244,9 @@ struct StatsArgs {
     qsv_version:          String,
 }
 
-static INFER_DATE_FLAGS: once_cell::sync::OnceCell<Vec<bool>> = OnceCell::new();
+static INFER_DATE_FLAGS: OnceLock<Vec<bool>> = OnceLock::new();
 static DMY_PREFERENCE: AtomicBool = AtomicBool::new(false);
-static RECORD_COUNT: once_cell::sync::OnceCell<u64> = OnceCell::new();
+static RECORD_COUNT: OnceLock<u64> = OnceLock::new();
 
 // number of milliseconds per day
 const MS_IN_DAY: f64 = 86_400_000.0;

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -54,7 +54,10 @@ use std::{
     fs::File,
     io::{BufReader, BufWriter, Read, Write},
     str,
-    sync::atomic::{AtomicU16, Ordering},
+    sync::{
+        atomic::{AtomicU16, Ordering},
+        OnceLock,
+    },
 };
 
 use csv::ByteRecord;
@@ -63,7 +66,6 @@ use indicatif::{ProgressBar, ProgressDrawTarget};
 use itertools::Itertools;
 use jsonschema::{output::BasicOutput, paths::PathChunk, JSONSchema};
 use log::{debug, info, log_enabled};
-use once_cell::sync::OnceCell;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     prelude::IntoParallelRefIterator,
@@ -79,7 +81,7 @@ use crate::{
 };
 
 // to save on repeated init/allocs
-static NULL_TYPE: once_cell::sync::OnceCell<Value> = OnceCell::new();
+static NULL_TYPE: OnceLock<Value> = OnceLock::new();
 
 static TIMEOUT_SECS: AtomicU16 = AtomicU16::new(15);
 


### PR DESCRIPTION
- now that Rust 1.70.0 has once_lock in std, we no longer need the once_cell crate
- remove parking lot crate as well, as we added it to use hardware_lock_ellision with once_cell on platforms that support it
- bump MSRV to 1.70.0