### PR TITLE
`validate`: improved utf8 error mesages

### DIFF
--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -275,30 +275,29 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             validation_error.to_string()
                         };
                         return fail_encoding_clierror!("{json_error}");
-                    } else {
-                        // it's not a UTF-8 error, so we report generic validation error
-                        let validation_error = json!({
-                            "errors": [{
-                                "title" : "Validation error",
-                                "detail" : format!("{e}"),
-                                "meta": {
-                                    "last_valid_record": format!("{record_idx}"),
-                                }
-                            }]
-                        });
-
-                        let json_error = if args.flag_pretty_json {
-                            serde_json::to_string_pretty(&validation_error).unwrap()
-                        } else {
-                            validation_error.to_string()
-                        };
-
-                        return fail!(json_error);
                     }
+                    // it's not a UTF-8 error, so we report generic validation error
+                    let validation_error = json!({
+                        "errors": [{
+                            "title" : "Validation error",
+                            "detail" : format!("{e}"),
+                            "meta": {
+                                "last_valid_record": format!("{record_idx}"),
+                            }
+                        }]
+                    });
+
+                    let json_error = if args.flag_pretty_json {
+                        serde_json::to_string_pretty(&validation_error).unwrap()
+                    } else {
+                        validation_error.to_string()
+                    };
+
+                    return fail!(json_error);
                 }
 
-                // we're not returning a JSON error, so we can use the more human-friendly
-                // error message
+                // we're not returning a JSON error, so we can use
+                // a user-friendly error message with suggestions
                 match e.kind() {
                     csv::ErrorKind::UnequalLengths {
                         expected_len: _,


### PR DESCRIPTION
- add header utf8-error specific error messages in RFC-4180 Validation Mode
- add utf8-error specific error messages in JSON Schema Validation Mode
- add more proactive guidance to error messages to transcode to utf8 when not returning error messages in JSON format
- also removed thousands crate and replaced with indicatif::HumanCount 
- expanded implementation comments