### PR TITLE
Remove generate

### DIFF
--- a/.github/workflows/macOS-arm64-selfhosted-publish-nightly.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish-nightly.yml
@@ -37,7 +37,7 @@ jobs:
             target: aarch64-apple-darwin
             architecture: aarch64
             use-cross: false
-            addl-build-args: --features=apply,generate,fetch,foreach,self_update,luau,polars,to,geocode
+            addl-build-args: --features=apply,fetch,foreach,self_update,luau,polars,to,geocode
             default-features: --no-default-features
             addl-qsvlite-features:
             addl-qsvdp-features: luau

--- a/.github/workflows/macOS-arm64-selfhosted-publish.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish.yml
@@ -37,7 +37,7 @@ jobs:
             target: aarch64-apple-darwin
             architecture: aarch64
             use-cross: false
-            addl-build-args: --features=apply,generate,fetch,foreach,self_update,luau,polars,to,geocode
+            addl-build-args: --features=apply,fetch,foreach,self_update,luau,polars,to,geocode
             default-features:
             addl-qsvlite-features:
             addl-qsvdp-features: luau

--- a/.github/workflows/publish-macOS-x86_64.yml
+++ b/.github/workflows/publish-macOS-x86_64.yml
@@ -37,7 +37,7 @@ jobs:
             target: x86_64-apple-darwin
             architecture: x86_64
             use-cross: false
-            addl-build-args: --features=apply,generate,fetch,foreach,self_update,luau,polars,to,geocode
+            addl-build-args: --features=apply,fetch,foreach,self_update,luau,polars,to,geocode
             default-features: --no-default-features
             addl-qsvlite-features:
             addl-qsvdp-features: luau

--- a/.github/workflows/publish-nightly-glibc-231-musl-1124.yml
+++ b/.github/workflows/publish-nightly-glibc-231-musl-1124.yml
@@ -33,7 +33,7 @@ jobs:
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,self_update,polars,geocode
+            addl-build-args: --features=apply,luau,fetch,foreach,nightly,self_update,polars,geocode
             default-features:
             addl-qsvlite-features:
             addl-qsvdp-features: luau
@@ -43,7 +43,7 @@ jobs:
             target: x86_64-unknown-linux-musl
             architecture: x86_64
             musl-prep: true
-            addl-build-args: --features=apply,generate,fetch,foreach,nightly,self_update,polars
+            addl-build-args: --features=apply,fetch,foreach,nightly,self_update,polars
             default-features:
             addl-qsvlite-features:
             addl-qsvdp-features:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -33,7 +33,7 @@ jobs:
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,self_update,geocode,polars,to
+            addl-build-args: --features=apply,luau,fetch,foreach,nightly,self_update,geocode,polars,to
             default-features:
             addl-qsvlite-features:
             addl-qsvdp-features: luau
@@ -43,7 +43,7 @@ jobs:
           #   target: x86_64-unknown-linux-musl
           #   architecture: x86_64
           #   musl-prep: true
-          #   addl-build-args: --features=apply,generate,fetch,foreach,nightly,self_update
+          #   addl-build-args: --features=apply,fetch,foreach,nightly,self_update
           #   default-features:
           - os: windows-latest
             os-name: windows

--- a/.github/workflows/test-publish-nightly.yml
+++ b/.github/workflows/test-publish-nightly.yml
@@ -18,7 +18,7 @@ jobs:
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,to,self_update,polars
+            addl-build-args: --features=apply,luau,fetch,foreach,nightly,to,self_update,polars
             default-features:
             addl-qsvdp-features: luau
           # - os: ubuntu-latest
@@ -26,27 +26,27 @@ jobs:
           #   target: x86_64-unknown-linux-musl
           #   architecture: x86_64
           #   musl-prep: true
-          #   addl-build-args: --features=apply,generate,fetch,foreach,nightly,self_update
+          #   addl-build-args: --features=apply,fetch,foreach,nightly,self_update
           #   default-features:
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-msvc
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,nightly,to,self_update,polars
+            addl-build-args: --features=apply,luau,fetch,nightly,to,self_update,polars
             default-features:
             addl-qsvdp-features: luau
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-gnu
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,nightly,self_update,polars
+            addl-build-args: --features=apply,luau,fetch,nightly,self_update,polars
             default-features: --no-default-features 
             addl-qsvdp-features: luau
           - os: macos-latest
             os-name: macos
             target: x86_64-apple-darwin
             architecture: x86_64
-            addl-build-args: --features=apply,generate,luau,fetch,foreach,nightly,to,self_update
+            addl-build-args: --features=apply,luau,fetch,foreach,nightly,to,self_update
             default-features:
             addl-qsvdp-features: luau
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,20 +1148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb9105919ca8e40d437fc9cbb8f1975d916f1bd28afe795a48aae32a2cc8920"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,7 +2090,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2330,17 +2316,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2576,12 +2551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
-
-[[package]]
 name = "lexical-core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,12 +2702,6 @@ dependencies = [
  "bindgen",
  "cc",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3314,7 +3277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -3542,7 +3505,7 @@ dependencies = [
  "comfy-table",
  "either",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -3622,7 +3585,7 @@ dependencies = [
  "chrono",
  "fallible-streaming-iterator",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap",
  "itoa",
  "num-traits",
  "polars-arrow",
@@ -3668,7 +3631,7 @@ dependencies = [
  "bytemuck",
  "either",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap",
  "memchr",
  "num-traits",
  "polars-arrow",
@@ -3813,7 +3776,7 @@ dependencies = [
  "ahash 0.8.7",
  "bytemuck",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap",
  "num-traits",
  "once_cell",
  "polars-error",
@@ -4090,7 +4053,7 @@ dependencies = [
  "grex",
  "gzp",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap",
  "indicatif",
  "itertools",
  "itoa",
@@ -4140,7 +4103,6 @@ dependencies = [
  "sysinfo",
  "tabwriter",
  "tempfile",
- "test-data-generation",
  "thousands",
  "threadpool",
  "titlecase",
@@ -4795,7 +4757,7 @@ version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4821,18 +4783,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -5287,27 +5237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-data-generation"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640e18df4252c8ccb6c1c3abd1e48c9f2c674a61eb3136936811b79b9b7f58d6"
-dependencies = [
- "crossbeam",
- "csv",
- "indexmap 1.9.3",
- "levenshtein",
- "log",
- "once_cell",
- "rand",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_yaml",
- "yaml-rust",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5508,7 +5437,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -6176,15 +6105,6 @@ name = "xxhash-rust"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,6 @@ strum_macros = "0.25"
 sysinfo = "0.30"
 tabwriter = "1.4"
 tempfile = "3"
-test-data-generation = { version = "0.3", optional = true }
 thousands = { version = "0.2", optional = true }
 threadpool = "1.8"
 titlecase = { version = "2", optional = true }
@@ -244,7 +243,6 @@ all_features = [
     "apply",
     "fetch",
     "foreach",
-    "generate",
     "geocode",
     "luau",
     "polars",
@@ -281,7 +279,6 @@ fetch = [
     "serde_urlencoded",
 ]
 foreach = []
-generate = ["test-data-generation"]
 geocode = [
     "anyhow",
     "cached",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@
 | [foreach](/src/cmd/foreach.rs#L3)<br>✨ | Loop over a CSV to execute shell commands. (not available on Windows)  |
 | [frequency](/src/cmd/frequency.rs#L2)<br>📇😣🏎️ | Build [frequency tables](https://statisticsbyjim.com/basics/frequency-table/) of each column. Uses multithreading to go faster if an index is present. |
 | [geocode](/src/cmd/geocode.rs#L2)<br>✨🧠🌐🚀🔣 | Geocodes a location against an updatable local copy of the [Geonames](https://www.geonames.org/) cities database. With caching and multi-threading, it geocodes up to 360,000 records/sec! |
-| [generate](/src/cmd/generate.rs#L2)<br>✨ | Generate test data by profiling a CSV using [Markov decision process](https://crates.io/crates/test-data-generation) machine learning.  |
 | [headers](/src/cmd/headers.rs#L2) | Show the headers of a CSV. Or show the intersection of all headers between many CSV files. |
 | [index](/src/cmd/index.rs#L2) | Create an index (📇) for a CSV. This is very quick (even the 15gb, 28m row NYC 311 dataset takes all of 15 seconds to index) & provides constant time indexing/random access into the CSV. With an index, `count`, `sample` & `slice` work instantaneously; random access mode is enabled in `luau`; and multithreading (🏎️) is enabled for the `frequency`, `split`, `stats`, `schema` & `tojsonl` commands. |
 | [input](/src/cmd/input.rs#L2) | Read CSV data with special commenting, quoting, trimming, line-skipping & non-UTF8 encoding handling rules. Typically used to "normalize" a CSV for further processing with other qsv commands. |
@@ -157,7 +156,7 @@ To install different [variants](#variants) and enable optional features, use car
 
 ```bash
 # to install qsv with all features enabled
-cargo install qsv --locked --bin qsv --features feature_capable,apply,generate,luau,fetch,foreach,python,to,self_update,polars
+cargo install qsv --locked --bin qsv --features feature_capable,apply,luau,fetch,foreach,python,to,self_update,polars
 # or shorthand
 cargo install qsv --locked --bin qsv -F all_features
 
@@ -187,7 +186,7 @@ To compile different [variants](#variants) and enable optional [features](#featu
 
 ```bash
 # to compile qsv with all features enabled
-cargo build --release --locked --bin qsv --features feature_capable,apply,generate,luau,fetch,foreach,python,to,self_update,polars
+cargo build --release --locked --bin qsv --features feature_capable,apply,luau,fetch,foreach,python,to,self_update,polars
 # shorthand
 cargo build --release --locked --bin qsv -F all_features
 
@@ -409,7 +408,7 @@ Dual-licensed under MIT or the [UNLICENSE](https://unlicense.org).
 
 ## Origins
 
-Quicksilver (qsv) is a fork of the popular [xsv](https://github.com/BurntSushi/xsv) utility, merging several pending PRs [since xsv 0.13.0's May 2018 release](https://github.com/BurntSushi/xsv/issues/267). On top of xsv's 20 commands, it adds numerous new features; 37 additional commands; 5 `apply` subcommands & 36 operations; 5 `to` subcommands; 3 `cat` subcommands; 7 `geocode` subcommands & 4 index operations; and 4 `snappy` subcommands.
+Quicksilver (qsv) is a fork of the popular [xsv](https://github.com/BurntSushi/xsv) utility, merging several pending PRs [since xsv 0.13.0's May 2018 release](https://github.com/BurntSushi/xsv/issues/267). On top of xsv's 20 commands, it adds numerous new features; 36 additional commands; 5 `apply` subcommands & 36 operations; 5 `to` subcommands; 3 `cat` subcommands; 7 `geocode` subcommands & 4 index operations; and 4 `snappy` subcommands.
 See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for more details.
 
 ## Sponsor

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -34,8 +34,6 @@ pub mod fmt;
 #[cfg(all(feature = "foreach", target_family = "unix", not(feature = "lite")))]
 pub mod foreach;
 pub mod frequency;
-#[cfg(all(feature = "generate", feature = "feature_capable"))]
-pub mod generate;
 #[cfg(all(feature = "geocode", feature = "feature_capable"))]
 pub mod geocode;
 pub mod headers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,9 +125,6 @@ fn main() -> QsvExitCode {
 
     enabled_commands.push_str("    frequency   Show frequency tables\n");
 
-    #[cfg(all(feature = "generate", not(feature = "lite")))]
-    enabled_commands.push_str("    generate    Generate test data by profiling a CSV\n");
-
     #[cfg(all(feature = "geocode", not(feature = "lite")))]
     enabled_commands
         .push_str("    geocode     Geocodes a location against the Geonames cities database.\n");
@@ -339,8 +336,6 @@ enum Command {
     #[cfg(all(feature = "foreach", target_family = "unix", not(feature = "lite")))]
     ForEach,
     Frequency,
-    #[cfg(all(feature = "generate", feature = "feature_capable"))]
-    Generate,
     #[cfg(all(feature = "geocode", feature = "feature_capable"))]
     Geocode,
     Headers,
@@ -424,8 +419,6 @@ impl Command {
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),
             Command::Frequency => cmd::frequency::run(argv),
-            #[cfg(all(feature = "generate", feature = "feature_capable"))]
-            Command::Generate => cmd::generate::run(argv),
             #[cfg(all(feature = "geocode", feature = "feature_capable"))]
             Command::Geocode => cmd::geocode::run(argv),
             Command::Headers => cmd::headers::run(argv),


### PR DESCRIPTION
the test-data-generation crate is unmaintained and has old dependencies. Also, the command is not reallly producing good test data that can be used for training models.

This will be replaced by a more feature complete fake command that will use summary statistics and frequency tables to produce more realistic test data that has the same properties as the  reference data that can be used for training.

#235 