### PR TITLE
`sort`: add --faster option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,6 +3670,7 @@ dependencies = [
  "dynfmt",
  "eudex",
  "ext-sort",
+ "fastrand",
  "file-format",
  "filetime",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ eudex = { version = "0.1", optional = true }
 ext-sort = { version = "0.1", features = [
     "memory-limit",
 ], default-features = false }
+fastrand = "2"
 flate2 = { version = "1", optional = true }
 file-format = { version = "0.18", features = ["reader"] }
 filetime = "0.2"


### PR DESCRIPTION
- which uses a faster, non-allocating (in-place) unstable parallel sort for the default, --numeric and --reverse sorts
- for --random sorts, this triggers using the fastrand crate with its Wyrand based cipher that is much faster than the standard random number generator's ChaCha algorithm