### PR TITLE
Make it easier and more consistent to package for distros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,7 @@ halfbrown = { git = "https://github.com/licenser/halfbrown", rev = "7cecc29422ae
 
 [features]
 default = ["mimalloc"]
-all_features = [
+distrib_features = [
     "feature_capable",
     "apply",
     "fetch",
@@ -248,9 +248,12 @@ all_features = [
     "luau",
     "polars",
     "python",
-    "self_update",
     "to",
     "to_parquet",
+]
+all_features = [
+    "distrib_features",
+    "self_update",
 ]
 apply = [
     "censor",

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -8,7 +8,6 @@
 * `fetch` - enables the `fetch` & `fetchpost` commands.
 * `foreach` - enable `foreach` command (not valid for Windows).
 * `geocode` - enable `geocode` command.
-* `generate` - enable `generate` command.
 * `luau` - enable `luau` command. Embeds a [Luau](https://luau-lang.org) interpreter into qsv. [Luau has type-checking, sandboxing, additional language operators, increased performance & other improvements](https://luau-lang.org/2022/11/04/luau-origins-and-evolution.html) over Lua.
 * `polars` - enables all [Polars](https://pola.rs)-powered commands (currently, `joinp` and `sqlp`). Note that Polars is a very powerful library, but it has a lot of dependencies that drastically increases both compile time and binary size.
 * `python` - enable `py` command. Note that qsv will look for the shared library for the Python version (Python 3.7 & above supported) it was compiled against & will abort on startup if the library is not found, even if you're NOT using the `py` command. Check [Python](#python) section for more info.
@@ -19,7 +18,7 @@ Use the `sqlp` command with the `--format parquet` option instead if you don't n
 It will NOT offer the choice to update itself to the prebuilt binaries published on GitHub. You need not worry that your manually built qsv will be overwritten by a self-update.
 
 * `feature_capable` - enable to build `qsv` binary variant which is feature-capable.
-* `all_features` - enable to build `qsv` binary variant with all features enabled (apply,fetch,foreach,generate,luau,polars,python,to,to_parquet,self_update).
+* `all_features` - enable to build `qsv` binary variant with all features enabled (apply,fetch,foreach,luau,polars,python,to,to_parquet,self_update).
 * `lite` - enable to build `qsvlite` binary variant with all features disabled.
 * `datapusher_plus` - enable to build `qsvdp` binary variant - the [DataPusher+](https://github.com/dathere/datapusher-plus) optimized qsv binary.
 * `nightly` - enable to turn on nightly/unstable features in the `rand`, `regex`, `hashbrown` & `pyo3` crates when building with Rust nightly/unstable.


### PR DESCRIPTION
The `all_features` set has, well, all features. That's fine for end users that are using `cargo install` or building directly from a Git clone, but that set of features includes one thing than is almost never appropriate for distro packagers to use: the `self_update` feature. Because the resulting binary in installed somewhere that the system package manager is tracking, it should never get messed with by a self-* feature. This is a common issue on many projects that enable this by default. If upstream projects don't include a way to disable it out of the box distro often have to patch it out themselves.

In the case of this project it can be avoided by manually assembling a long list of features: `--features='feature_capable,apply,fetch,foreach,generate,geocode,luau,polars,python,to,to_parquet'`.
This is somewhat combersome and error prone, and also subject to change. The last release for example removed the `generate` feature. That at least threw an error on build so I noticed it when updating the package, but it would be easy for a new feature to get added and have distro packagers miss it.

The arrangement in this PR adds a new feature set for the convenience of distro packagers or others distributing a binary through a channel other than "self". This should make it easier to maintain by staying up to date upstream and giving distros a single flag to set that works for most cases.
