### PR TITLE
add `to_parquet` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,8 +915,7 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 [[package]]
 name = "calamine"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2f67a25b1a04dfc4caf081d98bc758489a6e9b637cf566c3bc96b3cfe07aef"
+source = "git+https://github.com/tafia/calamine?rev=60a5614#60a5614aa339694b27fa97c7091e6289f2b18786"
 dependencies = [
  "byteorder",
  "chrono",
@@ -1120,6 +1119,16 @@ dependencies = [
  "serde_json",
  "time",
  "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4161,9 +4170,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "78fdbab6a7e1d7b13cc8ff10197f47986b41c639300cc3c8158cac7847c9bbef"
 dependencies = [
  "async-compression",
  "base64",
@@ -4190,6 +4199,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -4920,6 +4930,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ strip         = true
 
 [profile.release-samply]
 inherits = "release"
-debug         = true
-strip         = false
+debug    = true
+strip    = false
 
 [profile.release-nightly]
 inherits = "release"
@@ -85,7 +85,9 @@ crossbeam-channel = "0.5"
 csv = "1.2"
 csv-diff = "0.1.0-beta.4"
 csv-index = "0.1"
-csvs_convert = { version = "0.8", optional = true }
+csvs_convert = { version = "0.8", default-features = false, features = [
+    "converters",
+], optional = true }
 data-encoding = { version = "2.4", optional = true }
 dotenvy = "0.15"
 dynfmt = { version = "0.1", default-features = false, features = [
@@ -227,7 +229,8 @@ rusqlite = { version = "0.29", features = ["bundled"] }
 serial_test = { version = "2.0", features = ["file_locks"] }
 
 [patch.crates-io]
-actix-governor = { git = "https://github.com/AaronErhardt/actix-governor", rev = "a49b9be"}
+actix-governor = { git = "https://github.com/AaronErhardt/actix-governor", rev = "a49b9be" }
+calamine       = { git = "https://github.com/tafia/calamine", rev = "60a5614" }
 
 [features]
 default = ["mimalloc"]
@@ -243,6 +246,7 @@ all_features = [
     "python",
     "self_update",
     "to",
+    "to_parquet",
 ]
 apply = [
     "censor",
@@ -283,6 +287,7 @@ geocode = [
 luau = ["mlua", "sanitise-file-name", "simple-home-dir"]
 python = ["pyo3"]
 to = ["csvs_convert"]
+to_parquet = ["csvs_convert/parquet"]
 lite = []
 datapusher_plus = ["dynfmt", "self_update"]
 polars = ["dep:polars", "smartstring"]

--- a/README.md
+++ b/README.md
@@ -343,7 +343,9 @@ For details, see [Environment Variables](docs/ENVIRONMENT_VARIABLES.md) and the 
 * `luau` - enable `luau` command. Embeds a [Luau](https://luau-lang.org) interpreter into qsv. [Luau has type-checking, sandboxing, additional language operators, increased performance & other improvements](https://luau-lang.org/2022/11/04/luau-origins-and-evolution.html) over Lua.
 * `polars` - enables all [Polars](https://pola.rs)-powered commands (currently, `joinp` and `sqlp`). Note that Polars is a very powerful library, but it has a lot of dependencies that drastically increases both compile time and binary size.
 * `python` - enable `py` command. Note that qsv will look for the shared library for the Python version (Python 3.7 & above supported) it was compiled against & will abort on startup if the library is not found, even if you're NOT using the `py` command. Check [Python](#python) section for more info.
-* `to` - enables the `to` command. Note that enabling this feature will also noticeably increase both compile time and binary size.
+* `to` - enables the `to` command except the parquet option.
+* `to_parquet` - enables the `parquet` option of the `to` command. This is a separate feature as it brings in the `duckdb` dependency, which markedly increases binary size and compile time.
+Use the `sqlp` command with the `--format parquet` option instead if you don't need the `to` command's other options and you don't need to convert to parquet a directory of CSVs.
 * `self_update` - enable self-update engine, checking GitHub for the latest release. Note that if you manually built qsv, `self-update` will only check for new releases.
 It will NOT offer the choice to update itself to the prebuilt binaries published on GitHub. You need not worry that your manually built qsv will be overwritten by a self-update.
 
@@ -387,8 +389,8 @@ cargo t stats -F all_features
 # here we test only luau comand with the luau feature
 cargo t luau -F feature_capable,luau
 
-# to test a specific command with multiple features
-cargo t -F feature_capable,luau,polars
+# to test the count command with multiple features
+cargo t count -F feature_capable,luau,polars
 
 # to test using an alternate allocator
 # other than the default mimalloc allocator

--- a/tests/test_to.rs
+++ b/tests/test_to.rs
@@ -402,6 +402,7 @@ state       string      string"#
     );
 }
 
+#[cfg(all(feature = "to_parquet", feature = "feature_capable"))]
 #[test]
 fn to_parquet_dir() {
     let wrk = Workdir::new("to_parquet_dir");


### PR DESCRIPTION
`to parquet` brings in the `duckdb` dependency which markedly increases binary size and compile time.  This allows users to build qsv without the `to parquet` option if they don't need it and `sqlp`'s `--format parquet` option is enough.

Note that `to parquet` can handle a directory of CSVs in one go, unlike `sqlp` with the `--format` option, which only outputs to parquet format the query result of a SQL query.