### PR TITLE
docs/Describegpt.md: typo 'a' --> 'an'

### DIFF
--- a/docs/Describegpt.md
+++ b/docs/Describegpt.md
@@ -62,7 +62,7 @@ Note that `--jsonl` may not be used alongside `--json`, nor may they both be set
 
 ## `--max-tokens <value>`
 
-`--max-tokens` is a option that allows you to specify the maximum number of tokens in the completion **output**. This is limited by the maximum number of tokens allowed by the model including the input tokens.
+`--max-tokens` is an option that allows you to specify the maximum number of tokens in the completion **output**. This is limited by the maximum number of tokens allowed by the model including the input tokens.
 
 Input tokens may include the output of `qsv stats` and `qsv frequency` from your dataset, which can be large based on your dataset's size. Therefore we use `gpt-3.5-turbo-16k` as the default model for `describegpt` as it has a maximum token limit of 16,384.
 


### PR DESCRIPTION
Changes `a` to `an` for `an option`.

Before:

https://github.com/jqnatividad/qsv/blob/11e6aa70bb5d079c4ddd046c496a9f0ddeeedf30/docs/Describegpt.md?plain=1#L65

After:

https://github.com/jqnatividad/qsv/blob/8186ffd16b29299f3a695702f7c32458ff03782a/docs/Describegpt.md?plain=1#L65