### PR TITLE
Replace `QSV_AUTOINDEX` env var with `QSV_AUTOINDEX_SIZE`

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -6,7 +6,7 @@
 | `QSV_SNIFF_DELIMITER` | if set, the delimiter is automatically detected. Overrides `QSV_DEFAULT_DELIMITER` & `--delimiter` option. Note that this does not work with stdin. |
 | `QSV_NO_HEADERS` | if set, the first row will **NOT** be interpreted as headers. Supersedes `QSV_TOGGLE_HEADERS`. |
 | `QSV_TOGGLE_HEADERS` | if set to `1`, toggles header setting - i.e. inverts qsv header behavior, with no headers being the default, & setting `--no-headers` will actually mean headers will not be ignored. |
-| `QSV_AUTOINDEX_SIZE` | if set, specifies the minimum file size of a CSV file before an index is automatically created. Note that stale indices are automatically updated regardless of this setting. |
+| `QSV_AUTOINDEX_SIZE` | if set, specifies the minimum file size (in bytes) of a CSV file before an index is automatically created. Note that stale indices are automatically updated regardless of this setting. |
 | `QSV_CACHE_DIR` | The directory to use for caching downloaded lookup_table resources using the `luau` qsv_register_lookup() helper function. |
 | `QSV_CKAN_API` | The CKAN Action API endpoint to use with the `luau` qsv_register_lookup() helper function when using the "ckan://" scheme. |
 | `QSV_CKAN_TOKEN`| The CKAN token to use with the `luau` qsv_register_lookup() helper function when using the "ckan://" scheme. Only required to access private resources. |

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -6,7 +6,7 @@
 | `QSV_SNIFF_DELIMITER` | if set, the delimiter is automatically detected. Overrides `QSV_DEFAULT_DELIMITER` & `--delimiter` option. Note that this does not work with stdin. |
 | `QSV_NO_HEADERS` | if set, the first row will **NOT** be interpreted as headers. Supersedes `QSV_TOGGLE_HEADERS`. |
 | `QSV_TOGGLE_HEADERS` | if set to `1`, toggles header setting - i.e. inverts qsv header behavior, with no headers being the default, & setting `--no-headers` will actually mean headers will not be ignored. |
-| `QSV_AUTOINDEX` | if set, automatically create an index when none is detected. Also automatically updates stale indices. |
+| `QSV_AUTOINDEX_SIZE` | if set, specifies the minimum file size of a CSV file before an index is automatically created. Note that stale indices are automatically updated regardless of this setting. |
 | `QSV_CACHE_DIR` | The directory to use for caching downloaded lookup_table resources using the `luau` qsv_register_lookup() helper function. |
 | `QSV_CKAN_API` | The CKAN Action API endpoint to use with the `luau` qsv_register_lookup() helper function when using the "ckan://" scheme. |
 | `QSV_CKAN_TOKEN`| The CKAN token to use with the `luau` qsv_register_lookup() helper function when using the "ckan://" scheme. Only required to access private resources. |

--- a/dotenv.template.yaml
+++ b/dotenv.template.yaml
@@ -40,9 +40,11 @@ QSV_NO_HEADERS = False
 # mean headers will not be ignored.
 # QSV_TOGGLE_HEADERS = 1
 
-# if true, automatically create an index when none is detected.
-# Also automatically updates stale indices.
-QSV_AUTOINDEX = False
+# if set, specifies the minimum filesize (in bytes) at which qsv will automatically
+# create an index file for the input file. If not set, qsv will NOT automatically
+# create indices. Note that stale indices are automatically updated regardless of
+# this setting.
+# QSV_AUTOINDEX_SIZE = 1000000
 
 # The directory to use for caching various qsv files.
 # Used by the `geocode` command for downloaded geocoding resources.

--- a/dotenv.template.yaml
+++ b/dotenv.template.yaml
@@ -40,10 +40,9 @@ QSV_NO_HEADERS = False
 # mean headers will not be ignored.
 # QSV_TOGGLE_HEADERS = 1
 
-# if set, specifies the minimum filesize (in bytes) at which qsv will automatically
-# create an index file for the input file. If not set, qsv will NOT automatically
-# create indices. Note that stale indices are automatically updated regardless of
-# this setting.
+# if set, specifies the minimum file size (in bytes) of a CSV file before an 
+# index is automatically created. Note that stale indices are automatically 
+# updated regardless of this setting.
 # QSV_AUTOINDEX_SIZE = 1000000
 
 # The directory to use for caching various qsv files.

--- a/src/config.rs
+++ b/src/config.rs
@@ -391,7 +391,7 @@ impl Config {
                         if self.snappy {
                             // cannot index snappy compressed files
                             return Ok(None);
-                        } else if data_fsize >= self.autoindex_size {
+                        } else if self.autoindex_size > 0 && data_fsize >= self.autoindex_size {
                             // if CSV file size >= QSV_AUTOINDEX_SIZE, and
                             // its not a snappy file, create an index automatically
                             self.autoindex_file();

--- a/src/config.rs
+++ b/src/config.rs
@@ -365,7 +365,7 @@ impl Config {
     pub fn index_files(&self) -> io::Result<Option<(csv::Reader<fs::File>, fs::File)>> {
         let mut data_modified = 0_u64;
         let data_fsize;
-        let (csv_file, idx_file) = match (&self.path, &self.idx_path) {
+        let (csv_file, mut idx_file) = match (&self.path, &self.idx_path) {
             (&None, &None) => return Ok(None),
             (&None, &Some(_)) => {
                 return Err(io::Error::new(
@@ -415,7 +415,9 @@ impl Config {
         if data_modified > idx_modified {
             info!("index stale... autoindexing...");
             self.autoindex_file();
+            idx_file = fs::File::open(util::idx_path(self.path.as_ref().unwrap()))?;
         }
+
         let csv_rdr = self.from_reader(csv_file);
         Ok(Some((csv_rdr, idx_file)))
     }

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, io::Write};
 
 use filetime::{set_file_times, FileTime};
 
@@ -36,6 +36,11 @@ fn index_outdated_count() {
 #[test]
 fn index_outdated_stats() {
     let wrk = Workdir::new("index_outdated_stats");
+
+    // this test is flaky on Linux/Windows as stderr sometimes
+    // has some leftover data from the previous tests
+    // so we flush it to make sure it's empty
+    std::io::stderr().flush().unwrap();
 
     wrk.create_indexed(
         "in.csv",

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -55,11 +55,12 @@ fn index_outdated_stats() {
     )
     .unwrap();
 
-    // stats should fail if the index is stale
+    // even if the index is stale, stats should succeed
+    // as the index is automatically updated
     let mut cmd = wrk.command("stats");
     cmd.env_clear().arg("in.csv");
 
-    wrk.assert_err(&mut cmd);
+    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -86,13 +86,13 @@ fn index_outdated_index_autoindex() {
 
     // slice should NOT fail if the index is stale and
     // QSV_AUTOINDEX is set
-    std::env::set_var("QSV_AUTOINDEX", "1");
+    std::env::set_var("QSV_AUTOINDEX_SIZE", "1");
     let mut cmd = wrk.command("slice");
-    cmd.env("QSV_AUTOINDEX", "1")
+    cmd.env("QSV_AUTOINDEX_SIZE", "1")
         .arg("-i")
         .arg("2")
         .arg("in.csv");
-    std::env::remove_var("QSV_AUTOINDEX");
+    std::env::remove_var("QSV_AUTOINDEX_SIZE");
 
     wrk.assert_success(&mut cmd);
 }


### PR DESCRIPTION
resolves #1300 

If `QSV_AUTOINDEX_SIZE` is set, it specifies the minimum filesize (in bytes) after which qsv will automatically
create an index file. If not set, qsv will NOT automatically create indices (default).

Also, note that stale indices are now automatically updated regardless of this setting.