### PR TITLE
describegpt: add --jsonl option (resolves #1086)

### DIFF
--- a/docs/Describegpt.md
+++ b/docs/Describegpt.md
@@ -32,6 +32,34 @@ You may often see this error when `--max-tokens` is set too low and therefore th
 
 The invalid output will be printed in `stderr`.
 
+Note that `--json` may not be used alongside `--jsonl`, nor may they both be set to true in a prompt file at the same time. This will result in an error.
+
+## `--jsonl`
+
+Similar to `--json`, you can use the the `--jsonl` option to expect [JSON Lines](https://jsonlines.org/) output.
+
+If you use `--output` with `--jsonl`, the output will be written to a new file if it doesn't exist and any lines after the first will be appended to the file. If the file already exists, the output will be appended to the file. Each inference option (`--dictionary`, `--description`, `--tags`) will be written to a new line in the file.
+
+If you use `--prompt-file` with `--jsonl`, the prompt name and timestamp will also be included in the JSONL output for each inference option.
+
+Note that **the `--jsonl` option does not indicate to your prompt that you want to generate JSONL output based on your dataset**. It instead ensures the command output is in JSONL format. You must specify in your prompt to make a completion in JSON format, such as adding the phrase "in JSON format" to your prompt, and this will then be parsed into JSONL format by `describegpt`.
+
+If the prompt output is not in valid JSON format but the `--jsonl` option is specified, the command will generate a default error JSON output printed to `stdout`, such as the following:
+
+```json
+{
+    "option": {
+        "error": "Invalid JSON output for option."
+    }
+}
+```
+
+You may often see this error when `--max-tokens` is set too low and therefore the output is incomplete.
+
+The invalid output will be printed in `stderr`.
+
+Note that `--jsonl` may not be used alongside `--json`, nor may they both be set to true in a prompt file at the same time. This will result in an error.
+
 ## `--max-tokens <value>`
 
 `--max-tokens` is a option that allows you to specify the maximum number of tokens in the completion **output**. This is limited by the maximum number of tokens allowed by the model including the input tokens.
@@ -80,7 +108,8 @@ Here is an example of a prompt:
     "dictionary_prompt": "Here are the columns for each field in a data dictionary:\n\n- Type: the data type of this column\n- Label: a human-friendly label for this column\n- Description: a full description for this column (can be multiple sentences)\n\nGenerate a data dictionary as aforementioned{json_add} where each field has Name, Type, Label, and Description (so four columns in total) based on the following summary statistics and frequency data from a CSV file.\n\nSummary Statistics:\n\n{stats}\n\nFrequency:\n\n{frequency}",
     "description_prompt": "Generate only a description that is within 8 sentences about the entire dataset{json_add} based on the following summary statistics and frequency data derived from the CSV file it came from.\n\nSummary Statistics:\n\n{stats}\n\nFrequency:\n\n{frequency}\n\nDo not output the summary statistics for each field. Do not output the frequency for each field. Do not output data about each field individually, but instead output about the dataset as a whole in one 1-8 sentence description.",
     "tags_prompt": "A tag is a keyword or label that categorizes datasets with other, similar datasets. Using the right tags makes it easier for others to find and use datasets.\n\nGenerate single-word tags{json_add} about the dataset (lowercase only and remove all whitespace) based on the following summary statistics and frequency data from a CSV file.\n\nSummary Statistics:\n\n{stats}\n\nFrequency:\n\n{frequency}",
-    "json": true
+    "json": true,
+    "jsonl": false
 }
 ```
 

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -473,6 +473,12 @@ fn run_inference_options(
 
     // Assuming `total_json_output` is a Vec<serde_json::Value>
     if args.flag_jsonl {
+        // If --prompt-file is used then provide the name as prompt_file in total_json_output and the timestamp like 1996-12-19T16:39:57-08:00
+        if let Some(prompt_file) = args.flag_prompt_file.clone() {
+            let prompt_file = get_prompt_file(args)?;
+            total_json_output["prompt_file"] = json!(prompt_file.name);
+            total_json_output["timestamp"] = json!(chrono::offset::Utc::now().to_rfc3339());
+        }
         // Print all JSONL output
         let formatted_output = total_json_output
             .as_array()


### PR DESCRIPTION
## 🗺 Overview

Resolves #1086.

- Adds `--jsonl` flag & `jsonl` boolean in prompt file for expecting JSONL output (works with --output too).
- Updates [Describegpt.md](https://github.com/jqnatividad/qsv/blob/describegpt/jsonl/docs/Describegpt.md#:~:text=Note%20that%20%2D%2Djson%20may%20not%20be%20used%20alongside%20%2D%2Djsonl,%2D%2Djsonl).
- Uses specification mentioned in https://github.com/jqnatividad/qsv/issues/1086#issuecomment-1631717837.
- https://github.com/jqnatividad/qsv/blob/7927a8abceba888620bddaf222a4359f847c6ca4/src/cmd/describegpt.rs#L593
- https://github.com/jqnatividad/qsv/blob/7927a8abceba888620bddaf222a4359f847c6ca4/src/cmd/describegpt.rs#L586

## 🔍 Notes

- Lines 333-366 could potentially be refactored later.