### PR TITLE
`stats`: use fast-float to convert string to float

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,6 +3670,7 @@ dependencies = [
  "dynfmt",
  "eudex",
  "ext-sort",
+ "fast-float",
  "fastrand",
  "file-format",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ eudex = { version = "0.1", optional = true }
 ext-sort = { version = "0.1", features = [
     "memory-limit",
 ], default-features = false }
+fast-float = "0.2"
 fastrand = "2"
 flate2 = { version = "1", optional = true }
 file-format = { version = "0.18", features = ["reader"] }


### PR DESCRIPTION
which is markedly faster than Rust core's string to float conversion, even if the fast-float algorithm was adapted in core.

see https://github.com/aldanor/fast-float-rust#benchmarks,
https://github.com/pola-rs/polars/pull/7492 and
https://arxiv.org/abs/2101.11408