### PR TITLE
`search` &  `searchset`: amortize allocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for mor
 | [sample](/src/cmd/sample.rs#L2)<br>📇🌐 | Randomly draw rows (with optional seed) from a CSV using [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) (i.e., use memory proportional to the size of the sample).  |
 | [schema](/src/cmd/schema.rs#L2)<br>📇😣🏎️ | Infer schema from CSV data, replete with data type & domain/range validation & output in [JSON Schema](https://json-schema.org/) format. Uses multithreading to go faster if an index is present. See `validate` command to use the generated JSON Schema to validate if similar CSVs comply with the schema. |
 | [search](/src/cmd/search.rs#L2) | Run a regex over a CSV. Applies the regex to each field individually & shows only matching rows.  |
-| [searchset](/src/cmd/searchset.rs#L3) | *Run multiple regexes over a CSV in a single pass.* Applies the regexes to each field individually & shows only matching rows.  |
+| [searchset](/src/cmd/searchset.rs#L2) | *Run multiple regexes over a CSV in a single pass.* Applies the regexes to each field individually & shows only matching rows.  |
 | [select](/src/cmd/select.rs#L2) | Select, re-order, duplicate or drop columns.  |
 | [slice](/src/cmd/slice.rs#L2)<br>📇 | Slice rows from any part of a CSV. When an index is present, this only has to parse the rows in the slice (instead of all rows leading up to the start of the slice).  |
 | <a name="snappy_deeplink"></a>[snappy](/src/cmd/snappy.rs#L2)<br>🚀🌐 | Does streaming compression/decompression of the input using Google's [Snappy](https://github.com/google/snappy/blob/main/docs/README.md) framing format ([more info](#snappy-compressiondecompression)). |

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -146,6 +146,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut flag_rowi: u64 = 1;
     let mut match_ctr: u64 = 0;
     let mut row_ctr: u64 = 0;
+    let mut m;
 
     #[allow(unused_assignments)]
     let mut matched_rows = String::with_capacity(20); // to save on allocs
@@ -155,7 +156,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         if show_progress {
             progress.inc(1);
         }
-        let mut m = sel.select(&record).any(|f| pattern.is_match(f));
+        m = sel.select(&record).any(|f| pattern.is_match(f));
         if args.flag_invert_match {
             m = !m;
         }

--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -24,6 +24,8 @@ selected using regular expressions.
   Select columns using a regex using '/<regex>/':
   $ qsv select /^a/
   $ qsv select '/^.*\d.*$/'
+  # remove SSN, account_no and password columns
+  $ qsv select '!/SSN|account_no|password/'
 
   Re-order and duplicate columns arbitrarily:
   $ qsv select 3-1,Header3-Header1,Header1,Foo[2],Header1

--- a/tests/test_select.rs
+++ b/tests/test_select.rs
@@ -161,6 +161,15 @@ select_test!(
     ["h1", "h2", "h1"],
     ["a", "b", "e"]
 );
+
+select_test!(
+    select_not_regex,
+    "!/h1|h2/",
+    "3,4",
+    ["h[]3", "h4"],
+    ["c", "d"]
+);
+
 select_test!(
     select_regex_digit,
     r#"/h\d/"#,


### PR DESCRIPTION
to reduce allocs in hot loops and squeeze more performance