### PR TITLE
`sqlp`: various improvements

### DIFF
--- a/tests/test_sqlp.rs
+++ b/tests/test_sqlp.rs
@@ -869,6 +869,29 @@ select ward,count(*) as cnt from temp_table2 group by ward order by cnt desc, wa
         .args(["--format", "json"]);
 
     let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"[{"ward":"Ward 3","cnt":2},{"ward":" ","cnt":1},{"ward":"04","cnt":1},{"ward":"3","cnt":1},{"ward":"Ward 13","cnt":1},{"ward":"Ward 17","cnt":1},{"ward":"Ward 19","cnt":1},{"ward":"Ward 21","cnt":1},{"ward":"Ward 6","cnt":1}]"#;
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn sqlp_boston311_sql_script_jsonl() {
+    let wrk = Workdir::new("sqlp_boston311_sql_script_jsonl");
+    let test_file = wrk.load_test_file("boston311-100.csv");
+
+    wrk.create_from_string(
+        "test.sql",
+        r#"create table temp_table as select * from "boston311-100" where ontime = 'OVERDUE';
+create table temp_table2 as select * from temp_table limit 10;
+select ward,count(*) as cnt from temp_table2 group by ward order by cnt desc, ward asc;"#,
+    );
+
+    let mut cmd = wrk.command("sqlp");
+    cmd.arg(&test_file)
+        .arg("test.sql")
+        .args(["--format", "jsonl"]);
+
+    let got: String = wrk.stdout(&mut cmd);
     let expected = r#"{"ward":"Ward 3","cnt":2}
 {"ward":" ","cnt":1}
 {"ward":"04","cnt":1}


### PR DESCRIPTION
- link to Polars 0.38.1 tag for SQL functions/keywords
- add jsonl (JSON Lines) output format
- add compression support for Avro and Arrow