### PR TITLE
`fat`: `--out-delimiter` now treats "T" as special value for tab character

### DIFF
--- a/src/cmd/fmt.rs
+++ b/src/cmd/fmt.rs
@@ -15,6 +15,8 @@ Usage:
 
 fmt options:
     -t, --out-delimiter <arg>  The field delimiter for writing CSV data.
+                               Must be a single character.
+                               If set to "T", uses tab as the delimiter.
                                [default: ,]
     --crlf                     Use '\r\n' line endings in the output.
     --ascii                    Use ASCII field and record separators. Use Substitute (U+00A1) as the
@@ -25,7 +27,7 @@ fmt options:
     --escape <arg>             The escape character to use. When not specified,
                                quotes are escaped by doubling them.
     --no-final-newline         Do not write a newline at the end of the output.
-                               This makes it easier to paste the output into Excel.
+                               This makes it easier to paste the output into Excel. 
 
 Common options:
     -h, --help             Display this message
@@ -58,6 +60,10 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: Args = util::get_args(USAGE, argv)?;
+
+    if args.flag_out_delimiter == Some(Delimiter(b'T')) {
+        args.flag_out_delimiter = Some(Delimiter(b'\t'));
+    }
 
     let rconfig = Config::new(&args.arg_input)
         .delimiter(args.flag_delimiter)

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ const NO_INDEX_WARNING_FILESIZE: u64 = 100_000_000; // 100MB
 // so we don't have to keep checking if the index has been created
 static AUTO_INDEXED: AtomicBool = AtomicBool::new(false);
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Delimiter(pub u8);
 
 /// Delimiter represents values that can be passed from the command line that

--- a/tests/test_fmt.rs
+++ b/tests/test_fmt.rs
@@ -62,6 +62,16 @@ mnopqr,stuvwx\r
 }
 
 #[test]
+fn fmt_tab_delimiter() {
+    let (wrk, mut cmd) = setup("fmt_tab_delimiter");
+    cmd.args(["--out-delimiter", "T"]);
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "h1\th2\nabcdef\tghijkl\nmnopqr\tstuvwx\n\"ab\"\"cd\"\"ef\"\tgh,ij,kl";
+    assert_eq!(got, expected.to_string());
+}
+
+#[test]
 fn fmt_nofinalnewline() {
     let (wrk, mut cmd) = setup("fmt_nofinalnewline");
     cmd.arg("--no-final-newline");


### PR DESCRIPTION
this allows us to indicate the Tab character as an output delimiter thru the command line parser