### PR TITLE
`foreach`: fix command argument token splitter pattern

### DIFF
--- a/tests/test_foreach.rs
+++ b/tests/test_foreach.rs
@@ -17,6 +17,54 @@ fn foreach() {
 }
 
 #[test]
+fn foreach_multiple_braces() {
+    let wrk = Workdir::new("foreach");
+    wrk.create(
+        "data.csv",
+        vec![svec!["name"], svec!["John"], svec!["Mary"]],
+    );
+    let mut cmd = wrk.command("foreach");
+    cmd.arg("name")
+        .arg("echo 'NAME = {}, {}, {}'")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["NAME = John", " John", " John"],
+        svec!["NAME = Mary", " Mary", " Mary"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn foreach_special_chars_1171() {
+    let wrk = Workdir::new("foreach_special_chars");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["host"],
+            svec!["omadhina.co.NA"],
+            svec!["https://www.google.com"],
+            svec!["www.apple.com"],
+            svec!["https://civic-data-ecosystem.github.io"],
+        ],
+    );
+    let mut cmd = wrk.command("foreach");
+    cmd.arg("host")
+        .arg("echo 'dig +short {} a'")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["dig +short omadhina.co.NA a"],
+        svec!["dig +short https://www.google.com a"],
+        svec!["dig +short www.apple.com a"],
+        svec!["dig +short https://civic-data-ecosystem.github.io a"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn foreach_unify() {
     let wrk = Workdir::new("foreach_unify");
     wrk.create(


### PR DESCRIPTION
fixes #1171 

Also:
- improved usage text by adding arguments section
- add comments explaining regex patterns used
- replace unwrap() with ? operator