### PR TITLE
notebook/count: fix Google Colab link

### DIFF
--- a/contrib/notebooks/intro-to-count.ipynb
+++ b/contrib/notebooks/intro-to-count.ipynb
@@ -6,7 +6,7 @@
         "id": "YjOR1n15wn1K"
       },
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/jqnatividad/qsv/blob/master/notebooks/intro-to-count.ipynb\">\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/jqnatividad/qsv/blob/master/contrib/notebooks/intro-to-count.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/>\n",
         "</a>\n",
         "<a target=\"_blank\" href=\"https://nbviewer.org/github/jqnatividad/qsv/blob/master/contrib/notebooks/intro-to-count.ipynb\">\n",


### PR DESCRIPTION
Fixes the link to open the `contrib/notebooks/intro-to-count.ipynb` notebook.

Broken link: https://colab.research.google.com/github/jqnatividad/qsv/blob/master/notebooks/intro-to-count.ipynb
Working link: https://colab.research.google.com/github/jqnatividad/qsv/blob/master/contrib/notebooks/intro-to-count.ipynb