### PR TITLE
`geocode`: add  suggest `--country` filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,8 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "geosuggest-core"
-version = "0.3.0"
-source = "git+https://github.com/estin/geosuggest?rev=5c6b08b#5c6b08bbc9211972b489d5cfa13ce13cde42cb43"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349233f6bc33e706e9b450ff58bc42f571e2d1e97dffcad24d2d96a3573d9f9c"
 dependencies = [
  "bincode",
  "csv",
@@ -1961,8 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "geosuggest-utils"
-version = "0.3.0"
-source = "git+https://github.com/estin/geosuggest?rev=5c6b08b#5c6b08bbc9211972b489d5cfa13ce13cde42cb43"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b534065956ab2e4eff18dc6402b8b68db6c136a9815d1de7aeac2387b7c0662"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,10 +101,8 @@ flexi_logger = { version = "0.26", features = [
 ], default-features = false }
 futures = "0.3"
 futures-util = "0.3"
-geosuggest-core = { version = "0.3", optional = true }
-geosuggest-utils = { version = "0.3", optional = true }
-# geosuggest-core = { path = "../geosuggest/geosuggest-core", optional = true}
-# geosuggest-utils = { path = "../geosuggest/geosuggest-utils", optional = true}
+geosuggest-core = { version = "0.4", optional = true }
+geosuggest-utils = { version = "0.4", optional = true }
 governor = { version = "0.6", optional = true }
 grex = { version = "1.4", default-features = false }
 gzp = { version = "0.11", default-features = false, features = [
@@ -224,8 +222,6 @@ rusqlite = { version = "0.29", features = ["bundled"] }
 serial_test = { version = "2.0", features = ["file_locks"] }
 
 [patch.crates-io]
-geosuggest-core  = { git = "https://github.com/estin/geosuggest", rev = "5c6b08b" }
-geosuggest-utils = { git = "https://github.com/estin/geosuggest", rev = "5c6b08b" }
 calamine = { git = "https://github.com/jqnatividad/calamine", branch = "formula_empty_string_value" }
 
 [features]


### PR DESCRIPTION
limit suggestions to a comma-delimited list of countries using ISO 3166-2 country codes.

e.g. limit suggestions to US, Canada and Mexico
```bash
$ qsv geocode suggest city --country us,ca,mx file.csv
```