### PR TITLE
`geocode`: major improvements using geosuggest upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,8 +1948,7 @@ dependencies = [
 [[package]]
 name = "geosuggest-core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d339ac9809b2cdb8abdb87df2971877c4eb48deaec9d1ee9e30d2721d72ce43"
+source = "git+https://github.com/estin/geosuggest?rev=5c6b08b#5c6b08bbc9211972b489d5cfa13ce13cde42cb43"
 dependencies = [
  "bincode",
  "csv",
@@ -1959,22 +1958,18 @@ dependencies = [
  "serde",
  "serde_json",
  "strsim",
- "tracing",
 ]
 
 [[package]]
 name = "geosuggest-utils"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3609965d29046d62fc2ed4589df7b5f3da1142073eb49d14cdd518572674637"
+source = "git+https://github.com/estin/geosuggest?rev=5c6b08b#5c6b08bbc9211972b489d5cfa13ce13cde42cb43"
 dependencies = [
  "anyhow",
  "futures",
  "geosuggest-core",
  "reqwest",
  "tokio",
- "tracing",
- "tracing-subscriber",
  "zip",
 ]
 
@@ -2814,15 +2809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,16 +3060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,12 +3240,6 @@ checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -4285,17 +4255,8 @@ checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.7",
+ "regex-automata",
  "regex-syntax 0.7.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -4495,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.10"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -4786,15 +4747,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -5211,16 +5163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5416,19 +5358,7 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
 ]
 
 [[package]]
@@ -5438,36 +5368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -5626,12 +5526,6 @@ dependencies = [
  "regex",
  "unicase",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,8 @@ futures = "0.3"
 futures-util = "0.3"
 geosuggest-core = { version = "0.3", optional = true }
 geosuggest-utils = { version = "0.3", optional = true }
+# geosuggest-core = { path = "../geosuggest/geosuggest-core", optional = true}
+# geosuggest-utils = { path = "../geosuggest/geosuggest-utils", optional = true}
 governor = { version = "0.6", optional = true }
 grex = { version = "1.4", default-features = false }
 gzp = { version = "0.11", default-features = false, features = [
@@ -220,6 +222,10 @@ postgres = "0.19"
 quickcheck = { version = "1", default-features = false }
 rusqlite = { version = "0.29", features = ["bundled"] }
 serial_test = { version = "2.0", features = ["file_locks"] }
+
+[patch.crates-io]
+geosuggest-core  = { git = "https://github.com/estin/geosuggest", rev = "5c6b08b" }
+geosuggest-utils = { git = "https://github.com/estin/geosuggest", rev = "5c6b08b" }
 
 [features]
 default = ["mimalloc"]

--- a/tests/test_geocode.rs
+++ b/tests/test_geocode.rs
@@ -214,32 +214,38 @@ fn geocode_suggest_fmt_cityrecord() {
             "CitiesRecord { id: 5116495, name: \"Elmhurst\", latitude: 40.73649, longitude: \
              -73.87791, country: Some(Country { id: 6252001, code: \"US\", name: \"United \
              States\" }), admin_division: Some(AdminDivision { id: 5128638, code: \"US.NY\", \
-             name: \"New York\" }), timezone: \"America/New_York\", names: Some({\"en\": \
-             \"Elmhurst\"}), country_names: Some({\"en\": \"United States\"}), admin1_names: \
-             Some({\"en\": \"New York\"}), population: 113364 }"
+             name: \"New York\" }), admin2_division: Some(AdminDivision { id: 5133268, code: \
+             \"US.NY.081\", name: \"Queens County\" }), timezone: \"America/New_York\", names: \
+             Some({\"en\": \"Elmhurst\"}), country_names: Some({\"en\": \"United States\"}), \
+             admin1_names: Some({\"en\": \"New York\"}), admin2_names: Some({\"en\": \"Queens \
+             County\"}), population: 113364 }"
         ],
         svec![
             "CitiesRecord { id: 5115843, name: \"East Flatbush\", latitude: 40.65371, longitude: \
              -73.93042, country: Some(Country { id: 6252001, code: \"US\", name: \"United \
              States\" }), admin_division: Some(AdminDivision { id: 5128638, code: \"US.NY\", \
-             name: \"New York\" }), timezone: \"America/New_York\", names: Some({\"en\": \"East \
-             Flatbush\"}), country_names: Some({\"en\": \"United States\"}), admin1_names: \
-             Some({\"en\": \"New York\"}), population: 178464 }"
+             name: \"New York\" }), admin2_division: Some(AdminDivision { id: 6941775, code: \
+             \"US.NY.047\", name: \"Kings County\" }), timezone: \"America/New_York\", names: \
+             Some({\"en\": \"East Flatbush\"}), country_names: Some({\"en\": \"United States\"}), \
+             admin1_names: Some({\"en\": \"New York\"}), admin2_names: Some({\"en\": \"Kings\"}), \
+             population: 178464 }"
         ],
         svec![
             "CitiesRecord { id: 5128581, name: \"New York City\", latitude: 40.71427, longitude: \
              -74.00597, country: Some(Country { id: 6252001, code: \"US\", name: \"United \
              States\" }), admin_division: Some(AdminDivision { id: 5128638, code: \"US.NY\", \
-             name: \"New York\" }), timezone: \"America/New_York\", names: Some({\"en\": \"New \
-             York\"}), country_names: Some({\"en\": \"United States\"}), admin1_names: \
-             Some({\"en\": \"New York\"}), population: 8804190 }"
+             name: \"New York\" }), admin2_division: None, timezone: \"America/New_York\", names: \
+             Some({\"en\": \"New York\"}), country_names: Some({\"en\": \"United States\"}), \
+             admin1_names: Some({\"en\": \"New York\"}), admin2_names: None, population: 8804190 }"
         ],
         svec![
             "CitiesRecord { id: 6332428, name: \"East Harlem\", latitude: 40.79472, longitude: \
              -73.9425, country: Some(Country { id: 6252001, code: \"US\", name: \"United States\" \
              }), admin_division: Some(AdminDivision { id: 5128638, code: \"US.NY\", name: \"New \
-             York\" }), timezone: \"America/New_York\", names: None, country_names: Some({\"en\": \
-             \"United States\"}), admin1_names: Some({\"en\": \"New York\"}), population: 115921 }"
+             York\" }), admin2_division: Some(AdminDivision { id: 5128594, code: \"US.NY.061\", \
+             name: \"New York County\" }), timezone: \"America/New_York\", names: None, \
+             country_names: Some({\"en\": \"United States\"}), admin1_names: Some({\"en\": \"New \
+             York\"}), admin2_names: Some({\"en\": \"New York County\"}), population: 115921 }"
         ],
         svec!["This is not a Location and it will not be geocoded"],
         svec!["40.71427, -74.00597"],
@@ -247,9 +253,11 @@ fn geocode_suggest_fmt_cityrecord() {
             "CitiesRecord { id: 1703417, name: \"Makati City\", latitude: 14.55027, longitude: \
              121.03269, country: Some(Country { id: 1694008, code: \"PH\", name: \"Philippines\" \
              }), admin_division: Some(AdminDivision { id: 7521311, code: \"PH.NCR\", name: \
-             \"Metro Manila\" }), timezone: \"Asia/Manila\", names: Some({\"en\": \"Makati \
-             City\"}), country_names: Some({\"en\": \"Philippines\"}), admin1_names: \
-             Some({\"en\": \"National Capital Region\"}), population: 510383 }"
+             \"Metro Manila\" }), admin2_division: Some(AdminDivision { id: 11395838, code: \
+             \"PH.NCR.137600000\", name: \"Southern Manila District\" }), timezone: \
+             \"Asia/Manila\", names: Some({\"en\": \"Makati City\"}), country_names: \
+             Some({\"en\": \"Philippines\"}), admin1_names: Some({\"en\": \"National Capital \
+             Region\"}), admin2_names: None, population: 510383 }"
         ],
     ];
     assert_eq!(got, expected);


### PR DESCRIPTION
- add `--force` option to `index-update` subcommand
- improved usage text
- refactored result formatting
- added admin2
- geocoding lookup cache is now an LRU cache with a maximum of 2M entries. Previously it was an unbounded cache