### PR TITLE
`apply` & `applydp`: use perfect hash functions for operations lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,16 +2240,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -3260,11 +3260,55 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4872,6 +4916,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
+ "phf 0.10.1",
  "strum_macros 0.25.3",
 ]
 
@@ -5181,7 +5226,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.11.2",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
@@ -5625,10 +5670,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ simple-home-dir = { version = "0.2", features = [
 smartstring = { version = "1", optional = true }
 snap = "1"
 strsim = { version = "0.10", optional = true }
-strum = "0.25"
+strum = { version = "0.25", features = ["phf"] }
 strum_macros = "0.25"
 sysinfo = "0.29"
 tabwriter = "1.3"

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -377,7 +377,8 @@ use crate::{
     util, CliResult,
 };
 
-#[derive(EnumString)]
+#[derive(Clone, EnumString)]
+#[strum(use_phf)]
 #[strum(ascii_case_insensitive)]
 #[allow(non_camel_case_types)]
 enum Operations {

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -253,7 +253,8 @@ use crate::{
     util, CliResult,
 };
 
-#[derive(EnumString)]
+#[derive(Clone, EnumString)]
+#[strum(use_phf)]
 #[strum(ascii_case_insensitive)]
 #[allow(non_camel_case_types)]
 enum Operations {


### PR DESCRIPTION
use static compile time perfect hash functions for operations lookup instead of run-time match string lookups