### PR TITLE
fix: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "cargo-clippy",
+    clippy,
     allow(
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap,

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "cargo-clippy",
+    clippy,
     allow(
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap,


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html