### PR TITLE
`describegpt`: minor refactoring

### DIFF
--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -168,3 +168,9 @@ impl From<serde_json::Error> for CliError {
         CliError::Other(format!("JSON error: {err:?}"))
     }
 }
+
+impl From<reqwest::Error> for CliError {
+    fn from(err: reqwest::Error) -> CliError {
+        CliError::Other(err.to_string())
+    }
+}

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -195,8 +195,6 @@ fn run_inference_options(
         }
     }
 
-    // Get completion from OpenAI API
-    println!("Interacting with OpenAI API...\n");
     fn get_completion_output(completion: &str) -> CliResult<String> {
         // Parse the completion JSON
         let completion_json: serde_json::Value = match serde_json::from_str(completion) {
@@ -223,6 +221,9 @@ fn run_inference_options(
             .replace("\\`", "`"))
     }
 
+    // Get completion from OpenAI API
+    println!("Interacting with OpenAI API...\n");
+    
     let args_json = args.flag_json;
     let mut prompt: String;
     let mut messages: serde_json::Value;

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -32,6 +32,7 @@ Common options:
 
 use std::{env, process::Command, time::Duration};
 
+use log::log_enabled;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::json;
@@ -59,6 +60,12 @@ fn get_completion(api_key: &str, messages: &serde_json::Value, args: &Args) -> C
     let timeout_duration = Duration::from_secs(args.flag_timeout.into());
     let client = Client::builder()
         .user_agent(util::set_user_agent(args.flag_user_agent.clone()).unwrap())
+        .brotli(true)
+        .gzip(true)
+        .deflate(true)
+        .use_rustls_tls()
+        .http2_adaptive_window(true)
+        .connection_verbose(log_enabled!(log::Level::Debug) || log_enabled!(log::Level::Trace))
         .timeout(timeout_duration)
         .build()?;
 
@@ -223,7 +230,7 @@ fn run_inference_options(
 
     // Get completion from OpenAI API
     println!("Interacting with OpenAI API...\n");
-    
+
     let args_json = args.flag_json;
     let mut prompt: String;
     let mut messages: serde_json::Value;

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -20,6 +20,8 @@ describegpt options:
     --max-tokens <value>   Limits the number of generated tokens in the output.
                            [default: 50]
     --json                 Return results in JSON format.
+    --timeout <secs>       Timeout for downloading URLs in seconds.
+                           [default: 60]
     --user-agent <agent>   Specify custom user agent. It supports the following variables -
                            $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND.
                            Try to follow the syntax here -
@@ -46,6 +48,7 @@ struct Args {
     flag_max_tokens:  u16,
     flag_json:        bool,
     flag_user_agent:  Option<String>,
+    flag_timeout:     u16,
 }
 
 // OpenAI API model
@@ -53,7 +56,7 @@ const MODEL: &str = "gpt-3.5-turbo-16k";
 
 fn get_completion(api_key: &str, messages: &serde_json::Value, args: &Args) -> String {
     // Create client with timeout
-    let timeout_duration = Duration::from_secs(60);
+    let timeout_duration = Duration::from_secs(args.flag_timeout.into());
     let client = Client::builder()
         .user_agent(util::set_user_agent(args.flag_user_agent.clone()).unwrap())
         .timeout(timeout_duration)

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -54,14 +54,13 @@ struct Args {
 // OpenAI API model
 const MODEL: &str = "gpt-3.5-turbo-16k";
 
-fn get_completion(api_key: &str, messages: &serde_json::Value, args: &Args) -> String {
+fn get_completion(api_key: &str, messages: &serde_json::Value, args: &Args) -> CliResult<String> {
     // Create client with timeout
     let timeout_duration = Duration::from_secs(args.flag_timeout.into());
     let client = Client::builder()
         .user_agent(util::set_user_agent(args.flag_user_agent.clone()).unwrap())
         .timeout(timeout_duration)
-        .build()
-        .unwrap();
+        .build()?;
 
     let request_data = json!({
         "model": MODEL,
@@ -80,20 +79,16 @@ fn get_completion(api_key: &str, messages: &serde_json::Value, args: &Args) -> S
     // Get response from OpenAI API
     let response = match request {
         Ok(val) => val,
-        Err(err) => {
-            eprintln!("Error: {err}");
-            std::process::exit(1);
-        }
+        Err(e) => return fail_clierror!("OpenAI API Error: {e}"),
     };
 
     let response_body = response.text();
 
     // Return completion output
     match response_body {
-        Ok(val) => val,
-        Err(_) => {
-            eprintln!("Error: Unable to get response body from OpenAI API.");
-            std::process::exit(1);
+        Ok(val) => Ok(val),
+        Err(e) => {
+            fail_clierror!("Error: Unable to get response body from OpenAI API. {e}")
         }
     }
 }
@@ -190,7 +185,7 @@ fn run_inference_options(
     api_key: &str,
     stats_str: Option<&str>,
     frequency_str: Option<&str>,
-) {
+) -> CliResult<()> {
     // Add --dictionary output as context if it is not empty
     fn get_messages(prompt: &str, dictionary_completion_output: &str) -> serde_json::Value {
         if dictionary_completion_output.is_empty() {
@@ -202,32 +197,30 @@ fn run_inference_options(
 
     // Get completion from OpenAI API
     println!("Interacting with OpenAI API...\n");
-    fn get_completion_output(completion: &str) -> String {
+    fn get_completion_output(completion: &str) -> CliResult<String> {
         // Parse the completion JSON
         let completion_json: serde_json::Value = match serde_json::from_str(completion) {
             Ok(val) => val,
             Err(_) => {
-                eprintln!("Error: Unable to parse completion JSON.");
-                std::process::exit(1);
+                return fail_clierror!("Error: Unable to parse completion JSON.");
             }
         };
         // If OpenAI API returns error, print error message
         if let serde_json::Value::Object(ref map) = completion_json {
             if map.contains_key("error") {
-                eprintln!("Error: {}", map["error"]);
-                std::process::exit(1);
+                return fail_clierror!("OpenAI API Error: {}", map["error"]);
             }
         }
         // Set the completion output
         let message = &completion_json["choices"][0]["message"]["content"];
         // Convert escaped characters to normal characters
-        message
+        Ok(message
             .to_string()
             .replace("\\n", "\n")
             .replace("\\t", "\t")
             .replace("\\\"", "\"")
             .replace("\\'", "'")
-            .replace("\\`", "`")
+            .replace("\\`", "`"))
     }
 
     let args_json = args.flag_json;
@@ -240,8 +233,8 @@ fn run_inference_options(
         prompt = get_dictionary_prompt(stats_str, frequency_str, args_json);
         println!("Generating data dictionary from OpenAI API...");
         messages = json!([{"role": "user", "content": prompt}]);
-        completion = get_completion(api_key, &messages, args);
-        dictionary_completion_output = get_completion_output(&completion);
+        completion = get_completion(api_key, &messages, args)?;
+        dictionary_completion_output = get_completion_output(&completion)?;
         println!("Dictionary output:\n{completion_output}");
     }
 
@@ -253,8 +246,8 @@ fn run_inference_options(
         };
         messages = get_messages(&prompt, &dictionary_completion_output);
         println!("Generating description from OpenAI API...");
-        completion = get_completion(api_key, &messages, args);
-        completion_output = get_completion_output(&completion);
+        completion = get_completion(api_key, &messages, args)?;
+        completion_output = get_completion_output(&completion)?;
         println!("Description output:\n{completion_output}");
     }
     if args.flag_tags || args.flag_all {
@@ -265,10 +258,12 @@ fn run_inference_options(
         };
         messages = get_messages(&prompt, &dictionary_completion_output);
         println!("Generating tags from OpenAI API...");
-        completion = get_completion(api_key, &messages, args);
-        completion_output = get_completion_output(&completion);
+        completion = get_completion(api_key, &messages, args)?;
+        completion_output = get_completion_output(&completion)?;
         println!("Tags output:\n{completion_output}");
     }
+
+    Ok(())
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -366,7 +361,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
 
     // Run inference options
-    run_inference_options(&args, &api_key, Some(stats_str), Some(frequency_str));
+    run_inference_options(&args, &api_key, Some(stats_str), Some(frequency_str))?;
 
     Ok(())
 }

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -17,8 +17,8 @@ describegpt options:
                            human-readable label, a description, and stats.
     --tags                 Prints tags that categorize the dataset. Useful
                            for grouping datasets and filtering.
-    --max-tokens <value>   Limits the number of generated tokens in the
-                           output.
+    --max-tokens <value>   Limits the number of generated tokens in the output.
+                           [default: 50]
     --json                 Return results in JSON format.
     --user-agent <agent>   Specify custom user agent. It supports the following variables -
                            $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND.
@@ -329,11 +329,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     } else if args.flag_all && (args.flag_dictionary || args.flag_description || args.flag_tags) {
         eprintln!("Error: --all option cannot be specified with other inference flags.");
         std::process::exit(1);
-    }
-    // If --max-tokens is not specified, print warning message that maximum token limit will be
-    // used.
-    if args.flag_max_tokens.is_none() {
-        eprintln!("Warning: No --max-tokens specified. Defaulting to maximum token limit.");
     }
     // If --max-tokens is specified as 0 or less, print error message.
     if args.flag_max_tokens.is_some() && args.flag_max_tokens.unwrap() <= 0 {

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -43,7 +43,7 @@ struct Args {
     flag_description: bool,
     flag_dictionary:  bool,
     flag_tags:        bool,
-    flag_max_tokens:  Option<i32>,
+    flag_max_tokens:  u16,
     flag_json:        bool,
     flag_user_agent:  Option<String>,
 }
@@ -60,15 +60,11 @@ fn get_completion(api_key: &str, messages: &serde_json::Value, args: &Args) -> S
         .build()
         .unwrap();
 
-    let mut request_data = json!({
+    let request_data = json!({
         "model": MODEL,
+        "max_tokens": args.flag_max_tokens,
         "messages": messages
     });
-
-    // If max_tokens is specified, add it to the request data
-    if args.flag_max_tokens.is_some() {
-        request_data["max_tokens"] = json!(args.flag_max_tokens.unwrap());
-    }
 
     // Send request to OpenAI API
     let request = client
@@ -328,11 +324,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // message.
     } else if args.flag_all && (args.flag_dictionary || args.flag_description || args.flag_tags) {
         eprintln!("Error: --all option cannot be specified with other inference flags.");
-        std::process::exit(1);
-    }
-    // If --max-tokens is specified as 0 or less, print error message.
-    if args.flag_max_tokens.is_some() && args.flag_max_tokens.unwrap() <= 0 {
-        eprintln!("Error: --max-tokens must be greater than 0.");
         std::process::exit(1);
     }
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -266,11 +266,6 @@ enum ReportKind {
     None,
 }
 
-impl From<reqwest::Error> for CliError {
-    fn from(err: reqwest::Error) -> CliError {
-        CliError::Other(err.to_string())
-    }
-}
 #[derive(Debug)]
 struct RedisConfig {
     conn_str:      String,


### PR DESCRIPTION
- simplify max-tokens option processing
- add --timeout option
- bubble up errors, so we don't short-circuit auto-logging done in main if we use std::process:exit()
- standardize reqwest client setup to support brotli/gzip/.deflate compression/decompression; use http2; and do verbose connection tracing when debug logging is on