### PR TITLE
dotenv (.env) tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ It also has Out-of-Memory prevention, with two modes - NORMAL (default) & CONSER
 
 qsv supports an extensive list of environment variables and supports `.env` files to set them.
 
-For details, see [Environment Variables](docs/ENVIRONMENT_VARIABLES.md) and the [`dotenv.template.yaml`](dotenv.template.yaml) file.
+For details, see [Environment Variables](docs/ENVIRONMENT_VARIABLES.md) and the [`dotenv.template.yaml`](dotenv.template) file.
 ## Feature Flags
 
 qsv has several [feature flags](https://doc.rust-lang.org/cargo/reference/features.html) that can be used to enable/disable optional features.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -63,4 +63,4 @@ When processing `.env` files, qsv will:
 * where multiple declarations of the same variable exist, the last one will be used
 * ignore any lines that start with `#` (comments)
 
-To facilitate the use of `.env` files, a [`dotenv.template.yaml`](../dotenv.template.yaml) file is included in the qsv distribution. This file contains all the environment variables that qsv recognizes, along with their default values. Copy the template to a file named '.env' and modify it to suit your needs.
+To facilitate the use of `.env` files, a [`dotenv.template`](../dotenv.template) file is included in the qsv distribution. This file contains all the environment variables that qsv recognizes, along with their default values. Copy the template to a file named '.env' and modify it to suit your needs.

--- a/dotenv.template
+++ b/dotenv.template
@@ -38,7 +38,7 @@ QSV_NO_HEADERS = False
 # if set to `1`, toggles header setting - i.e. inverts qsv header behavior,
 # with no headers being the default, & setting `--no-headers` will actually
 # mean headers will not be ignored.
-# QSV_TOGGLE_HEADERS = 1
+# QSV_TOGGLE_HEADERS = False
 
 # if set, specifies the minimum file size (in bytes) of a CSV file before an 
 # index is automatically created. Note that stale indices are automatically 
@@ -48,7 +48,7 @@ QSV_NO_HEADERS = False
 # if set, add a BOM (Byte Order Mark) to the beginning of the output.
 # Note that this will also set the BOM for qsv's output to stdout.
 # This is useful when generating CSV files for Excel on Windows.
-# QSV_OUTPUT_BOM = 1
+# QSV_OUTPUT_BOM = False
 
 # The directory to use for caching various qsv files.
 # Used by the `geocode` command for downloaded geocoding resources.
@@ -72,7 +72,7 @@ QSV_NO_HEADERS = False
 # with this character are ignored. Note that when you want to use the pound sign
 # as a comment char, you need to enclose it in single quotes as its a reserved
 # character for dotenv files, e.g.
-QSV_COMMENT_CHAR = '#'
+QSV_COMMENT_CHAR: '#'
 
 # Otherwise, you can just use the character without enclosing it in single quotes
 # QSV_COMMENT_CHAR = !
@@ -100,11 +100,11 @@ QSV_PREFER_DMY = False
 # operation is always unicode-aware.
 QSV_REGEX_UNICODE = False
 
-# reader buffer size (default (bytes): 16384)
-QSV_RDR_BUFFER_CAPACITY = 16384
+# reader buffer size (default (bytes): 131,072 - 128k)
+QSV_RDR_BUFFER_CAPACITY = 131072
 
-# writer buffer size (default (bytes): 65536)
-QSV_WTR_BUFFER_CAPACITY = 65536
+# writer buffer size (default (bytes): 524,288 - 512k)
+QSV_WTR_BUFFER_CAPACITY = 524288
 
 # the percentage of free available memory required when running qsv in
 # "non-streaming" mode (i.e. the entire file needs to be loaded into memory).


### PR DESCRIPTION
remove yaml file extension as it was triggering false positive yaml lints
- also set i/o buffer settings to be consistent with the higher defaults (128k and 512k respectively)
- set QSV_NO_HEADERS and QSV_TOGGLE_HEADERS commented examples to False