### PR TITLE
`sort`: add `--rng` kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libduckdb-sys"
@@ -4040,7 +4040,6 @@ dependencies = [
  "dynfmt",
  "eudex",
  "ext-sort",
- "fastrand 2.0.1",
  "file-format",
  "filetime",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ eudex = { version = "0.1", optional = true }
 ext-sort = { version = "0.1", features = [
     "memory-limit",
 ], default-features = false }
-fastrand = "2"
 flate2 = { version = "1", optional = true }
 file-format = { version = "0.23", features = ["reader"] }
 filetime = "0.2"

--- a/tests/test_sort.rs
+++ b/tests/test_sort.rs
@@ -465,18 +465,53 @@ fn sort_random_faster() {
     let mut cmd = wrk.command("sort");
     cmd.arg("--random")
         .args(["--seed", "42"])
-        .arg("--faster")
+        .args(["--rng", "faster"])
         .arg("in.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["R", "S"],
+        svec!["5", "f"],
+        svec!["3", "d"],
+        svec!["4", "c"],
+        svec!["6", "e"],
+        svec!["2", "a"],
         svec!["1", "b"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn sort_random_secure() {
+    let wrk = Workdir::new("sort_random_secure");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["R", "S"],
+            svec!["1", "b"],
+            svec!["2", "a"],
+            svec!["3", "d"],
+            svec!["4", "c"],
+            svec!["5", "f"],
+            svec!["6", "e"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sort");
+    cmd.arg("--random")
+        .args(["--seed", "42"])
+        .args(["--rng", "cryptosecure"])
+        .arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["R", "S"],
+        svec!["3", "d"],
+        svec!["5", "f"],
         svec!["2", "a"],
         svec!["6", "e"],
         svec!["4", "c"],
-        svec!["5", "f"],
-        svec!["3", "d"],
+        svec!["1", "b"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
like `sample`, users now have a choice of three random number generators when doing a `--random` sort  - standard, faster (using Xoshiro256Plus algorithm) and crypto secure (using HC128 algorithm)