### PR TITLE
make thousands crate optional with apply feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ sysinfo = "0.29"
 tabwriter = "1.3"
 tempfile = "3"
 test-data-generation = { version = "0.3", optional = true }
-thousands = "0.2"
+thousands = { version = "0.2", optional = true }
 threadpool = "1.8"
 titlecase = { version = "2", optional = true }
 tokio = "1"
@@ -255,6 +255,7 @@ apply = [
     "hashbrown",
     "qsv_currency",
     "strsim",
+    "thousands",
     "titlecase",
     "vader_sentiment",
     "whatlang",

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -70,16 +70,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
 
     if args.flag_human_readable {
-        use thousands::Separable;
+        use indicatif::HumanCount;
 
         if args.flag_width {
-            woutinfo!(
-                "{};{}",
-                count.separate_with_commas(),
-                width.separate_with_commas()
-            );
+            woutinfo!("{};{}", HumanCount(count as u64), HumanCount(width as u64));
         } else {
-            woutinfo!("{}", count.separate_with_commas());
+            woutinfo!("{}", HumanCount(count as u64));
         }
     } else if args.flag_width {
         woutinfo!("{count};{width}");

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -201,9 +201,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     if args.flag_human_readable {
-        use thousands::Separable;
+        use indicatif::HumanCount;
 
-        eprintln!("{}", dupe_count.separate_with_commas());
+        eprintln!("{}", HumanCount(dupe_count as u64));
     } else {
         eprintln!("{dupe_count}");
     }

--- a/src/cmd/extdedup.rs
+++ b/src/cmd/extdedup.rs
@@ -37,9 +37,9 @@ use std::{
     io::{self, stdin, stdout, BufRead, Write},
 };
 
+use indicatif::HumanCount;
 use serde::Deserialize;
 use sysinfo::{System, SystemExt};
-use thousands::Separable;
 
 use crate::{config, odhtcache, util, CliResult};
 
@@ -159,7 +159,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     eprintln!(
         "{}",
         if args.flag_human_readable {
-            dupes_count.separate_with_commas()
+            HumanCount(dupes_count).to_string()
         } else {
             dupes_count.to_string()
         }

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -112,15 +112,15 @@ use bytes::Bytes;
 use file_format::FileFormat;
 use futures::executor::block_on;
 use futures_util::StreamExt;
+use indicatif::HumanCount;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
-use indicatif::{HumanBytes, HumanCount, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use indicatif::{HumanBytes, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use qsv_sniffer::{DatePreference, SampleSize, Sniffer};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tabwriter::TabWriter;
 use tempfile::NamedTempFile;
-use thousands::Separable;
 use url::Url;
 
 use crate::{
@@ -207,7 +207,7 @@ impl fmt::Display for SniffStruct {
         writeln!(
             f,
             "Preamble Rows: {}",
-            self.preamble_rows.separate_with_commas()
+            HumanCount(self.preamble_rows as u64)
         )?;
         writeln!(f, "Quote Char: {}", self.quote_char)?;
         writeln!(f, "Flexible: {}", self.flexible)?;
@@ -217,30 +217,26 @@ impl fmt::Display for SniffStruct {
         writeln!(
             f,
             "Retrieved Size (bytes): {}",
-            self.retrieved_size.separate_with_commas()
+            HumanCount(self.retrieved_size as u64)
         )?;
         writeln!(
             f,
             "File Size (bytes): {}",
-            self.file_size.separate_with_commas()
+            HumanCount(self.file_size as u64)
         )?;
         writeln!(
             f,
             "Sampled Records: {}",
-            self.sampled_records.separate_with_commas()
+            HumanCount(self.sampled_records as u64)
         )?;
         writeln!(f, "Estimated: {}", self.estimated)?;
-        writeln!(
-            f,
-            "Num Records: {}",
-            self.num_records.separate_with_commas()
-        )?;
+        writeln!(f, "Num Records: {}", HumanCount(self.num_records as u64))?;
         writeln!(
             f,
             "Avg Record Len (bytes): {}",
-            self.avg_record_len.separate_with_commas()
+            HumanCount(self.avg_record_len as u64)
         )?;
-        writeln!(f, "Num Fields: {}", self.num_fields.separate_with_commas())?;
+        writeln!(f, "Num Fields: {}", HumanCount(self.num_fields as u64))?;
         writeln!(f, "Stats Types: {}", self.stats_types)?;
         writeln!(f, "Fields:")?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -416,14 +416,14 @@ impl Config {
                                 fs::File::open(&idx_path_work)?
                             } else if data_fsize >= NO_INDEX_WARNING_FILESIZE {
                                 // warn user that the CSV file is large and not indexed
-                                use thousands::Separable;
+                                use indicatif::HumanCount;
 
                                 warn!(
                                     "The {} MB CSV file is larger than the {} MB \
                                      NO_INDEX_WARNING_FILESIZE threshold. Consider creating an \
                                      index file as it will make qsv commands much faster.",
-                                    (data_fsize * 100).separate_with_commas(),
-                                    (NO_INDEX_WARNING_FILESIZE * 100).separate_with_commas()
+                                    HumanCount(data_fsize * 100),
+                                    HumanCount(NO_INDEX_WARNING_FILESIZE * 100)
                                 );
                                 return Ok(None);
                             } else {

--- a/tests/test_count.rs
+++ b/tests/test_count.rs
@@ -121,10 +121,10 @@ fn prop_count_len(
     cmd.arg("in.csv");
 
     if human_readable {
-        use thousands::Separable;
+        use indicatif::HumanCount;
 
         let got_count: String = wrk.stdout(&mut cmd);
-        let expected_count_commas = expected_count.separate_with_commas();
+        let expected_count_commas = HumanCount(expected_count as u64).to_string();
 
         rassert_eq!(got_count, expected_count_commas)
     } else {


### PR DESCRIPTION
and use indicative::HumanCount instead.

Only use with `apply` as the thousands crate enable different thousands separation policies