### PR TITLE
align `apply`/`applydp` with `replace` to use <NULL> case-insensitive…

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -50,7 +50,7 @@ It has 36 supported operations:
   * replace: Replace all matches of a pattern (using --comparand)
       with a string (using --replacement) (Rust replace)
   * regex_replace: Replace all regex matches in --comparand w/ --replacement.
-      Specify <EMPTY> as --replacement to remove matches.
+      Specify <NULL> as --replacement to remove matches.
   * titlecase - capitalizes English text using Daring Fireball titlecase style
       https://daringfireball.net/2008/05/title_case
   * censor: profanity filter. Add additional comma-delimited profanities with --comparand.
@@ -470,6 +470,8 @@ const DEFAULT_THRESHOLD: f64 = 0.9;
 // default number of decimal places to round to
 const DEFAULT_ROUND_PLACES: u32 = 3;
 
+const NULL_VALUE: &str = "<null>";
+
 // for thousands operator
 static INDIANCOMMA_POLICY: SeparatorPolicy = SeparatorPolicy {
     separator: ",",
@@ -584,11 +586,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         wtr.write_record(&headers)?;
     }
 
-    // if there is a regex_replace operation and replacement is <empty> case-insensitive,
+    // if there is a regex_replace operation and replacement is <NULL> case-insensitive,
     // we set it to empty string
     let flag_replacement = if apply_cmd == ApplySubCmd::Operations
         && ops_vec.contains(&Operations::Regex_Replace)
-        && args.flag_replacement.to_lowercase() == "<empty>"
+        && args.flag_replacement.to_lowercase() == NULL_VALUE
     {
         String::new()
     } else {

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -43,7 +43,7 @@ It has 18 supported operations:
   * replace: Replace all matches of a pattern (using --comparand)
       with a string (using --replacement) (Rust replace)
   * regex_replace: Replace all regex matches in --comparand w/ --replacement.
-      Specify <EMPTY> as --replacement to remove matches.
+      Specify <NULL> as --replacement to remove matches.
   * round: Round numeric values to the specified number of decimal places using
       Midpoint Nearest Even Rounding Strategy AKA "Bankers Rounding."
       Specify the number of decimal places with --formatstr (default: 3).
@@ -319,6 +319,8 @@ static ROUND_PLACES: OnceLock<u32> = OnceLock::new();
 // default number of decimal places to round to
 const DEFAULT_ROUND_PLACES: u32 = 3;
 
+const NULL_VALUE: &str = "<null>";
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let rconfig = Config::new(&args.arg_input)
@@ -422,11 +424,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         wtr.write_record(&headers)?;
     }
 
-    // if there is a regex_replace operation and replacement is <empty> case-insensitive,
+    // if there is a regex_replace operation and replacement is <NULL> case-insensitive,
     // we set it to empty string
     let flag_replacement = if applydp_cmd == ApplydpSubCmd::Operations
         && ops_vec.contains(&Operations::Regex_Replace)
-        && args.flag_replacement.to_lowercase() == "<empty>"
+        && args.flag_replacement.to_lowercase() == NULL_VALUE
     {
         String::new()
     } else {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -81,7 +81,7 @@ struct Args {
     flag_quiet:          bool,
 }
 
-const NULL_VALUE: &str = "<NULL>";
+const NULL_VALUE: &str = "<null>";
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
@@ -95,7 +95,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .size_limit(args.flag_size_limit * (1 << 20))
         .dfa_size_limit(args.flag_dfa_size_limit * (1 << 20))
         .build()?;
-    let replacement = if args.arg_replacement == NULL_VALUE {
+    let replacement = if args.arg_replacement.to_lowercase() == NULL_VALUE {
         b""
     } else {
         args.arg_replacement.as_bytes()

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -458,7 +458,7 @@ fn apply_regex_replace_issue1469() {
         .arg("regex_replace")
         .arg("col1,col2,col3")
         .args(["--comparand", r"\([^)]+\)"])
-        .args(["--replacement", "<EmpTY>"])
+        .args(["--replacement", "<Null>"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);

--- a/tests/test_applydp.rs
+++ b/tests/test_applydp.rs
@@ -384,7 +384,7 @@ fn applydp_regex_replace_issue1469() {
         .arg("regex_replace")
         .arg("col1,col2,col3")
         .args(["--comparand", r"\([^)]+\)"])
-        .args(["--replacement", "<EMPTY>"])
+        .args(["--replacement", "<NULL>"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);


### PR DESCRIPTION
… instead of <EMPTY>

for consistency