### PR TITLE
notebooks: fix qsv colab quickstart link

### DIFF
--- a/contrib/notebooks/qsv-colab-quickstart.ipynb
+++ b/contrib/notebooks/qsv-colab-quickstart.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# qsv Quickstart on Google Colab\n",
         "\n",
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/jqnatividad/qsv/blob/master/notebooks/qsv-colab-quickstart.ipynb\">\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/jqnatividad/qsv/blob/master/contrib/notebooks/qsv-colab-quickstart.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/>\n",
         "</a>"
       ]
@@ -21,7 +21,7 @@
       "source": [
         "Get up and running with using [qsv](https://github.com/jqnatividad/qsv) on [Google Colab](https://colab.google)!\n",
         "\n",
-        "Simply [open this notebook in Google Colab](https://colab.research.google.com/github/jqnatividad/qsv/blob/master/notebooks/qsv-colab-quickstart.ipynb), sign in to your Google account, and **follow Parts 1 & 2 below**."
+        "Simply [open this notebook in Google Colab](https://colab.research.google.com/github/jqnatividad/qsv/blob/master/contrib/notebooks/qsv-colab-quickstart.ipynb), sign in to your Google account, and **follow Parts 1 & 2 below**."
       ]
     },
     {


### PR DESCRIPTION
Fixes Open in Colab link. Links to https://colab.research.google.com/github/jqnatividad/qsv/blob/master/contrib/notebooks/qsv-colab-quickstart.ipynb now.