### PR TITLE
`geocode`: when producing JSON output with the now subcommands, use c…

### DIFF
--- a/tests/test_geocode.rs
+++ b/tests/test_geocode.rs
@@ -1564,9 +1564,8 @@ fn geocode_countryinfonow_formatstr_pretty_json() {
         .arg("mx")
         .args(["--formatstr", "%pretty-json"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    let expected = vec![svec![
-        r######"{
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r######"{
   "info": {
     "iso": "MX",
     "iso3": "MEX",
@@ -1594,7 +1593,6 @@ fn geocode_countryinfonow_formatstr_pretty_json() {
   "capital_names": {
     "en": "Mexico City"
   }
-}"######
-    ]];
+}"######;
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
…sv::QuoteStyle::Never so we produce valid JSON output