### PR TITLE
`flatten`: refactor for performance

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -519,6 +519,7 @@ pub fn mem_file_check(
 }
 
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
+#[inline]
 pub fn condense(val: Cow<[u8]>, n: Option<usize>) -> Cow<[u8]> {
     match n {
         None => val,


### PR DESCRIPTION
- amortize allocations
- precompute flags and separators before loop
- use read_byte_record() instead of byte_records() to use amortized record var
- inline condense() helper fn