### PR TITLE
security.md: fix mailto text

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ As such, only the latest release will have security updates.
 If you've found a vulnerability, pleases [create an issue](https://github.com/jqnatividad/qsv/issues/new/choose) in GitHub.
 
 However, if a vulnerability is severe and could lead to zero-day
-exploits, please send an email to mailto:qsv-severe@datHere.com instead.
+exploits, please send an email to [qsv-severe@datHere.com](mailto:qsv-severe@datHere.com) instead.
 
 The vulnerability report will be addressed within one business day. A 
 mitigation/workaround, if available, will be included in the next release and mentioned


### PR DESCRIPTION
# PR Description

Just fixes the text that is displayed for the email to report a severe security issue (`mailto:` is removed in display but is included in clickable link).

## Before

![image](https://github.com/jqnatividad/qsv/assets/30333942/0ef86295-d5a3-4ffb-98ec-d7b8045fc426)

https://github.com/jqnatividad/qsv/blob/4ca1f55013f7a78179cbd9d4fa104b99d184e1bd/SECURITY.md?plain=1#L15

## After

![image](https://github.com/jqnatividad/qsv/assets/30333942/82747969-e6b7-4f5b-801e-51f4fdb39c22)

https://github.com/jqnatividad/qsv/blob/ce0aef41c3240a4dea9e0770315a441bdd182058/SECURITY.md?plain=1#L15
