### PR TITLE
`sniff`: replace magic with file-format crate

### DIFF
--- a/.github/workflows/macOS-arm64-selfhosted-publish.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish.yml
@@ -55,10 +55,6 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
-    - name: Install libmagic on linux
-      if: ${{ matrix.job.os-name == 'linux' }}
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev    
     - name: build prep for x86_64-unknown-linux-musl
       if: ${{ matrix.job.musl-prep }}
       run: |

--- a/.github/workflows/publish-linux-glibc-231-musl-1124.yml
+++ b/.github/workflows/publish-linux-glibc-231-musl-1124.yml
@@ -33,20 +33,20 @@ jobs:
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,self_update,magic,polars
+            addl-build-args: --features=apply,generate,luau,fetch,foreach,self_update,polars
             default-features:
-            addl-qsvlite-features: magic
-            addl-qsvdp-features: luau,magic
+            addl-qsvlite-features:
+            addl-qsvdp-features: luau
             name-suffix: glibc-2.31
           - os: ubuntu-20.04
             os-name: linux
             target: x86_64-unknown-linux-musl
             architecture: x86_64
             musl-prep: true
-            addl-build-args: --features=apply,generate,fetch,foreach,self_update,magic
+            addl-build-args: --features=apply,generate,fetch,foreach,self_update
             default-features:
-            addl-qsvlite-features: magic
-            addl-qsvdp-features: magic
+            addl-qsvlite-features:
+            addl-qsvdp-features:
             name-suffix: musl-1.1.24
 
     steps:
@@ -62,10 +62,6 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
-    - name: Install libmagic on linux
-      if: ${{ matrix.job.os-name == 'linux' }}
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: build prep for x86_64-unknown-linux-musl
       if: ${{ matrix.job.musl-prep }}
       run: |

--- a/.github/workflows/publish-nightly-glibc-231-musl-1124.yml
+++ b/.github/workflows/publish-nightly-glibc-231-musl-1124.yml
@@ -33,10 +33,10 @@ jobs:
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,self_update,magic,polars
+            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,self_update,polars
             default-features:
-            addl-qsvlite-features: magic
-            addl-qsvdp-features: luau,magic
+            addl-qsvlite-features:
+            addl-qsvdp-features: luau
             name-suffix: glibc-2.31
           - os: ubuntu-20.04
             os-name: linux
@@ -45,8 +45,8 @@ jobs:
             musl-prep: true
             addl-build-args: --features=apply,generate,fetch,foreach,nightly,self_update,polars
             default-features:
-            addl-qsvlite-features: magic
-            addl-qsvdp-features: magic
+            addl-qsvlite-features:
+            addl-qsvdp-features:
             name-suffix: musl-1.1.24
 
     steps:
@@ -64,10 +64,6 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
-    - name: Install libmagic on linux
-      if: ${{ matrix.job.os-name == 'linux' }}
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: build prep for x86_64-unknown-linux-musl
       if: ${{ matrix.job.musl-prep }}
       run: |

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -33,10 +33,10 @@ jobs:
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,self_update,magic,polars
+            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,self_update,polars
             default-features:
-            addl-qsvlite-features: magic
-            addl-qsvdp-features: luau,magic
+            addl-qsvlite-features:
+            addl-qsvdp-features: luau
           # - os: ubuntu-latest
           #   os-name: linux
           #   target: x86_64-unknown-linux-musl
@@ -84,10 +84,6 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
-    - name: Install libmagic on linux
-      if: ${{ matrix.job.os-name == 'linux' }}
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: build prep for x86_64-unknown-linux-musl
       if: ${{ matrix.job.musl-prep }}
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,20 +37,20 @@ jobs:
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
             use-cross: false
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,self_update,magic,polars
+            addl-build-args: --features=apply,generate,luau,fetch,foreach,self_update,polars
             default-features:
-            addl-qsvlite-features: magic
-            addl-qsvdp-features: luau,magic
+            addl-qsvlite-features:
+            addl-qsvdp-features: luau
           - os: ubuntu-22.04
             os-name: linux
             target: x86_64-unknown-linux-musl
             architecture: x86_64
             musl-prep: true
             use-cross: false
-            addl-build-args: --features=apply,generate,fetch,foreach,self_update,magic
+            addl-build-args: --features=apply,generate,fetch,foreach,self_update
             default-features:
-            addl-qsvlite-features: magic
-            addl-qsvdp-features: magic
+            addl-qsvlite-features:
+            addl-qsvdp-features:
           - os: ubuntu-22.04
             os-name: linux
             target: i686-unknown-linux-gnu
@@ -142,10 +142,6 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
-    - name: Install libmagic on linux
-      if: ${{ matrix.job.os-name == 'linux' }}
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev    
     - name: build prep for x86_64-unknown-linux-musl
       if: ${{ matrix.job.musl-prep }}
       run: |

--- a/.github/workflows/rust-beta.yml
+++ b/.github/workflows/rust-beta.yml
@@ -18,12 +18,9 @@ jobs:
     - uses: actions/setup-python@v4.6.1
       with:
         python-version: '3.11'
-    - name: Install libmagic
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: Update Rust Beta
       run: |
         rustup update beta
         rustup default beta
     - name: Run tests
-      run: cargo test --verbose --features feature_capable,apply,fetch,generate,foreach,python,luau,magic,polars
+      run: cargo test --verbose --features feature_capable,apply,fetch,generate,foreach,python,luau,polars

--- a/.github/workflows/rust-nightly-bleeding-edge.yml
+++ b/.github/workflows/rust-nightly-bleeding-edge.yml
@@ -33,4 +33,4 @@ jobs:
         override: true
         default: true
     - name: Run tests
-      run: cargo test --verbose --locked --features=apply,fetch,foreach,generate,luau,python,feature_capable,nightly,magic,polars
+      run: cargo test --verbose --locked --features=apply,fetch,foreach,generate,luau,python,feature_capable,nightly,polars

--- a/.github/workflows/rust-qsvdp.yml
+++ b/.github/workflows/rust-qsvdp.yml
@@ -22,12 +22,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: Update Rust
       run: rustup update
-    - name: Install libmagic
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: Setup Rust-cache
       uses: Swatinem/rust-cache@v2
       with:
         key: qsvdp-cache
     - name: Run tests
-      run: cargo test --verbose --locked --features=datapusher_plus,luau,magic
+      run: cargo test --verbose --locked --features=datapusher_plus,luau

--- a/.github/workflows/rust-qsvlite.yml
+++ b/.github/workflows/rust-qsvlite.yml
@@ -22,12 +22,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: Update Rust
       run: rustup update
-    - name: Install libmagic
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: Setup Rust-cache
       uses: Swatinem/rust-cache@v2
       with:
         key: qsvlite-cache
     - name: Run tests
-      run: cargo test --verbose --locked --features=lite,magic
+      run: cargo test --verbose --locked --features=lite

--- a/.github/workflows/rust-to.yml
+++ b/.github/workflows/rust-to.yml
@@ -24,9 +24,6 @@ jobs:
       run: |
         sudo apt-get update
     - uses: actions/checkout@v3
-    - name: Install libmagic
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: Update Rust
       run: rustup update
     - name: Setup Rust-cache
@@ -34,4 +31,4 @@ jobs:
       with:
         key: qsvto-cache
     - name: Run tests
-      run: cargo test --verbose --locked --features=magic,to,feature_capable
+      run: cargo test --verbose --locked --features=to,feature_capable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,9 +27,6 @@ jobs:
     - uses: actions/setup-python@v4.6.1
       with:
         python-version: '3.11'
-    - name: Install libmagic
-      run: |
-        sudo apt-get install libmagic1 libmagic-dev
     - name: Install and Run Redis
       run: |
         sudo apt-get install redis-server
@@ -41,4 +38,4 @@ jobs:
       with:
         key: qsv-cache
     - name: Run tests
-      run: cargo test --verbose --locked --features=apply,fetch,foreach,generate,luau,python,magic,polars,feature_capable
+      run: cargo test --verbose --locked --features=apply,fetch,foreach,generate,luau,python,polars,feature_capable

--- a/.github/workflows/test-publish-nightly.yml
+++ b/.github/workflows/test-publish-nightly.yml
@@ -20,7 +20,7 @@ jobs:
             architecture: x86_64
             addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,to,self_update,polars
             default-features:
-            addl-qsvdp-features: luau,magic
+            addl-qsvdp-features: luau
           # - os: ubuntu-latest
           #   os-name: linux
           #   target: x86_64-unknown-linux-musl

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -19,7 +19,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
             use-cross: false
-            addl-build-args:  --features=apply,generate,luau,fetch,foreach,self_update,to,magic
+            addl-build-args:  --features=apply,generate,luau,fetch,foreach,self_update,to
             default-features:
             addl-qsvdp-features: luau
           - os: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
             architecture: x86_64
             musl-prep: true
             use-cross: false
-            addl-build-args: --features=apply,generate,fetch,foreach,self_update,magic
+            addl-build-args: --features=apply,generate,fetch,foreach,self_update
             default-features:
             addl-qsvdp-features:
           - os: ubuntu-latest
@@ -126,11 +126,6 @@ jobs:
       run: |
         sudo apt-get install musl-tools musl-dev
         sudo ln -s /usr/bin/g++ /usr/bin/musl-g++        
-    - name: set MAGIC_STATIC false when cross-compiling
-      if: ${{ matrix.job.use-cross }}
-      env:
-        MAGIC_STATIC: false
-      uses: actions-rs/cargo@v1
     - name: Build qsv
       env:
         RUSTFLAGS: --emit=asm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -696,7 +696,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
+ "syn 2.0.20",
  "which",
 ]
 
@@ -927,7 +927,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -1037,6 +1037,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "cfb"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d9a1a046ad1c0410627f29da8dbdeee2c91fb046d0aed5381e5b558bcf3230"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -1625,17 +1636,6 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
@@ -1716,6 +1716,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "file-format"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805eab5eeca901cbdfabf3f54adb2f27464073617279fd4e14eedb2a0757222e"
+dependencies = [
+ "cfb",
+ "zip",
 ]
 
 [[package]]
@@ -1887,7 +1897,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -2733,29 +2743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "magic"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87142e3acb1f4daa62eaea96605421a534119d4777a9fb43fb2784798fd89665"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.2.8",
- "libc",
- "magic-sys",
- "thiserror",
-]
-
-[[package]]
-name = "magic-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff86ae08895140d628119d407d568f3b657145ee8c265878064f717534bb3bc"
-dependencies = [
- "libc",
- "vcpkg",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,18 +3238,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -3284,7 +3271,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -3635,12 +3622,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -3660,9 +3647,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "363a6f739a0c0addeaf6ed75150b95743aa18643a3c6f40409ed7b6db3a6911f"
 dependencies = [
  "unicode-ident",
 ]
@@ -3799,6 +3786,7 @@ dependencies = [
  "dynfmt",
  "eudex",
  "ext-sort",
+ "file-format",
  "filetime",
  "flate2",
  "flexi_logger",
@@ -3817,7 +3805,6 @@ dependencies = [
  "jsonschema",
  "jsonxf",
  "log",
- "magic",
  "mimalloc",
  "mlua",
  "newline-converter",
@@ -4319,7 +4306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.3.1",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
@@ -4473,7 +4460,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -4545,7 +4532,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -4841,7 +4828,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -4863,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "fcb8d4cebc40aa517dfb69618fa647a346562e67228e2236ae0042ee6ac14775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4910,9 +4897,9 @@ checksum = "06f6b473c37f9add4cf1df5b4d66a8ef58ab6c895f1a3b3f949cf3e21230140e"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
 
 [[package]]
 name = "tempfile"
@@ -4966,7 +4953,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -5083,7 +5070,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
 ]
 
 [[package]]
@@ -5403,7 +5390,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
  "wasm-bindgen-shared",
 ]
 
@@ -5437,7 +5424,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.20",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ ext-sort = { version = "0.1", features = [
     "memory-limit",
 ], default-features = false }
 flate2 = { version = "1", optional = true }
+file-format = {version = "0.17", features = ["reader"] }
 filetime = "0.2"
 flexi_logger = { version = "0.25", features = [
     "async",
@@ -196,9 +197,6 @@ simdutf8 = "0.1"
 # use SIMD on aarch64 (Apple Silicon, Raspberry Pi 4, etc.)
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 simdutf8 = { version = "0.1", features = ["aarch64_neon"] }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-magic = { version = "0.13", optional = true }
 
 [dev-dependencies]
 actix-governor = "0.4"

--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -165,10 +165,3 @@ impl From<serde_json::Error> for CliError {
         CliError::Other(format!("JSON error: {err:?}"))
     }
 }
-
-#[cfg(all(target_os = "linux", feature = "magic"))]
-impl From<magic::MagicError> for CliError {
-    fn from(err: magic::MagicError) -> CliError {
-        CliError::Other(format!("magic error: {err:?}"))
-    }
-}

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -5,15 +5,10 @@ content length and estimated number of records if sniffing a URL, file size, num
 field names & data types) using a Viterbi algorithm.
 (https://en.wikipedia.org/wiki/Viterbi_algorithm)
 
-On Linux, `sniff` also acts as a general mime type detector using the libmagic library,
-returning the detected mime type, file size and last modified date. If --no-infer is enabled,
-it doesn't even bother to infer the CSV's schema. This makes it especially useful for accelerated
-CKAN harvesting and for checking stale/broken resource URLs.
-
-On macOS and Windows however, `sniff` is only a CSV dialect detector and does not
-detect other file types. It can only sniff files with the "csv", "tsv", "tab" and
-"txt" extensions, and snappy compressed variants of these formats (e.g. "csv.sz",
-"tsv.sz", etc.) extensions.
+`sniff` is also a general mime type detector, returning the detected mime type, file size and
+last modified date. If --no-infer is enabled, it doesn't even bother to infer the CSV's schema.
+This makes it especially useful for accelerated CKAN harvesting and for checking stale/broken
+resource URLs.
 
 NOTE: This command "sniffs" a CSV's schema by sampling the first n rows (default: 1000)
 of a file. Its inferences are sometimes wrong if the the file is too small to infer a pattern
@@ -87,15 +82,12 @@ sniff options:
                              (Unsigned, Signed => Integer, Text => String, everything else the same)
     --no-infer               Do not infer the schema. Only return the file's mime type, size and
                              last modified date. Use this to use sniff as a general mime type detector.
-                             Valid only on Linux.
     --quick                  When sniffing a non-CSV remote file, only download the first chunk of the file
                              before attempting to detect the mime type. This is faster but less accurate as
                              some mime types cannot be detected with just the first downloaded chunk.
-                             Valid only on Linux.
     --harvest-mode           This is a convenience flag when using sniff in CKAN harvesters. 
                              It is equivalent to --quick --timeout 10 --stats-types --json
                              and --user-agent "CKAN-harvest/$QSV_VERSION ($QSV_TARGET; $QSV_BIN_NAME)"
-                             Valid only on Linux.
 
 Common options:
     -h, --help               Display this message
@@ -111,6 +103,7 @@ use std::{
 };
 
 use bytes::Bytes;
+use file_format::FileFormat;
 use futures::executor::block_on;
 use futures_util::StreamExt;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
@@ -159,7 +152,6 @@ struct SniffStruct {
     quote_char:      String,
     flexible:        bool,
     is_utf8:         bool,
-    #[cfg(all(target_os = "linux", feature = "magic"))]
     detected_mime:   String,
     retrieved_size:  usize,
     file_size:       usize,
@@ -212,7 +204,6 @@ impl fmt::Display for SniffStruct {
         writeln!(f, "Quote Char: {}", self.quote_char)?;
         writeln!(f, "Flexible: {}", self.flexible)?;
         writeln!(f, "Is UTF8: {}", self.is_utf8)?;
-        #[cfg(all(target_os = "linux", feature = "magic"))]
         writeln!(f, "Detected Mime Type: {}", self.detected_mime)?;
         writeln!(
             f,
@@ -277,7 +268,6 @@ impl fmt::Display for SniffStruct {
 struct SniffFileStruct {
     display_path:       String,
     file_to_sniff:      String,
-    #[cfg(all(target_os = "linux", feature = "magic"))]
     detected_mime:      String,
     tempfile_flag:      bool,
     retrieved_size:     usize,
@@ -428,13 +418,7 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                 let mut downloaded_lines = 0_usize;
                 #[allow(unused_assignments)]
                 let mut chunk = Bytes::new(); // amortize the allocation
-
-                // the unused_muts are here to suppress warnings
-                // when the magic feature is not enabled
-                #[allow(unused_mut)]
                 let mut firstchunk = Bytes::new();
-                #[allow(unused_mut)]
-                let mut magic_flag = false;
 
                 // download chunks until we have the desired sample size
                 while let Some(item) = stream.next().await {
@@ -444,18 +428,8 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                         .map_err(|_| "Error while writing to file")?;
                     let chunk_len = chunk.len();
 
-                    #[cfg(all(target_os = "linux", feature = "magic"))]
-                    {
-                        // we're using magic!
-                        magic_flag = true;
-                    }
-
-                    // on linux, we can short-circuit downloading
-                    // by checking the file type from the first chunk
-                    // when --quick is enabled
-                    #[cfg(all(target_os = "linux", feature = "magic"))]
                     if downloaded == 0 && !snappy_flag && args.flag_quick {
-                        let mime = util::sniff_filetype_from_buffer(&chunk)?;
+                        let mime = FileFormat::from_bytes(&chunk).media_type().to_string();
                         log::debug!("scanned first {chunk_len} bytes - detected mime: {mime}");
                         if !mime.starts_with("text/") && mime != "application/csv" {
                             downloaded = chunk_len;
@@ -504,17 +478,11 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                 }
 
                 let wtr_file_path;
-                #[allow(unused_mut)]
                 let mut csv_candidate = true;
-                #[allow(unused_mut)]
-                #[allow(unused_assignments)]
-                #[allow(unused_variables)]
                 let mut detected_mime = String::new();
 
-                #[cfg(all(target_os = "linux", feature = "magic"))]
                 if !args.flag_quick {
-                    detected_mime =
-                        util::get_filetype(&file.path().to_path_buf().display().to_string())?;
+                    detected_mime = FileFormat::from_file(file.path())?.media_type().to_string();
                     csv_candidate =
                         detected_mime.starts_with("text/") || detected_mime == "application/csv";
                 }
@@ -534,8 +502,8 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                     // before we can sniff it
                     wtr_file_path =
                         util::decompress_snappy_file(&file.path().to_path_buf(), tmpdir)?;
-                } else if args.flag_quick && magic_flag && !csv_candidate {
-                    // on linux, when --quiick is enabled, we short-circuit downloading by checking
+                } else if args.flag_quick && !csv_candidate {
+                    // when --quick is enabled, we short-circuit downloading by checking
                     // the file type from the first chunk. If the file is not a CSV,
                     // we just write the first chunk to a file and return
                     wtr_file_path = path.display().to_string();
@@ -545,8 +513,7 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                     // we downloaded a non-snappy file and it might be a CSV file.
                     // Rewrite it so we only have the exact sample size and truncate potentially
                     // incomplete lines. We do this coz we streamed the download and the downloaded
-                    // file may be more than the sample size, and the final line
-                    // may be incomplete.
+                    // file may be more than the sample size, and the final line may be incomplete.
                     wtr_file_path = path.display().to_string();
                     let mut wtr = Config::new(&Some(wtr_file_path.clone()))
                         .no_headers(false)
@@ -582,8 +549,7 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                     }
                     wtr.flush()?;
                 } else {
-                    // we downloaded a non-snappy file and its not a CSV file
-                    // just copy it over
+                    // we downloaded a non-snappy file and its not a CSV file just copy it over
                     wtr_file_path = path.display().to_string();
                     file.seek(SeekFrom::Start(0))?;
                     copy(&mut file, &mut tmp_file)?;
@@ -593,19 +559,13 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                 Ok(SniffFileStruct {
                     display_path: url,
                     file_to_sniff: wtr_file_path,
-                    #[cfg(all(target_os = "linux", feature = "magic"))]
                     detected_mime,
                     tempfile_flag: true,
                     retrieved_size: downloaded,
-                    file_size: if magic_flag && total_size == usize::MAX {
-                        // we're using magic and the server didn't give us content length
+                    file_size: if total_size == usize::MAX {
+                        // the server didn't give us content length
                         // so send usize::MAX to indicate that we don't know the file size
                         usize::MAX
-                    } else if total_size == usize::MAX {
-                        // the server didn't give us content length, so we just
-                        // downloaded the entire file. downloaded variable
-                        // is the total size of the file
-                        downloaded
                     } else {
                         total_size
                     },
@@ -636,26 +596,8 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                                 .unwrap();
                             log::info!("Decompressed {lower_ext} file to {path}");
                         }
-                        // on linux, we don't need to check the extension
-                        // because we use magic to get the file type
-                        #[cfg(not(feature = "magic"))]
-                        match lower_ext.as_str() {
-                            "csv" | "tsv" | "txt" | "tab" => {}
-                            ext if ext.ends_with("_decompressed") => {}
-                            _ => {
-                                return fail_clierror!(
-                                    "File extension '{lower_ext}' is not supported",
-                                    // ext = ext.to_str().unwrap()
-                                );
-                            }
-                        }
                     }
                     None => {
-                        // on linux, we log a warning and continue if no
-                        // extension is found. On other platforms, we fail
-                        #[cfg(not(feature = "magic"))]
-                        return fail_clierror!("File extension not found");
-                        #[cfg(all(target_os = "linux", feature = "magic"))]
                         log::warn!("File extension not found");
                     }
                 }
@@ -685,8 +627,7 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                 Ok(SniffFileStruct {
                     display_path: canonical_path,
                     file_to_sniff: path,
-                    #[cfg(all(target_os = "linux", feature = "magic"))]
-                    detected_mime: "".to_string(),
+                    detected_mime: String::new(),
                     tempfile_flag: false,
                     retrieved_size: file_size,
                     file_size,
@@ -725,8 +666,7 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
         Ok(SniffFileStruct {
             display_path: "stdin".to_string(),
             file_to_sniff: path_string,
-            #[cfg(all(target_os = "linux", feature = "magic"))]
-            detected_mime: "".to_string(),
+            detected_mime: String::new(),
             tempfile_flag: true,
             retrieved_size: file_size,
             file_size,
@@ -766,20 +706,6 @@ async fn sniff_main(mut args: Args) -> CliResult<()> {
             Some("CKAN-harvest/$QSV_VERSION ($QSV_TARGET; $QSV_BIN_NAME)".to_string());
     }
 
-    #[cfg(not(target_os = "linux"))]
-    if args.flag_no_infer || args.flag_quick {
-        return fail_clierror!(
-            "--no-infer and --quick are only supported on Linux with the 'magic' feature enabled"
-        );
-    }
-
-    #[cfg(all(target_os = "linux", not(feature = "magic")))]
-    if args.flag_no_infer || args.flag_quick {
-        return fail_clierror!(
-            "--no-infer and --quick are only supported when the 'magic' feature is enabled"
-        );
-    }
-
     let mut sample_size = args.flag_sample;
     if sample_size < 0.0 {
         if args.flag_json || args.flag_pretty_json {
@@ -801,88 +727,77 @@ async fn sniff_main(mut args: Args) -> CliResult<()> {
     let sfile_info = block_on(future)?;
     let tempfile_to_delete = sfile_info.file_to_sniff.clone();
     #[allow(unused_assignments)]
-    #[allow(unused_mut)]
-    #[allow(unused_variables)]
     let mut file_type = String::new();
 
-    // on linux, check what kind of file we have
-    // if its NOT a CSV or a text file, we fail, showing the detected mime type
-    #[cfg(all(target_os = "linux", feature = "magic"))]
+    // if we have a detected mime type earlier, we can skip the sniffing
+    // unless it was a snappy file and --no-infer is disabled,
+    // as we need to sniff the uncompressed file
+    if sfile_info.detected_mime.is_empty()
+        || sfile_info.detected_mime == "application/x-snappy-framed" && !args.flag_no_infer
     {
-        // if we have a detected mime type earlier, we can skip the sniffing
-        // unless it was a snappy file and --no-infer is disabled,
-        // as we need to sniff the uncompressed file
-        if sfile_info.detected_mime.is_empty()
-            || sfile_info.detected_mime == "application/x-snappy-framed" && !args.flag_no_infer
-        {
-            file_type = util::get_filetype(&sfile_info.file_to_sniff)?;
+        file_type = FileFormat::from_file(&sfile_info.file_to_sniff)?
+            .media_type()
+            .to_string();
+    } else {
+        file_type = sfile_info.detected_mime.clone();
+    }
+
+    // we also accept text/* files, as sniff may still be able to suss out
+    // if the file is a CSV, even if its not using a CSV extension
+    // we can also be here if the user has specified --no-infer
+    if (file_type != "application/csv" && !file_type.starts_with("text/")) || args.flag_no_infer {
+        cleanup_tempfile(sfile_info.tempfile_flag, tempfile_to_delete)?;
+
+        let size = if sfile_info.file_size == usize::MAX {
+            "Unknown".to_string()
         } else {
-            file_type = sfile_info.detected_mime.clone();
-        }
+            sfile_info.file_size.to_string()
+        };
+        let last_modified = sfile_info.last_modified;
 
-        // we also accept text/* files, as sniff may still be able to suss out
-        // if the file is a CSV, even if its not using a CSV extension
-        // we can also be here if the user has specified --no-infer
-        if (file_type != "application/csv" && !file_type.starts_with("text/")) || args.flag_no_infer
-        {
-            cleanup_tempfile(sfile_info.tempfile_flag, tempfile_to_delete)?;
-
-            let size = if sfile_info.file_size == usize::MAX {
-                "Unknown".to_string()
-            } else {
-                sfile_info.file_size.to_string()
-            };
-            let last_modified = sfile_info.last_modified;
-
-            if args.flag_json || args.flag_pretty_json {
-                if args.flag_no_infer {
-                    let json_result = json!({
-                        "title": "sniff mime type",
-                        "meta": {
-                            "detected_mime_type": file_type,
-                            "size": size,
-                            "last_modified": last_modified,
-                        }
-                    });
-                    if args.flag_pretty_json {
-                        woutinfo!("{}", serde_json::to_string_pretty(&json_result).unwrap());
-                        return Ok(());
-                    }
-                    woutinfo!("{json_result}");
-                    return Ok(());
-                } else {
-                    let json_result = json!({
-                        "errors": [{
-                            "title": "sniff error",
-                            "detail": format!("File is not a CSV file. Detected mime type: {file_type}"),
-                            "meta": {
-                                "detected_mime_type": file_type,
-                                "size": size,
-                                "last_modified": last_modified,
-                            }
-                        }]
-                    });
-                    if args.flag_pretty_json {
-                        return fail_clierror!(
-                            "{}",
-                            serde_json::to_string_pretty(&json_result).unwrap()
-                        );
-                    }
-                    return fail_clierror!("{json_result}");
-                }
-            }
+        if args.flag_json || args.flag_pretty_json {
             if args.flag_no_infer {
-                woutinfo!(
-                    "Detected mime type: {file_type}, size: {size}, last modified: {last_modified}"
-                );
+                let json_result = json!({
+                    "title": "sniff mime type",
+                    "meta": {
+                        "detected_mime_type": file_type,
+                        "size": size,
+                        "last_modified": last_modified,
+                    }
+                });
+                if args.flag_pretty_json {
+                    woutinfo!("{}", serde_json::to_string_pretty(&json_result).unwrap());
+                    return Ok(());
+                }
+                woutinfo!("{json_result}");
                 return Ok(());
-            } else {
-                return fail_clierror!(
-                    "File is not a CSV file. Detected mime type: {file_type}, size: {size}, last \
-                     modified: {last_modified}"
-                );
             }
+            let json_result = json!({
+                "errors": [{
+                    "title": "sniff error",
+                    "detail": format!("File is not a CSV file. Detected mime type: {file_type}"),
+                    "meta": {
+                        "detected_mime_type": file_type,
+                        "size": size,
+                        "last_modified": last_modified,
+                    }
+                }]
+            });
+            if args.flag_pretty_json {
+                return fail_clierror!("{}", serde_json::to_string_pretty(&json_result).unwrap());
+            }
+            return fail_clierror!("{json_result}");
         }
+        if args.flag_no_infer {
+            woutinfo!(
+                "Detected mime type: {file_type}, size: {size}, last modified: {last_modified}"
+            );
+            return Ok(());
+        }
+        return fail_clierror!(
+            "File is not a CSV file. Detected mime type: {file_type}, size: {size}, last \
+             modified: {last_modified}"
+        );
     }
 
     let conf = Config::new(&Some(sfile_info.file_to_sniff.clone()))
@@ -908,7 +823,6 @@ async fn sniff_main(mut args: Args) -> CliResult<()> {
             }
         }
     } else {
-        // sfile_info.sampled_records
         // usize::MAX is a sentinel value to let us
         // know that we need to estimate the number of records
         // since we only downloaded a sample, not the entire file
@@ -1038,7 +952,6 @@ async fn sniff_main(mut args: Args) -> CliResult<()> {
                 },
                 flexible: metadata.dialect.flexible,
                 is_utf8: metadata.dialect.is_utf8,
-                #[cfg(all(target_os = "linux", feature = "magic"))]
                 detected_mime: file_type.clone(),
                 retrieved_size: sfile_info.retrieved_size,
                 file_size: sfile_info.file_size,
@@ -1078,25 +991,12 @@ async fn sniff_main(mut args: Args) -> CliResult<()> {
         } else {
             #[allow(unused_assignments)]
             let mut sniff_error_json: serde_json::Value = Value::default();
-            #[cfg(all(target_os = "linux", feature = "magic"))]
             {
                 sniff_error_json = json!({
                     "title": "sniff error",
                     "detail": format!("{}", sniff_error.unwrap()),
                     "meta": {
                         "detected_mime_type": file_type,
-                        "size": sfile_info.file_size,
-                        "last_modified": sfile_info.last_modified,
-                    }
-                });
-            }
-            #[cfg(not(feature = "magic"))]
-            {
-                sniff_error_json = json!({
-                    "title": "sniff error",
-                    "detail": format!("{}", sniff_error.unwrap()),
-                    "meta": {
-                        "detected_mime_type": "Unknown",
                         "size": sfile_info.file_size,
                         "last_modified": sfile_info.last_modified,
                     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -144,10 +144,6 @@ pub fn version() -> String {
     enabled_features.push_str("foreach;");
     #[cfg(all(feature = "generate", not(feature = "lite")))]
     enabled_features.push_str("generate;");
-    #[cfg(all(target_os = "linux", feature = "magic"))]
-    {
-        enabled_features.push_str(format!("magic-{};", magic::version()).as_str());
-    }
 
     #[cfg(all(feature = "luau", not(feature = "lite")))]
     {
@@ -1396,44 +1392,6 @@ pub fn isutf8_file(path: &Path) -> Result<bool, CliError> {
     reader.read_to_end(&mut buffer)?;
 
     Ok(simdutf8::basic::from_utf8(&buffer).is_ok())
-}
-
-/// find out what kind of file we have using magic
-#[cfg(all(target_os = "linux", feature = "magic"))]
-pub fn get_filetype(path: &str) -> Result<String, CliError> {
-    // We just want the mime type
-    let cookie = magic::Cookie::open(magic::CookieFlags::MIME_TYPE)?;
-
-    // Load libmagic's default database
-    cookie.load::<&str>(&[])?;
-
-    let mime = cookie.file(path)?;
-
-    Ok(mime)
-}
-
-/// find out what kind of file we have using magic
-/// by sampling the provided bytes of the file
-#[cfg(all(target_os = "linux", feature = "magic"))]
-pub fn sniff_filetype_from_buffer(in_buffer: &bytes::Bytes) -> Result<String, CliError> {
-    // We just want the mime type
-    let cookie = magic::Cookie::open(magic::CookieFlags::MIME_TYPE)?;
-
-    // Load libmagic's default database
-    cookie.load::<&str>(&[])?;
-
-    let buffer_len = in_buffer.len();
-
-    if buffer_len > 0 {
-        let mut buffer_wrk = bytes::BytesMut::with_capacity(buffer_len);
-        buffer_wrk.extend_from_slice(&in_buffer[0..buffer_len]);
-        let mime = cookie.buffer(&buffer_wrk)?;
-
-        Ok(mime)
-    } else {
-        // empty file, so we return inode/x-empty
-        Ok("inode/x-empty".to_string())
-    }
 }
 
 /// Process the input files and return a vector of paths to the input files

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -78,18 +78,11 @@ fn sniff_url_notcsv() {
     let mut cmd = wrk.command("sniff");
     cmd.arg("https://github.com/jqnatividad/qsv/raw/master/resources/test/excel-xlsx.xlsx");
 
-    #[cfg(all(target_os = "linux", feature = "magic"))]
-    {
-        let got_error = wrk.output_stderr(&mut cmd);
+    let got_error = wrk.output_stderr(&mut cmd);
 
-        let expected = "File is not a CSV file. Detected mime type: \
-                        application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-        assert!(got_error.starts_with(expected));
-    }
-    #[cfg(not(feature = "magic"))]
-    {
-        wrk.assert_err(&mut cmd);
-    }
+    let expected = "File is not a CSV file. Detected mime type: \
+                    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    assert!(got_error.starts_with(expected));
 }
 
 #[test]
@@ -101,23 +94,10 @@ fn sniff_notcsv() {
     let mut cmd = wrk.command("sniff");
     cmd.arg(test_file);
 
-    #[cfg(all(target_os = "linux", feature = "magic"))]
-    {
-        let got_error = wrk.output_stderr(&mut cmd);
+    let got_error = wrk.output_stderr(&mut cmd);
 
-        let expected = "File is not a CSV file. Detected mime type: application/vnd.ms-excel";
-        assert!(got_error.starts_with(expected));
-    }
-    #[cfg(not(feature = "magic"))]
-    {
-        let got_error = wrk.output_stderr(&mut cmd);
-
-        let expected = "File extension 'xls' is not supported";
-        assert_eq!(
-            dos2unix(&got_error).trim_end(),
-            dos2unix(expected).trim_end()
-        );
-    }
+    let expected = "File is not a CSV file. Detected mime type: application/vnd.ms-excel";
+    assert!(got_error.starts_with(expected));
 }
 
 #[test]
@@ -177,19 +157,11 @@ fn sniff_url_snappy_noinfer() {
     cmd.arg("https://github.com/jqnatividad/qsv/raw/master/resources/test/boston311-100.csv.sz")
         .arg("--no-infer");
 
-    #[cfg(all(target_os = "linux", feature = "magic"))]
-    {
-        let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout(&mut cmd);
 
-        let expected = "Detected mime type: application/x-snappy-framed";
+    let expected = "Detected mime type: application/x-snappy-framed";
 
-        assert!(got.starts_with(expected));
-    }
-
-    #[cfg(not(feature = "magic"))]
-    {
-        wrk.assert_err(&mut cmd);
-    }
+    assert!(got.starts_with(expected));
 }
 
 #[test]
@@ -251,11 +223,9 @@ fn sniff_tab() {
     let mut cmd = wrk.command("sniff");
     cmd.arg("in.TAB");
 
-    #[cfg(all(target_os = "linux", feature = "magic"))]
-    {
-        let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout(&mut cmd);
 
-        let expected_end = r#"Delimiter: tab
+    let expected_end = r#"Delimiter: tab
 Header Row: true
 Preamble Rows: 0
 Quote Char: none
@@ -275,33 +245,7 @@ Fields:
     1:  Unsigned  h2
     2:  Text      h3"#;
 
-        assert!(dos2unix(&got).trim_end().ends_with(expected_end.trim_end()));
-    }
-    #[cfg(not(feature = "magic"))]
-    {
-        let got: String = wrk.stdout(&mut cmd);
-
-        let expected_end = r#"Delimiter: tab
-Header Row: true
-Preamble Rows: 0
-Quote Char: none
-Flexible: false
-Is UTF8: true
-Retrieved Size (bytes): 27
-File Size (bytes): 27
-Sampled Records: 2
-Estimated: false
-Num Records: 2
-Avg Record Len (bytes): 6
-Num Fields: 3
-Stats Types: false
-Fields:
-    0:  Text      h1
-    1:  Unsigned  h2
-    2:  Text      h3"#;
-
-        assert!(dos2unix(&got).trim_end().ends_with(expected_end.trim_end()));
-    }
+    assert!(dos2unix(&got).trim_end().ends_with(expected_end.trim_end()));
 }
 
 #[test]


### PR DESCRIPTION
* file-format works on all platforms without issue, unlike magic which only works in a straightforward manner on Linux
* no need to link to C-based lib magic, its all Rust
* vastly simplified code structure for sniff as all the conditional compilation stuff to only use magic on Linux is gone