### PR TITLE
`exclude`: also consider rows with empty fields

### DIFF
--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -205,17 +205,15 @@ impl<R: io::Read + io::Seek> ValueIndex<R> {
                 .select(&row)
                 .map(|v| util::transform(v, casei))
                 .collect();
-            if !fields.iter().any(std::vec::Vec::is_empty) {
-                match val_idx.entry(fields) {
-                    Entry::Vacant(v) => {
-                        let mut rows = Vec::with_capacity(4);
-                        rows.push(rowi);
-                        v.insert(rows);
-                    },
-                    Entry::Occupied(mut v) => {
-                        v.get_mut().push(rowi);
-                    },
-                }
+            match val_idx.entry(fields) {
+                Entry::Vacant(v) => {
+                    let mut rows = Vec::with_capacity(4);
+                    rows.push(rowi);
+                    v.insert(rows);
+                },
+                Entry::Occupied(mut v) => {
+                    v.get_mut().push(rowi);
+                },
             }
             rowi += 1;
             count += 1;

--- a/tests/test_exclude.rs
+++ b/tests/test_exclude.rs
@@ -121,3 +121,39 @@ fn exclude_utf8_issue778_positions_aliases() {
 
     assert_eq!(got, expected.trim_end());
 }
+
+#[test]
+fn exclude_1497_empty_fields() {
+    let wrk = Workdir::new("exclude_1497_empty_fields");
+
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["id", "start", "end"],
+            svec!["1", "2001", "2003"],
+            svec!["2", "2004", "2006"],
+            svec!["3", "2006", ""],
+            svec!["4", "2007", "2010"],
+        ],
+    );
+
+    wrk.create(
+        "skip.csv",
+        vec![
+            svec!["id", "start", "end"],
+            svec!["2", "2004", "2006"],
+            svec!["3", "2006", ""],
+        ],
+    );
+
+    let mut cmd = wrk.command("exclude");
+    cmd.arg("id,end")
+        .arg("data.csv")
+        .arg("id,end")
+        .arg("skip.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "id,start,end\n1,2001,2003\n4,2007,2010";
+
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
resolves #1497