### PR TITLE
describegpt: add --user-agent in help message

### DIFF
--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -51,8 +51,12 @@ struct Args {
 // OpenAI API model
 const MODEL: &str = "gpt-3.5-turbo-16k";
 
-fn get_completion(api_key: &str, messages: &serde_json::Value, max_tokens: Option<i32>, flag_user_agent: Option<String>) -> String {
-
+fn get_completion(
+    api_key: &str,
+    messages: &serde_json::Value,
+    max_tokens: Option<i32>,
+    flag_user_agent: Option<String>,
+) -> String {
     // If --user-agent is not specified, use an empty string as the default value
     let user_agent = flag_user_agent.unwrap_or_default();
 
@@ -246,7 +250,12 @@ fn run_inference_options(
         prompt = get_dictionary_prompt(stats_str, frequency_str, args_json);
         println!("Generating data dictionary from OpenAI API...");
         messages = json!([{"role": "user", "content": prompt}]);
-        completion = get_completion(api_key, &messages, args.flag_max_tokens, args.flag_user_agent.clone());
+        completion = get_completion(
+            api_key,
+            &messages,
+            args.flag_max_tokens,
+            args.flag_user_agent.clone(),
+        );
         dictionary_completion_output = get_completion_output(&completion);
         println!("Dictionary output:\n{completion_output}");
     }
@@ -259,7 +268,12 @@ fn run_inference_options(
         };
         messages = get_messages(&prompt, &dictionary_completion_output);
         println!("Generating description from OpenAI API...");
-        completion = get_completion(api_key, &messages, args.flag_max_tokens, args.flag_user_agent.clone());
+        completion = get_completion(
+            api_key,
+            &messages,
+            args.flag_max_tokens,
+            args.flag_user_agent.clone(),
+        );
         completion_output = get_completion_output(&completion);
         println!("Description output:\n{completion_output}");
     }
@@ -271,7 +285,12 @@ fn run_inference_options(
         };
         messages = get_messages(&prompt, &dictionary_completion_output);
         println!("Generating tags from OpenAI API...");
-        completion = get_completion(api_key, &messages, args.flag_max_tokens, args.flag_user_agent.clone());
+        completion = get_completion(
+            api_key,
+            &messages,
+            args.flag_max_tokens,
+            args.flag_user_agent.clone(),
+        );
         completion_output = get_completion_output(&completion);
         println!("Tags output:\n{completion_output}");
     }

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -54,17 +54,14 @@ const MODEL: &str = "gpt-3.5-turbo-16k";
 fn get_completion(
     api_key: &str,
     messages: &serde_json::Value,
-    max_tokens: Option<i32>,
-    flag_user_agent: Option<String>,
+    args: &Args,
 ) -> String {
-    // If --user-agent is not specified, use an empty string as the default value
-    let user_agent = flag_user_agent.unwrap_or_default();
 
     // Create client with timeout
     let timeout_duration = Duration::from_secs(60);
     let client = Client::builder()
+        .user_agent(util::set_user_agent(args.flag_user_agent.clone()).unwrap())
         .timeout(timeout_duration)
-        .user_agent(user_agent.clone())
         .build()
         .unwrap();
 
@@ -74,8 +71,8 @@ fn get_completion(
     });
 
     // If max_tokens is specified, add it to the request data
-    if max_tokens.is_some() {
-        request_data["max_tokens"] = json!(max_tokens.unwrap());
+    if args.flag_max_tokens.is_some() {
+        request_data["max_tokens"] = json!(args.flag_max_tokens.unwrap());
     }
 
     // Send request to OpenAI API
@@ -252,8 +249,7 @@ fn run_inference_options(
         completion = get_completion(
             api_key,
             &messages,
-            args.flag_max_tokens,
-            args.flag_user_agent.clone(),
+            args
         );
         dictionary_completion_output = get_completion_output(&completion);
         println!("Dictionary output:\n{completion_output}");
@@ -270,8 +266,7 @@ fn run_inference_options(
         completion = get_completion(
             api_key,
             &messages,
-            args.flag_max_tokens,
-            args.flag_user_agent.clone(),
+            args
         );
         completion_output = get_completion_output(&completion);
         println!("Description output:\n{completion_output}");
@@ -287,8 +282,7 @@ fn run_inference_options(
         completion = get_completion(
             api_key,
             &messages,
-            args.flag_max_tokens,
-            args.flag_user_agent.clone(),
+            args
         );
         completion_output = get_completion_output(&completion);
         println!("Tags output:\n{completion_output}");

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -83,7 +83,6 @@ fn get_completion(
         .post("https://api.openai.com/v1/chat/completions")
         .header("Authorization", format!("Bearer {api_key}"))
         .header("Content-Type", "application/json")
-        .header("User-Agent", user_agent)
         .body(request_data.to_string())
         .send();
 

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -20,7 +20,10 @@ describegpt options:
     --max-tokens <value>   Limits the number of generated tokens in the
                            output.
     --json                 Return results in JSON format.
-
+    --user-agent <agent>   Specify custom user agent. It supports the following variables -
+                           $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND.
+                           Try to follow the syntax here -
+                           https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
 Common options:
     -h, --help             Display this message
 "#;

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -51,12 +51,7 @@ struct Args {
 // OpenAI API model
 const MODEL: &str = "gpt-3.5-turbo-16k";
 
-fn get_completion(
-    api_key: &str,
-    messages: &serde_json::Value,
-    args: &Args,
-) -> String {
-
+fn get_completion(api_key: &str, messages: &serde_json::Value, args: &Args) -> String {
     // Create client with timeout
     let timeout_duration = Duration::from_secs(60);
     let client = Client::builder()
@@ -246,11 +241,7 @@ fn run_inference_options(
         prompt = get_dictionary_prompt(stats_str, frequency_str, args_json);
         println!("Generating data dictionary from OpenAI API...");
         messages = json!([{"role": "user", "content": prompt}]);
-        completion = get_completion(
-            api_key,
-            &messages,
-            args
-        );
+        completion = get_completion(api_key, &messages, args);
         dictionary_completion_output = get_completion_output(&completion);
         println!("Dictionary output:\n{completion_output}");
     }
@@ -263,11 +254,7 @@ fn run_inference_options(
         };
         messages = get_messages(&prompt, &dictionary_completion_output);
         println!("Generating description from OpenAI API...");
-        completion = get_completion(
-            api_key,
-            &messages,
-            args
-        );
+        completion = get_completion(api_key, &messages, args);
         completion_output = get_completion_output(&completion);
         println!("Description output:\n{completion_output}");
     }
@@ -279,11 +266,7 @@ fn run_inference_options(
         };
         messages = get_messages(&prompt, &dictionary_completion_output);
         println!("Generating tags from OpenAI API...");
-        completion = get_completion(
-            api_key,
-            &messages,
-            args
-        );
+        completion = get_completion(api_key, &messages, args);
         completion_output = get_completion_output(&completion);
         println!("Tags output:\n{completion_output}");
     }


### PR DESCRIPTION
## 🗺 Overview

Resolves #1082. Adds the `--user-agent` option to `describegpt`.


