### PR TITLE
`geocode`: automatic --country inferencing from --admin1 code

### DIFF
--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -403,6 +403,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let debuglog_flag = log::log_enabled!(log::Level::Debug);
     if debuglog_flag {
         log::debug!("Optimization state: {optimization_state:?}");
+        log::debug!(
+            "Delimiter: {delim} Infer_schema_len: {num_rows:?} try_parse_dates: {parse_dates} \
+             ignore_errors: {ignore_errors}, low_memory: {low_memory}",
+            parse_dates = args.flag_try_parsedates,
+            ignore_errors = args.flag_ignore_errors,
+            low_memory = args.flag_low_memory
+        );
     }
 
     let mut ctx = SQLContext::new();
@@ -424,13 +431,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         if debuglog_flag {
             log::debug!(
-                "Registering table: {table_name} as {alias} -  Delimiter: {delim} \
-                 Infer_schema_len: {num_rows:?} try_parse_dates: {parse_dates} ignore_errors: \
-                 {ignore_errors}, low_memory: {low_memory}",
+                "Registering table: {table_name} as {alias}",
                 alias = table_aliases.get(table_name).unwrap(),
-                parse_dates = args.flag_try_parsedates,
-                ignore_errors = args.flag_ignore_errors,
-                low_memory = args.flag_low_memory
             );
         }
         let lf = LazyCsvReader::new(table)
@@ -468,7 +470,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         vec![args.arg_sql.clone()]
     };
 
-    log::debug!("Executing query/ies: {queries:?}");
+    if debuglog_flag {
+        log::debug!("SQL query/ies: {queries:?}");
+    }
 
     let num_queries = queries.len();
     let last_query: usize = num_queries.saturating_sub(1);

--- a/tests/test_geocode.rs
+++ b/tests/test_geocode.rs
@@ -142,6 +142,32 @@ fn geocode_suggest_intl_admin1_filter_error() {
 }
 
 #[test]
+fn geocode_suggest_intl_admin1_filter_country_inferencing() {
+    let wrk = Workdir::new("geocode_suggest_intl_admin1_filter_country_inferencing");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["Location"],
+            svec!["Paris"],
+            svec!["Manila"],
+            svec!["London"],
+        ],
+    );
+    let mut cmd = wrk.command("geocode");
+    cmd.arg("suggest")
+        .arg("Location")
+        .args(["--admin1", "US.NJ,US.TX,US.NY"])
+        .args(["-f", "%city-admin1-country"])
+        .arg("data.csv");
+
+    // admin1 requires a country filter
+    // however, since all the admin1 filters are in the US
+    // or more specifically, the admin1 filters have a prefix of "US."
+    // the country filter is inferred to be "US"
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
 fn geocode_suggest_intl_multi_country_filter() {
     let wrk = Workdir::new("geocode_suggest_intl_multi_country_filter");
     wrk.create(


### PR DESCRIPTION
normally, --country is required if setting --admin1.

However, if using admin1 codes, and all the specified admin1 codes have the same country prefix, the country is automatically inferred and need not be set explicitly.

Also improved usage text by indenting examples, and expanding --admin1 option