### PR TITLE
use `ato_simd` for fast &[u8] to int conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e73784f0357111c71a6f0f765ec91a5f1487bc5cdd9d41e54f81fd53e06e73"
+checksum = "bd5581898a3cc5d0930f40f76034a4cf9e18dc4d38e13ef769fb6f427cf63215"
 dependencies = [
  "arrow-format",
  "regex",
@@ -3717,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3075dda9bfecbdcd3d721c6ed4f15f00edf58acba3d5e7711e6f1a9cedf46444"
+checksum = "c18e77b1bddfe72ff522bfedf5b1bf1e9d9651b1e6a22f86c50022d1aab2b651"
 dependencies = [
  "ahash 0.8.6",
  "bytemuck",
@@ -3967,7 +3967,7 @@ dependencies = [
  "ahash 0.8.6",
  "anyhow",
  "assert-json-diff",
- "atoi",
+ "atoi_simd",
  "bincode",
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ panic    = "abort"
 [dependencies]
 ahash = "0.8"
 anyhow = { version = "1.0", optional = true }
-atoi = "2"
+atoi_simd = "0.15"
 bincode = "1.3"
 byteorder = "1.5"
 bytes = "1"
@@ -150,7 +150,6 @@ polars = { version = "0.35", features = [
     "ipc",
     "performant",
     "cse",
-    "dtype-categorical"
 ], optional = true }
 pyo3 = { version = "0.20", features = ["auto-initialize"], optional = true }
 qsv-dateparser = "0.10"

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -332,19 +332,19 @@ pub fn infer_schema_from_stats(args: &Args, input_filename: &str) -> CliResult<M
                 type_list.push(Value::String("integer".to_string()));
 
                 if let Some(min_str) = stats_record.get(stats_col_index_map["min"]) {
-                    let min = min_str.parse::<i64>().unwrap();
+                    let min = atoi_simd::parse::<i64>(min_str.as_bytes()).unwrap();
                     field_map.insert("minimum".to_string(), Value::Number(Number::from(min)));
                 };
 
                 if let Some(max_str) = stats_record.get(stats_col_index_map["max"]) {
-                    let max = max_str.parse::<i64>().unwrap();
+                    let max = atoi_simd::parse::<i64>(max_str.as_bytes()).unwrap();
                     field_map.insert("maximum".to_string(), Value::Number(Number::from(max)));
                 };
 
                 // enum constraint
                 if let Some(values) = unique_values_map.get(&header_string) {
                     for value in values {
-                        let int_value = value.parse::<i64>().unwrap();
+                        let int_value = atoi_simd::parse::<i64>(value.as_bytes()).unwrap();
                         enum_list.push(Value::Number(Number::from(int_value)));
                     }
                 }

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -308,15 +308,19 @@ fn next_num<'a, X>(xs: &mut X) -> Option<Number>
 where
     X: Iterator<Item = &'a [u8]>,
 {
-    xs.next()
-        .map(|bytes| from_utf8(bytes).unwrap())
-        .and_then(|s| {
-            if let Ok(i) = s.parse::<i64>() {
+    match xs.next() {
+        Some(bytes) => {
+            if let Ok(i) = atoi_simd::parse::<i64>(bytes) {
                 Some(Number::Int(i))
-            } else if let Ok(f) = s.parse::<f64>() {
-                Some(Number::Float(f))
             } else {
-                None
+                // If parsing as i64 failed, try parsing as f64
+                if let Ok(f) = from_utf8(bytes).unwrap().parse::<f64>() {
+                    Some(Number::Float(f))
+                } else {
+                    None
+                }
             }
-        })
+        }
+        None => None,
+    }
 }

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -320,7 +320,7 @@ where
                     None
                 }
             }
-        }
+        },
         None => None,
     }
 }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1494,7 +1494,7 @@ impl FieldType {
             || current_type == FieldType::TInteger
             || current_type == FieldType::TNull
         {
-            if let Ok(int_val) = string.parse::<i64>() {
+            if let Ok(int_val) = atoi_simd::parse::<i64>(sample) {
                 // leading zero, its a string (e.g. zip codes)
                 if string.as_bytes()[0] == b'0' && int_val != 0 {
                     return (TString, None);
@@ -1612,7 +1612,7 @@ impl TypedSum {
                     // so we don't panic on overflow/underflow, use saturating_add
                     self.integer = self
                         .integer
-                        .saturating_add(atoi::atoi::<i64>(sample).unwrap());
+                        .saturating_add(atoi_simd::parse::<i64>(sample).unwrap());
                 }
             },
             _ => {},
@@ -1685,13 +1685,13 @@ impl TypedMinMax {
                 self.integers.add(n as i64);
             },
             TInteger => {
-                let n = atoi::atoi::<i64>(sample).unwrap();
+                let n = atoi_simd::parse::<i64>(sample).unwrap();
                 self.integers.add(n);
                 #[allow(clippy::cast_precision_loss)]
                 self.floats.add(n as f64);
             },
             TDate | TDateTime => {
-                let n = atoi::atoi::<i64>(sample).unwrap();
+                let n = atoi_simd::parse::<i64>(sample).unwrap();
                 self.dates.add(n);
             },
         }

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -794,7 +794,7 @@ fn to_json_instance(
             },
             b'i' => {
                 // integer
-                if let Ok(int) = value_string.parse::<i64>() {
+                if let Ok(int) = atoi_simd::parse::<i64>(value_string.as_bytes()) {
                     json_object_map.insert(key_string, Value::Number(Number::from(int)));
                 } else {
                     return fail_clierror!(


### PR DESCRIPTION
- faster than std::parse - SIMD accelerated and skips utf8 validation