### PR TITLE
Avoid sysinfo::System::new_all

### DIFF
--- a/src/cmd/extdedup.rs
+++ b/src/cmd/extdedup.rs
@@ -64,7 +64,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // and up to --memory-limit (capped at 50%),
     // otherwise, if we cannot detect the free memory use a default of 100 MB
     let mem_limited_buffer = if System::IS_SUPPORTED {
-        let mut sys = System::new_all();
+        let mut sys = System::new();
         sys.refresh_memory();
         (sys.total_memory() * 1000) / u8::min(args.flag_memory_limit.unwrap_or(10), 50) as u64
     } else {
@@ -171,7 +171,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 #[test]
 fn test_extdedup_mem_check() {
     // check to see if sysinfo return meminfo without segfaulting
-    let mut sys = System::new_all();
+    let mut sys = System::new();
     sys.refresh_memory();
     let mem10percent = (sys.total_memory() * 1000) / 10; // 10 percent of total memory
     assert!(mem10percent > 0);

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -56,7 +56,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // and up to --memory-limit (capped at 50%),
     // otherwise, if we cannot detect the free memory use a default of 100 MB
     let mem_limited_buffer = if System::IS_SUPPORTED {
-        let mut sys = System::new_all();
+        let mut sys = System::new();
         sys.refresh_memory();
         (sys.total_memory() * 1000) / u8::min(args.flag_memory_limit.unwrap_or(10), 50) as u64
     } else {
@@ -136,7 +136,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 #[test]
 fn test_mem_check() {
     // check to see if sysinfo return meminfo without segfaulting
-    let mut sys = System::new_all();
+    let mut sys = System::new();
     sys.refresh_memory();
     let mem10percent = (sys.total_memory() * 1000) / 10; // 10 percent of total memory
     assert!(mem10percent > 0);

--- a/src/util.rs
+++ b/src/util.rs
@@ -188,7 +188,7 @@ pub fn version() -> String {
     // get max_file_size & memory info. max_file_size is based on QSV_FREEMEMORY_HEADROOM_PCT
     // setting and is only enforced when qsv is running in "non-streaming" mode (i.e. needs to
     // load the entire file into memory).
-    let mut sys = System::new_all();
+    let mut sys = System::new();
     sys.refresh_memory();
     let avail_mem = sys.available_memory();
     let total_mem = sys.total_memory();
@@ -839,7 +839,7 @@ fn send_hwsurvey(
     static HW_SURVEY_URL: &str =
         "https://4dhmneehnl.execute-api.us-east-1.amazonaws.com/dev/qsv-hwsurvey";
 
-    let mut sys = System::new_all();
+    let mut sys = System::new();
     sys.refresh_all();
     let total_mem = sys.total_memory();
     let kernel_version = sys


### PR DESCRIPTION
`new_all` fetches _all_ possible information (including all processes and disks details), which is slow and a privacy risk.

qsv uses `refresh_*` methods to request specific information about the system anyway, so plain `System::new` should be enough.

Resolves #1063.