### PR TITLE
`stats`, `schema` and `tojsonl`:  stats cache bincode refactor

### DIFF
--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -2,12 +2,16 @@
 static USAGE: &str = r#"
 Smartly converts CSV to a newline-delimited JSON (JSONL/NDJSON).
 
-By scanning the CSV first, it "smartly" infers the appropriate JSON data type
+By computing stats on the CSV first, it "smartly" infers the appropriate JSON data type
 for each column (string, number, boolean, null).
 
-It will infer a column as boolean if it only has a domain of two values,
-and the first character of the values are one of the following case-insensitive
-combinations: t/f; t/null; 1/0; 1/null; y/n & y/null are treated as true/false.
+It will infer a column as boolean if its cardinality is 2, and the first character of
+the values are one of the following case-insensitive combinations:
+  t/f; t/null; 1/0; 1/null; y/n & y/null are treated as true/false.
+
+The `tojsonl` command will reuse a `stats.csv.bin.sz` file if it exists and is current
+(i.e. stats generated with --cardinality and --infer-dates options) and will skip
+recomputing stats.
 
 For examples, see https://github.com/jqnatividad/qsv/blob/master/tests/test_tojsonl.rs.
 


### PR DESCRIPTION
`stats` automatically caches stats and serializes it into a bincode file.

This is done so other qsv commands (currently, only `schema` and `tojsonl`) can deserialize the precomputed stats and skip recomputing stats if they are still valid.

As `schema` and `tojsonl` are not as often used, we should only generate the bincode file when requested.

Other changes:
- bincode file is now snappy compressed
- changed stats-binout to a bool flag from an Option<String> parm. We always write stats bincode cache to <FILESTEM>.stats.csv.bin.sz
- removed unneeded bufwriter as snappy encoding has built-in buffering
- expanded cache section in usage text
- `schema` and `tojsonl` commands adjusted accordingly, and their usage texts explicitly mentions the cache, so users can elect to pregenerate it when they need it, instead of `stats` generating it all the time.