### PR TITLE
`diff`: add option/flag for headers in output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "csv-diff"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995ff146e82a65fb2c98855cc498a6b6081ca15cbbf5fa81e68ca9f14ec25ee8"
+checksum = "cf378965e48a7d858973826f7e7ef4a09c38543d0c074195f126023e30572fb5"
 dependencies = [
  "ahash 0.8.3",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ console = { version = "0.15", optional = true }
 cpc = { version = "1.9", optional = true }
 crossbeam-channel = "0.5"
 csv = "1.3"
-csv-diff = "0.1.0-beta.4"
+csv-diff = "0.1.0"
 csv-index = "0.1"
 csvs_convert = { version = "0.8", default-features = false, features = [
     "converters",

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -66,13 +66,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let headers = rdr.byte_headers()?;
 
     if args.arg_headers.to_lowercase() == "_all_generic" {
-        let mut generic_headers = String::new();
-        for (i, _) in headers.iter().enumerate() {
-            generic_headers.push_str(&format!("_col_{},", i + 1));
-        }
-        // remove the trailing comma
-        generic_headers.pop();
-        args.arg_headers = generic_headers;
+        args.arg_headers = rename_headers_all_generic(headers.len());
     }
 
     let mut new_rdr = csv::Reader::from_reader(args.arg_headers.as_bytes());
@@ -94,4 +88,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
     wtr.flush()?;
     Ok(())
+}
+
+pub(crate) fn rename_headers_all_generic(num_of_cols: usize) -> String {
+    let mut generic_headers = String::new();
+    for i in 1..=num_of_cols {
+        generic_headers.push_str(&format!("_col_{},", i));
+    }
+    // remove the trailing comma
+    generic_headers.pop();
+    generic_headers
 }

--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -216,6 +216,215 @@ diffresult,case_enquiry_id,open_dt,target_dt,closed_dt,ontime,case_status,closur
     }
 }
 
+#[test]
+fn diff_with_no_headers_in_result() {
+    let wrk = Workdir::new("diff_no_headers_in_result");
+
+    let left = vec![svec!["h1", "h2", "h3"], svec!["1", "foo", "bar"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["h1", "h2", "h3"], svec!["1", "foo_changed", "bar"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv", "--no-headers-result"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["-", "1", "foo", "bar",],
+        svec!["+", "1", "foo_changed", "bar",],
+    ];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_no_diff_with_no_headers_in_result() {
+    let wrk = Workdir::new("diff_no_diff_with_no_headers_in_result");
+
+    let left = vec![svec!["h1", "h2", "h3"], svec!["1", "foo", "bar"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["h1", "h2", "h3"], svec!["1", "foo", "bar"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv", "--no-headers-result"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected: Vec<Vec<String>> = vec![];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_only_left_has_headers_headers_in_result() {
+    let wrk = Workdir::new("diff_only_left_has_headers_headers_in_result");
+
+    let left = vec![svec!["h1", "h2", "h3"], svec!["1", "foo", "bar"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["1", "foo_changed", "bar"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv", "--no-headers-right"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["diffresult", "h1", "h2", "h3"],
+        svec!["-", "1", "foo", "bar",],
+        svec!["+", "1", "foo_changed", "bar",],
+    ];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_only_right_has_headers_headers_in_result() {
+    let wrk = Workdir::new("diff_only_left_has_headers_headers_in_result");
+
+    let left = vec![svec!["1", "foo", "bar"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["h1", "h2", "h3"], svec!["1", "foo_changed", "bar"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv", "--no-headers-left"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["diffresult", "h1", "h2", "h3"],
+        svec!["-", "1", "foo", "bar",],
+        svec!["+", "1", "foo_changed", "bar",],
+    ];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_with_generic_headers_in_result() {
+    let wrk = Workdir::new("diff_with_generic_headers_in_result");
+
+    let left = vec![svec!["1", "foo", "bar"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["1", "foo_changed", "bar"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args([
+        "left.csv",
+        "right.csv",
+        "--no-headers-left",
+        "--no-headers-right",
+    ]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["diffresult", "_col_1", "_col_2", "_col_3",],
+        svec!["-", "1", "foo", "bar",],
+        svec!["+", "1", "foo_changed", "bar",],
+    ];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_with_no_left_no_right_and_no_headers_in_result() {
+    let wrk = Workdir::new("diff_with_no_left_no_right_and_no_headers_in_result");
+
+    let left = vec![svec!["1", "foo", "bar"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["1", "foo_changed", "bar"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args([
+        "left.csv",
+        "right.csv",
+        "--no-headers-left",
+        "--no-headers-right",
+        "--no-headers-result",
+    ]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["-", "1", "foo", "bar",],
+        svec!["+", "1", "foo_changed", "bar",],
+    ];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_no_diff_with_generic_headers_in_result() {
+    let wrk = Workdir::new("diff_no_diff_with_generic_headers_in_result");
+
+    let left = vec![svec!["1", "foo", "bar"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["1", "foo", "bar"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args([
+        "left.csv",
+        "right.csv",
+        "--no-headers-left",
+        "--no-headers-right",
+    ]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["diffresult", "_col_1", "_col_2", "_col_3",]];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_no_diff_and_zero_columns_flag_true_for_headers_in_result_but_none_are_in_result() {
+    let wrk = Workdir::new(
+        "diff_no_diff_and_zero_columns_flag_true_for_headers_in_result_but_none_are_in_result",
+    );
+
+    let left: Vec<Vec<String>> = vec![];
+    wrk.create("left.csv", left);
+
+    let right: Vec<Vec<String>> = vec![];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected: Vec<Vec<String>> = vec![];
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn diff_left_has_one_column_right_has_none_headers_in_result() {
+    let wrk = Workdir::new(
+        "diff_no_diff_and_zero_columns_flag_true_for_headers_in_result_but_none_are_in_result",
+    );
+
+    let left = vec![svec!["h1"]];
+    wrk.create("left.csv", left);
+
+    let right: Vec<Vec<String>> = vec![];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv", "--no-headers-right"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["diffresult", "h1"]];
+
+    assert_eq!(got, expected);
+}
+
 fn create_file_with_delim(wrk: &Workdir, file_path_new: &str, file_path: &str, delimiter: u8) {
     let mut select_cmd = wrk.command("select");
     select_cmd.args(["1-", file_path]);


### PR DESCRIPTION
This implements a new option for `diff`: It is now possible to decide, whether the CSV headers in the compared CSVs should be in the diff output. If neither CSVs have headers and this option is _not_ active (which means the output _should_ have headers), the `all_generic` strategy from `rename` is used (`_col_1`, `_col_2`, etc.).

Closes #1326 

### Example 1 (no diff, no headers in result):
csv_left.csv
```
col1,col2,col3
1,foo,bar
```
csv_right.csv
```
1,foo,bar
```

```
qsv diff --no-headers-result --no-headers-right csv_left.csv csv_right.csv
```

Output (_nothing will be printed here, because there are no differences and we don't want to print headers in the result_):
```

```

------------------------------------------------------------------------

### Example 2 (has diff, no headers in result):
csv_left.csv
```
col1,col2,col3
1,foo,bar
```

csv_right.csv
```
1,foo,baz
```

```
qsv diff --no-headers-result --no-headers-right csv_left.csv csv_right.csv
```

Output:
```
-,1,foo,bar
+,1,foo,baz
```

------------------------------------------------------------------------

### Example 3 (has diff, add generic headers):
csv_left.csv
```
1,foo,bar
```

csv_right.csv
```
1,foo,baz
```

```
qsv diff --no-headers-left --no-headers-right csv_left.csv csv_right.csv
```

Output:
```
diffresult,_col_1,_col_2,_col_3
-,1,foo,bar
+,1,foo,baz
```