### PR TITLE
Remove redundant registries protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ include = [
     "resources/luau/vendor/luadate/date.lua",
 ]
 
-[registries.crates-io]
-protocol = "sparse"
-
 [[bin]]
 name              = "qsv"
 test              = true


### PR DESCRIPTION
This should have been in `.cargo/config.toml` instead of `Cargo.toml` as you can see by the warning text at the start of every build `unused manifest key: registries`. Anyway, since Rust 1.70 defaults to sparse protocol, this isn't even necessary anymore.