### PR TITLE
refactor commands that accept multiple input files to use improved process_input helper

### DIFF
--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -572,7 +572,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             args.arg_input.clone().unwrap_or_else(|| "-".to_string()),
         )],
         &tmpdir,
-        "No data on stdin. Please provide at least one input file or pipe data to stdin.",
+        "",
     )?;
     // safety: we just checked that there is at least one input file
     let input_path = work_input[0]

--- a/src/cmd/headers.rs
+++ b/src/cmd/headers.rs
@@ -13,6 +13,15 @@ Usage:
     qsv headers [options] [<input>...]
     qsv headers --help
 
+headers arguments:
+    <input>...             The CSV file(s) to read. Use '-' for standard input.
+                           If input is a directory, all files in the directory will
+                           be read as input.
+                           If the input is a file with a '.infile-list' extension,
+                           the file will be read as a list of input files.
+                           If the input are snappy-compressed files(s), it will be
+                           decompressed automatically.
+
 headers options:
     -j, --just-names       Only show the header names (hide column index).
                            This is automatically enabled if more than one
@@ -27,7 +36,7 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
-use std::io;
+use std::{io, path::PathBuf};
 
 use serde::Deserialize;
 use tabwriter::TabWriter;
@@ -36,7 +45,7 @@ use crate::{config::Delimiter, util, CliResult};
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input:       Vec<String>,
+    arg_input:       Vec<PathBuf>,
     flag_just_names: bool,
     flag_intersect:  bool,
     flag_trim:       bool,
@@ -44,7 +53,9 @@ struct Args {
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
-    let args: Args = util::get_args(USAGE, argv)?;
+    let mut args: Args = util::get_args(USAGE, argv)?;
+    let tmpdir = tempfile::tempdir()?;
+    args.arg_input = util::process_input(args.arg_input, &tmpdir, "")?;
     let configs = util::many_configs(&args.arg_input, args.flag_delimiter, true, false)?;
 
     let num_inputs = configs.len();

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -376,11 +376,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: Args = util::get_args(USAGE, argv)?;
 
     let tmpdir = tempfile::tempdir()?;
-    args.arg_input = process_input(
-        args.arg_input,
-        &tmpdir,
-        "No data on stdin. Please provide at least one input file or pipe data to stdin.",
-    )?;
+    args.arg_input = process_input(args.arg_input, &tmpdir, "")?;
 
     let rnull_values = if args.flag_rnull_values == "<empty string>" {
         vec![String::new()]

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -100,8 +100,9 @@ Usage:
 
 sqlp arguments:
     input                  The CSV file/s to query. Use '-' for standard input.
-                           If input is a directory, all CSV files in the directory will
-                           be used.
+                           If input is a directory, all files in the directory will be read as input.
+                           If the input is a file with a '.infile-list' extension, the
+                           file will be read as a list of files to use as input.
                            If the input are snappy compressed file(s), it will be
                            decompressed automatically.
                            Column headers are required. Use 'qsv rename _all_generic --no-headers'

--- a/src/cmd/to.rs
+++ b/src/cmd/to.rs
@@ -26,7 +26,11 @@ Load same files into a new/existing postgres database whose connection string is
 
 Load files inside a directory to a local database 'test' with user `testuser`, password `pass`.
 
-  $ qsv to postgres 'postgres://testuser:pass@localhost/test' dir1 
+  $ qsv to postgres 'postgres://testuser:pass@localhost/test' dir1
+
+Load files listed in the 'input.infile-list' to a local database 'test' with user `testuser`, password `pass`.
+
+  $ qsv to postgres 'postgres://testuser:pass@localhost/test' input.infile-list
 
 Drop tables if they exist before loading.
 
@@ -61,6 +65,10 @@ Load all files in dir1 to sqlite database `test.db`
 
   $ qsv to sqlite test.db dir
 
+Load files listed in the 'mydata.infile-list' to sqlite database `test.db`
+
+    $ qsv to sqlite test.db mydata.infile-list
+
 Drop tables if they exist before loading.
 
   $ qsv to sqlite test.db --drop file1.csv file2.csv
@@ -90,6 +98,14 @@ filename without the extension. Note the `output.xlsx` will be overwritten if it
 
   $ qsv to xlsx output.xlsx file1.csv file2.csv
 
+Load all files in dir1 into xlsx file.
+
+    $ qsv to xlsx output.xlsx dir1
+
+Load files listed in the 'ourdata.infile-list' into xlsx file.
+
+    $ qsv to xlsx output.xlsx ourdata.infile-list
+
 PARQUET (only available if compiled with `to_parquet` feature)
 Convert to directory of parquet files.  Need to select a directory, it will be created if it does not exists.
 If the `to_parquet` feature is not enabled, a simpler parquet conversion is available using the `sqlp`
@@ -108,6 +124,14 @@ Convert from stdin.
 
   $ qsv to parquet --pipe mydir -
 
+Convert all files in dir1 into parquet files in myparquetdir.
+
+    $ qsv to parquet myparquetdir dir1
+
+Convert files listed in the 'data.infile-list' into parquet files in myparquetdir.
+    
+        $ qsv to parquet myparquetdir data.infile-list
+
 DATAPACKAGE
 Generate a datapackage, which contains stats and information about what is in the CSV files.
 
@@ -124,6 +148,10 @@ Add more stats to datapackage.
 Generate a `datapackage.json` file from all the files in dir1
 
   $ qsv to datapackage datapackage.json dir1
+
+Generate a `datapackage.json` file from all the files listed in the 'data.infile-list'
+
+    $ qsv to datapackage datapackage.json data.infile-list
 
 For all other conversions you can output the datapackage created by specifying `--print-package`.
 

--- a/src/cmd/to.rs
+++ b/src/cmd/to.rs
@@ -246,6 +246,9 @@ impl From<csvs_convert::DescribeError> for CliError {
     }
 }
 
+static EMPTY_STDIN_ERRMSG: &str =
+    "No data on stdin. Need to add connection string as first argument then the input CSVs";
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     debug!("'to' command running");
@@ -267,11 +270,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     if args.cmd_postgres {
         debug!("converting to postgres");
-        arg_input = process_input(
-            arg_input,
-            &tmpdir,
-            "No data on stdin. Need to add connection string as first argument then the input CSVs",
-        )?;
+        arg_input = process_input(arg_input, &tmpdir, EMPTY_STDIN_ERRMSG)?;
         if args.flag_dump {
             options.dump_file = args.arg_postgres.expect("checked above");
             output = csvs_to_postgres_with_options(String::new(), arg_input, options)?;
@@ -285,12 +284,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         debug!("conversion to postgres complete");
     } else if args.cmd_sqlite {
         debug!("converting to sqlite");
-        arg_input = process_input(
-            arg_input,
-            &tmpdir,
-            "No data on stdin. Need to add the name of a sqlite db as first argument then the \
-             input CSVs",
-        )?;
+        arg_input = process_input(arg_input, &tmpdir, EMPTY_STDIN_ERRMSG)?;
         if args.flag_dump {
             options.dump_file = args.arg_sqlite.expect("checked above");
             output = csvs_to_sqlite_with_options(String::new(), arg_input, options)?;
@@ -306,12 +300,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         #[cfg(all(feature = "to_parquet", feature = "feature_capable"))]
         {
             debug!("converting to parquet");
-            arg_input = process_input(
-                arg_input,
-                &tmpdir,
-                "No data on stdin. Need to add the name of a parquet directory as first argument \
-                 then the input CSVs",
-            )?;
+            arg_input = process_input(arg_input, &tmpdir, EMPTY_STDIN_ERRMSG)?;
             output = csvs_to_parquet_with_options(
                 args.arg_parquet.expect("checked above"),
                 arg_input,
@@ -327,24 +316,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
     } else if args.cmd_xlsx {
         debug!("converting to xlsx");
-        arg_input = process_input(
-            arg_input,
-            &tmpdir,
-            "No data on stdin. Need to add the name of an xlsx file as first argument then the \
-             input CSVs",
-        )?;
+        arg_input = process_input(arg_input, &tmpdir, EMPTY_STDIN_ERRMSG)?;
 
         output =
             csvs_to_xlsx_with_options(args.arg_xlsx.expect("checked above"), arg_input, options)?;
         debug!("conversion to xlsx complete");
     } else if args.cmd_datapackage {
         debug!("creating datapackage");
-        arg_input = process_input(
-            arg_input,
-            &tmpdir,
-            "No data on stdin. Need to add the name of a datapackage file as first argument then \
-             the input CSVs",
-        )?;
+        arg_input = process_input(arg_input, &tmpdir, EMPTY_STDIN_ERRMSG)?;
 
         let describe_options = DescribeOptions::builder()
             .delimiter(options.delimiter)

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -87,7 +87,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             args.arg_input.clone().unwrap_or_else(|| "-".to_string()),
         )],
         &tmpdir,
-        "No data on stdin. Please provide at least one input file or pipe data to stdin.",
+        "",
     )?;
 
     // safety: there's at least one valid element in work_input

--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -172,6 +172,58 @@ fn cat_rows_flexible() {
 }
 
 #[test]
+fn cat_rows_flexible_infile() {
+    let wrk = Workdir::new("cat_rows_flexible_infile");
+    wrk.create(
+        "in1.csv",
+        vec![
+            svec!["a", "b", "c"],
+            svec!["1", "2", "3"],
+            svec!["2", "3", "4"],
+        ],
+    );
+
+    wrk.create(
+        "in2.csv",
+        vec![
+            svec!["a", "b", "c"],
+            svec!["3", "1", "2"],
+            svec!["4", "2", "3"],
+        ],
+    );
+
+    wrk.create(
+        "in3.csv",
+        vec![
+            svec!["a", "b", "c", "d"],
+            svec!["1", "2", "4", "3"],
+            svec!["2", "3", "5", "4"],
+            svec!["z", "y", "w", "x"],
+        ],
+    );
+
+    wrk.create_from_string("testdata.infile-list", "in1.csv\nin2.csv\nin3.csv\n");
+
+    let mut cmd = wrk.command("cat");
+    cmd.arg("rows")
+        .arg("--flexible")
+        .arg("testdata.infile-list");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["a", "b", "c"],
+        svec!["1", "2", "3"],
+        svec!["2", "3", "4"],
+        svec!["3", "1", "2"],
+        svec!["4", "2", "3"],
+        svec!["1", "2", "4", "3"],
+        svec!["2", "3", "5", "4"],
+        svec!["z", "y", "w", "x"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn cat_rowskey_grouping() {
     let wrk = Workdir::new("cat_rowskey_grouping");
     wrk.create(
@@ -208,6 +260,58 @@ fn cat_rowskey_grouping() {
         .arg("in1.csv")
         .arg("in2.csv")
         .arg("in3.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["file", "a", "b", "c", "d"],
+        svec!["in1", "1", "2", "3", ""],
+        svec!["in1", "2", "3", "4", ""],
+        svec!["in2", "1", "2", "3", ""],
+        svec!["in2", "2", "3", "4", ""],
+        svec!["in3", "1", "2", "3", "4"],
+        svec!["in3", "2", "3", "4", "5"],
+        svec!["in3", "z", "y", "x", "w"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn cat_rowskey_grouping_infile() {
+    let wrk = Workdir::new("cat_rowskey_grouping_infile");
+    wrk.create(
+        "in1.csv",
+        vec![
+            svec!["a", "b", "c"],
+            svec!["1", "2", "3"],
+            svec!["2", "3", "4"],
+        ],
+    );
+
+    wrk.create(
+        "in2.csv",
+        vec![
+            svec!["c", "a", "b"],
+            svec!["3", "1", "2"],
+            svec!["4", "2", "3"],
+        ],
+    );
+
+    wrk.create(
+        "in3.csv",
+        vec![
+            svec!["a", "b", "d", "c"],
+            svec!["1", "2", "4", "3"],
+            svec!["2", "3", "5", "4"],
+            svec!["z", "y", "w", "x"],
+        ],
+    );
+
+    wrk.create_from_string("testdata.infile-list", "in1.csv\nin2.csv\nin3.csv\n");
+
+    let mut cmd = wrk.command("cat");
+    cmd.arg("rowskey")
+        .arg("--group")
+        .arg("testdata.infile-list");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![

--- a/tests/test_headers.rs
+++ b/tests/test_headers.rs
@@ -171,3 +171,58 @@ h2
 h3";
     assert_eq!(got, expected.to_string());
 }
+
+#[test]
+fn headers_infile() {
+    let wrk = Workdir::new("headers_infile");
+    wrk.create("in1.csv", vec![svec!["a", "b", "c"], svec!["1", "2", "3"]]);
+
+    wrk.create("in2.csv", vec![svec!["c", "d", "e"], svec!["3", "1", "2"]]);
+
+    wrk.create(
+        "in3.csv",
+        vec![svec!["a", "b", "f", "g"], svec!["1", "2", "4", "3"]],
+    );
+
+    wrk.create_from_string("testdata.infile-list", "in1.csv\nin2.csv\nin3.csv\n");
+
+    let mut cmd = wrk.command("headers");
+    cmd.arg("testdata.infile-list");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        ["a"],
+        ["b"],
+        ["c"],
+        ["c"],
+        ["d"],
+        ["e"],
+        ["a"],
+        ["b"],
+        ["f"],
+        ["g"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn headers_intersect_infile() {
+    let wrk = Workdir::new("headers_intersect_infile");
+    wrk.create("in1.csv", vec![svec!["a", "b", "c"], svec!["1", "2", "3"]]);
+
+    wrk.create("in2.csv", vec![svec!["c", "d", "e"], svec!["3", "1", "2"]]);
+
+    wrk.create(
+        "in3.csv",
+        vec![svec!["a", "b", "f", "g"], svec!["1", "2", "4", "3"]],
+    );
+
+    wrk.create_from_string("testdata.infile-list", "in1.csv\nin2.csv\nin3.csv\n");
+
+    let mut cmd = wrk.command("headers");
+    cmd.arg("--intersect").arg("testdata.infile-list");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![["a"], ["b"], ["c"], ["d"], ["e"], ["f"], ["g"]];
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
As per the function doc of `process_input`
```rust
/// Process the input files and return a vector of paths to the input files
///
/// If the input is empty, try to copy stdin to a file named stdin in the passed temp directory
/// If the input is empty and stdin is empty, return an error
/// If it's not empty, check the input files if they exist, and return an error if they don't
///
/// If the input is a directory, add all the files in the directory to the input
/// If the input is a file with the extension ".infile-list" read the file, and add each line as a
/// file to the input If the input is a file, add the file to the input
/// If the input are snappy compressed files, uncompress them before adding them to the input
```

resolves #1293 for `cat`. `headers` command also now uses `process_input` and gained `infile-list` support along with other `process_input` capabilities.

Commands that previously used `process_input` now also support `.infile-list` files - `sqlp` and `to` commands.