### PR TITLE
`excel`: return  workbook subformat in metadata mode; log.info! headers; wordsmith comments

### DIFF
--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -13,7 +13,7 @@ Excel options:
                                Negative indices start from the end (-1 = last sheet). 
                                If the sheet cannot be found, qsv will read the first sheet.
                                [default: 0]
-    --metadata <c|j|J>         Outputs workbook metadata in CSV or JSON format: 
+    --metadata <c|j|J>         Outputs workbook metadata in CSV or JSON format:
                                  index, sheet_name, headers, num_columns, num_rows, safe_headers,
                                  safe_headers_count, unsafe_headers, unsafe_headers_count and
                                  duplicate_headers_count.
@@ -27,8 +27,8 @@ Excel options:
                                
                                In JSON(j) mode, the output is minified JSON.
                                In Pretty JSON(J) mode, the output is pretty-printed JSON.
-                               For both JSON modes, the filename and spreadsheet format are
-                               also included.
+                               For both JSON modes, the filename, the full file path, the workbook format
+                               and the number of sheets are also included.
                                
                                All other Excel options are ignored.
                                [default: none]
@@ -233,7 +233,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let mut excelmetadata_struct = MetadataStruct {
             filename,
             canonical_filename,
-            format,
+            format: if ods_flag {
+                "ODS".to_string()
+            } else {
+                format!("Excel: {format}")
+            },
             num_sheets,
             sheet: vec![],
         };

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -454,13 +454,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let (row_count, col_count) = range.get_size();
 
     if row_count > 0 {
-        // there are row to export
+        // there are rows to export
         let mut rows_iter = range.rows();
 
-        // use with_capacity to minimize reallocations
+        // amortize allocations
         let mut record = csv::StringRecord::with_capacity(500, col_count);
         let mut trimmed_record = csv::StringRecord::with_capacity(500, col_count);
-
         let mut col_name: String;
 
         // get the first row as header
@@ -495,10 +494,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     trimmed_record.push_field(field);
                 }
             });
-            wtr.write_record(&trimmed_record)?;
-        } else {
-            wtr.write_record(&record)?;
+            record.clone_from(&trimmed_record);
         }
+        info!("header: {record:?}");
+        wtr.write_record(&record)?;
 
         // process the rest of the rows
         // first, amortize allocs by declaring mutable vars we'll use

--- a/tests/test_excel.rs
+++ b/tests/test_excel.rs
@@ -528,7 +528,7 @@ fn excel_metadata_pretty_json() {
     cmd.arg("--metadata").arg("J").arg(xls_file);
 
     let got: String = wrk.stdout(&mut cmd);
-    let expected: &str = r#""format": "xls",
+    let expected: &str = r#""format": "Excel: xls",
   "num_sheets": 8,
   "sheet": [
     {
@@ -677,6 +677,85 @@ fn excel_metadata_pretty_json() {
       "safe_headers": [
         "Last sheet col1",
         "Last-2"
+      ],
+      "safe_headers_count": 2,
+      "unsafe_headers": [],
+      "unsafe_headers_count": 0,
+      "duplicate_headers_count": 0
+    }
+  ]
+}"#;
+    assert!(got.ends_with(expected));
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn ods_metadata() {
+    let wrk = Workdir::new("ods_metadata");
+
+    let xls_file = wrk.load_test_file("excel-ods.ods");
+
+    let mut cmd = wrk.command("excel");
+    cmd.arg("--metadata").arg("c").arg(xls_file);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec![
+            "index",
+            "sheet_name",
+            "headers",
+            "num_columns",
+            "num_rows",
+            "safe_headers",
+            "safe_headers_count",
+            "unsafe_headers",
+            "unsafe_headers_count",
+            "duplicate_headers_count"
+        ],
+        svec![
+            "0",
+            "Sheet1",
+            "[\"URL\", \"City\"]",
+            "2",
+            "4",
+            "[\"URL\", \"City\"]",
+            "2",
+            "[]",
+            "0",
+            "0"
+        ],
+    ];
+
+    assert_eq!(got, expected);
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn ods_metadata_pretty_json() {
+    let wrk = Workdir::new("ods_metadata_pretty_json");
+
+    let xls_file = wrk.load_test_file("excel-ods.ods");
+
+    let mut cmd = wrk.command("excel");
+    cmd.arg("--metadata").arg("J").arg(xls_file);
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected: &str = r#"excel-ods.ods",
+  "format": "ODS",
+  "num_sheets": 1,
+  "sheet": [
+    {
+      "index": 0,
+      "name": "Sheet1",
+      "headers": [
+        "URL",
+        "City"
+      ],
+      "num_columns": 2,
+      "num_rows": 4,
+      "safe_headers": [
+        "URL",
+        "City"
       ],
       "safe_headers_count": 2,
       "unsafe_headers": [],


### PR DESCRIPTION
also added tests for ODS metadata