### PR TITLE
`cat`: faster `cat rows`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,8 @@ use crate::{
 
 // rdr default is 8k in csv crate, we're making it 128k
 pub const DEFAULT_RDR_BUFFER_CAPACITY: usize = 128 * (1 << 10);
-// previous wtr default in xsv is 32k, we're making it 256k
-pub const DEFAULT_WTR_BUFFER_CAPACITY: usize = 256 * (1 << 10);
+// previous wtr default in xsv is 32k, we're making it 512k
+pub const DEFAULT_WTR_BUFFER_CAPACITY: usize = 512 * (1 << 10);
 
 // number of rows for qsv_sniffer to sample
 const DEFAULT_SNIFFER_SAMPLE: usize = 100;

--- a/src/util.rs
+++ b/src/util.rs
@@ -405,6 +405,7 @@ where
         .map_err(From::from)
 }
 
+#[inline]
 pub fn many_configs(
     inps: &[String],
     delim: Option<Delimiter>,


### PR DESCRIPTION
Refactored `cat rows` for more performance:
- only check for headers in first file, not repeatedly in hot loop
- amortize rdr allocation
- inline configs helper fn which call many_configs in utils to minimize passing vec of configs by value
- inline many_configs
- increase default csv write buffer from 256k to 512k to reduce expensive os write calls

Should noticeably improve `cat rows` performance in @derekmahar's benchmarks in #1293 