### PR TITLE
Bump to qsv stats 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "qsv-stats"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61480a7785e732819b3c5f07f6b3194075292f591207500bb3438e3ba77ae513"
+checksum = "0501c57961bae68e593d4fb05153d7be3ebef6b64ed25fbb213898ab91a7cedd"
 dependencies = [
  "ahash 0.8.3",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ polars = { version = "0.31", features = [
 pyo3 = { version = "0.19", features = ["auto-initialize"], optional = true }
 qsv-dateparser = "0.10"
 qsv_docopt = "1.3"
-qsv-stats = "0.10"
+qsv-stats = "0.11"
 qsv_currency = { version = "0.6", optional = true }
 qsv-sniffer = { version = "0.10", default-features = false, features = [
     "runtime-dispatch-simd",

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1056,7 +1056,7 @@ impl Stats {
                         v.add(n);
                     }
                     if let Some(v) = self.online.as_mut() {
-                        v.add(n);
+                        v.add(&n);
                     }
                 }
             }
@@ -1084,7 +1084,7 @@ impl Stats {
                         v.add(n);
                     }
                     if let Some(v) = self.online.as_mut() {
-                        v.add(n);
+                        v.add(&n);
                     }
                 }
             }


### PR DESCRIPTION
this should make all stats-backed commands (stats, schema, tojsonl, etc.) marginally faster