### PR TITLE
`cat`: emulate csvkit's csvstack

### DIFF
--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -31,10 +31,18 @@ Usage:
     qsv cat --help
 
 cat options:
-    -p, --pad              When concatenating columns, this flag will cause
-                           all records to appear. It will pad each row if
-                           other CSV data isn't long enough.
+                             COLUMNS OPTION:
+    -p, --pad                When concatenating columns, this flag will cause
+                             all records to appear. It will pad each row if
+                             other CSV data isn't long enough.
 
+                             ROWSKEY OPTIONS:
+    -g, --group              When concatenating with rowskey, use the file stem of each
+                             input file as a grouping value. A new column will be added
+                             to the beginning of each row with the name given by --group-name.
+    -N, --group-name <arg>   When concatenating with rowskey, this flag provides the name
+                             for the new grouping column. [default: file]
+                             
 Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.
@@ -58,6 +66,8 @@ struct Args {
     cmd_rows:        bool,
     cmd_rowskey:     bool,
     cmd_columns:     bool,
+    flag_group:      bool,
+    flag_group_name: String,
     arg_input:       Vec<String>,
     flag_pad:        bool,
     flag_output:     Option<String>,
@@ -108,6 +118,10 @@ impl Args {
         }
         let mut columns_global: IndexSet<Box<[u8]>> = IndexSet::with_capacity(32);
 
+        if self.flag_group {
+            columns_global.insert(self.flag_group_name.as_bytes().to_vec().into_boxed_slice());
+        }
+
         // First pass, add all column headers to an IndexSet
         for conf in &self.configs()? {
             if conf.is_stdin() {
@@ -131,6 +145,9 @@ impl Args {
         }
         wtr.write_byte_record(&csv::ByteRecord::new())?;
 
+        #[allow(unused_assignments)]
+        let mut grouping_value = String::with_capacity(64); // amortize allocation
+
         for conf in self.configs()? {
             let mut rdr = conf.reader()?;
             let h = rdr.byte_headers()?;
@@ -149,15 +166,28 @@ impl Args {
                 columns_of_this_file.insert(fi, n);
             }
 
+            // use the file stem as the grouping value
+            // safety: we know that this is a file path
+            grouping_value = conf
+                .path
+                .clone()
+                .unwrap()
+                .file_stem()
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+
             for row in rdr.byte_records() {
                 let row = row?;
-                for c in &columns_global {
+                for (col_idx, c) in columns_global.iter().enumerate() {
                     if let Some(idx) = columns_of_this_file.get(c) {
                         if let Some(d) = row.get(*idx) {
                             wtr.write_field(d)?;
                         } else {
                             wtr.write_field(b"")?;
                         }
+                    } else if self.flag_group && col_idx == 0 {
+                        wtr.write_field(&grouping_value)?;
                     } else {
                         wtr.write_field(b"")?;
                     }

--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -120,6 +120,111 @@ fn cat_rowskey() {
 }
 
 #[test]
+fn cat_rowskey_grouping() {
+    let wrk = Workdir::new("cat_rowskey_grouping");
+    wrk.create(
+        "in1.csv",
+        vec![
+            svec!["a", "b", "c"],
+            svec!["1", "2", "3"],
+            svec!["2", "3", "4"],
+        ],
+    );
+
+    wrk.create(
+        "in2.csv",
+        vec![
+            svec!["c", "a", "b"],
+            svec!["3", "1", "2"],
+            svec!["4", "2", "3"],
+        ],
+    );
+
+    wrk.create(
+        "in3.csv",
+        vec![
+            svec!["a", "b", "d", "c"],
+            svec!["1", "2", "4", "3"],
+            svec!["2", "3", "5", "4"],
+            svec!["z", "y", "w", "x"],
+        ],
+    );
+
+    let mut cmd = wrk.command("cat");
+    cmd.arg("rowskey")
+        .arg("--group")
+        .arg("in1.csv")
+        .arg("in2.csv")
+        .arg("in3.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["file", "a", "b", "c", "d"],
+        svec!["in1", "1", "2", "3", ""],
+        svec!["in1", "2", "3", "4", ""],
+        svec!["in2", "1", "2", "3", ""],
+        svec!["in2", "2", "3", "4", ""],
+        svec!["in3", "1", "2", "3", "4"],
+        svec!["in3", "2", "3", "4", "5"],
+        svec!["in3", "z", "y", "x", "w"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn cat_rowskey_grouping_customname() {
+    let wrk = Workdir::new("cat_rowskey_grouping_customname");
+    wrk.create(
+        "in1.csv",
+        vec![
+            svec!["a", "b", "c"],
+            svec!["1", "2", "3"],
+            svec!["2", "3", "4"],
+        ],
+    );
+
+    wrk.create(
+        "in2.csv",
+        vec![
+            svec!["c", "a", "b"],
+            svec!["3", "1", "2"],
+            svec!["4", "2", "3"],
+        ],
+    );
+
+    wrk.create(
+        "in3.csv",
+        vec![
+            svec!["a", "b", "d", "c"],
+            svec!["1", "2", "4", "3"],
+            svec!["2", "3", "5", "4"],
+            svec!["z", "y", "w", "x"],
+        ],
+    );
+
+    let mut cmd = wrk.command("cat");
+    cmd.arg("rowskey")
+        .arg("--group")
+        .args(&["--group-name", "file group label"])
+        .arg("in1.csv")
+        .arg("in2.csv")
+        .arg("in3.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["file group label", "a", "b", "c", "d"],
+        svec!["in1", "1", "2", "3", ""],
+        svec!["in1", "2", "3", "4", ""],
+        svec!["in2", "1", "2", "3", ""],
+        svec!["in2", "2", "3", "4", ""],
+        svec!["in3", "1", "2", "3", "4"],
+        svec!["in3", "2", "3", "4", "5"],
+        svec!["in3", "z", "y", "x", "w"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn cat_rowskey_insertion_order() {
     let wrk = Workdir::new("cat_rowskey_insertion_order");
     wrk.create(


### PR DESCRIPTION
I went for a simpler implementation though, just grouping by file stem name.

resolves #1053 