### PR TITLE
fix typo in tojsonl.rs (optionns -> options)

### DIFF
--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -15,7 +15,7 @@ Usage:
     qsv tojsonl [options] [<input>]
     qsv tojsonl --help
 
-Tojsonl optionns:
+Tojsonl options:
     -j, --jobs <arg>       The number of jobs to run in parallel.
                            When not set, the number of jobs is set to the
                            number of CPUs detected.


### PR DESCRIPTION
Fixes typo in [tojsonl.rs](https://github.com/jqnatividad/qsv/blob/master/src/cmd/tojsonl.rs) help message: `optionns` -> `options`.

https://github.com/jqnatividad/qsv/blob/b76a760e669c29b20002e6988a6dcee70334422e/src/cmd/tojsonl.rs#L18

Before when running `qsv tojsonl -h`:

![image](https://github.com/jqnatividad/qsv/assets/30333942/98bbb7cc-48d2-4c0a-88ae-aa1214fb5403)

After when running  `qsv tojsonl -h`:

![image](https://github.com/jqnatividad/qsv/assets/30333942/93022af3-7d3b-44af-abf5-7f07a7adc80c)
