### PR TITLE
`sample`: replace `--faster` RNG sampling option with `--rng <kind>` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,6 +4078,8 @@ dependencies = [
  "qsv_docopt",
  "quickcheck",
  "rand",
+ "rand_hc",
+ "rand_xoshiro",
  "rayon",
  "redis",
  "regex",
@@ -4283,6 +4285,24 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,8 @@ qsv-sniffer = { version = "0.10", default-features = false, features = [
     "runtime-dispatch-simd",
 ] }
 rand = "0.8"
+rand_hc = "0.3"
+rand_xoshiro = "0.6"
 rayon = "1.8"
 redis = { version = "0.24", features = [
     "ahash",

--- a/tests/test_sample.rs
+++ b/tests/test_sample.rs
@@ -86,7 +86,7 @@ fn sample_seed_faster() {
     );
 
     let mut cmd = wrk.command("sample");
-    cmd.arg("--faster")
+    cmd.args(["--rng", "faster"])
         .args(["--seed", "42"])
         .arg("5")
         .arg("in.csv");
@@ -94,11 +94,47 @@ fn sample_seed_faster() {
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["R", "S"],
-        svec!["1", "b"],
+        svec!["6", "e"],
         svec!["2", "a"],
+        svec!["8", "h"],
+        svec!["4", "c"],
+        svec!["5", "f"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn sample_seed_secure() {
+    let wrk = Workdir::new("sample_seed_secure");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["R", "S"],
+            svec!["1", "b"],
+            svec!["2", "a"],
+            svec!["3", "d"],
+            svec!["4", "c"],
+            svec!["5", "f"],
+            svec!["6", "e"],
+            svec!["7", "i"],
+            svec!["8", "h"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sample");
+    cmd.args(["--rng", "cryptosecure"])
+        .args(["--seed", "42"])
+        .arg("5")
+        .arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["R", "S"],
+        svec!["8", "h"],
+        svec!["7", "i"],
         svec!["3", "d"],
         svec!["4", "c"],
-        svec!["6", "e"],
+        svec!["5", "f"],
     ];
     assert_eq!(got, expected);
 }
@@ -217,7 +253,7 @@ fn sample_percentage_seed_indexed_faster() {
     );
 
     let mut cmd = wrk.command("sample");
-    cmd.arg("--faster")
+    cmd.args(["--rng", "faster"])
         .args(["--seed", "42"])
         .arg("0.4")
         .arg("in.csv");
@@ -225,8 +261,43 @@ fn sample_percentage_seed_indexed_faster() {
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["R", "S"],
-        svec!["1", "b"],
-        svec!["2", "a"],
+        svec!["4", "c"],
+        svec!["6", "e"],
+        svec!["7", "i"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn sample_percentage_seed_indexed_secure() {
+    let wrk = Workdir::new("sample_indexed_secure");
+    wrk.create_indexed(
+        "in.csv",
+        vec![
+            svec!["R", "S"],
+            svec!["1", "b"],
+            svec!["2", "a"],
+            svec!["3", "d"],
+            svec!["4", "c"],
+            svec!["5", "f"],
+            svec!["6", "e"],
+            svec!["7", "i"],
+            svec!["8", "h"],
+            svec!["8", "h"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sample");
+    cmd.args(["--rng", "cryptosecure"])
+        .args(["--seed", "42"])
+        .arg("0.4")
+        .arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["R", "S"],
+        svec!["3", "d"],
+        svec!["5", "f"],
         svec!["8", "h"],
     ];
     assert_eq!(got, expected);
@@ -319,7 +390,7 @@ fn sample_indexed_random_access_faster() {
     );
 
     let mut cmd = wrk.command("sample");
-    cmd.arg("--faster")
+    cmd.args(["--rng", "faster"])
         .args(["--seed", "42"])
         .arg("4")
         .arg("in.csv");
@@ -327,10 +398,63 @@ fn sample_indexed_random_access_faster() {
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["R", "S"],
+        svec!["4", "c"],
         svec!["19", "s"],
+        svec!["16", "p"],
         svec!["15", "o"],
-        svec!["17", "q"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn sample_indexed_random_access_secure() {
+    let wrk = Workdir::new("sample_indexed_random_access_secure");
+    wrk.create_indexed(
+        "in.csv",
+        vec![
+            svec!["R", "S"],
+            svec!["1", "b"],
+            svec!["2", "a"],
+            svec!["3", "d"],
+            svec!["4", "c"],
+            svec!["5", "f"],
+            svec!["6", "e"],
+            svec!["7", "i"],
+            svec!["8", "h"],
+            svec!["9", "i"],
+            svec!["10", "j"],
+            svec!["11", "k"],
+            svec!["12", "l"],
+            svec!["13", "m"],
+            svec!["14", "n"],
+            svec!["15", "o"],
+            svec!["16", "p"],
+            svec!["17", "q"],
+            svec!["18", "r"],
+            svec!["19", "s"],
+            svec!["20", "t"],
+            svec!["21", "u"],
+            svec!["22", "v"],
+            svec!["23", "w"],
+            svec!["24", "x"],
+            svec!["25", "y"],
+            svec!["26", "z"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sample");
+    cmd.args(["--rng", "cryptosecure"])
+        .args(["--seed", "42"])
+        .arg("4")
+        .arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["R", "S"],
+        svec!["24", "x"],
+        svec!["10", "j"],
         svec!["26", "z"],
+        svec!["6", "e"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
Users now have a choice of three random number generators - standard, faster (using Xoshiro256Plus algorithm) and crypto secure (using HC128 algorithm)