### PR TITLE
`qsvdp`: add polars support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ cargo install qsv --locked --bin qsv -F feature_capable,apply,polars
 cargo install qsv --locked --bin qsvlite -F lite
 
 # or to install qsvdp
-cargo install qsv --locked --bin qsvdp -F datapusher_plus,luau
+cargo install qsv --locked --bin qsvdp -F datapusher_plus,luau,polars
 ```
 
 ### Option 4: Compile from Source
@@ -201,7 +201,7 @@ cargo build --release --locked --bin qsv -F feature_capable,fetch,foreach
 cargo build --release --locked --bin qsvlite -F lite
 
 # for qsvdp
-cargo build --release --locked --bin qsvdp -F datapusher_plus,luau
+cargo build --release --locked --bin qsvdp -F datapusher_plus,luau,polars
 ```
 
 NOTE: To build with Rust nightly, see [Nightly Release Builds](docs/PERFORMANCE.md#nightly-release-builds).
@@ -397,7 +397,7 @@ cargo test --features lite
 cargo test stats --features lite
 
 # to test qsvdp
-cargo test --features datapusher_plus,luau
+cargo test --features datapusher_plus,luau,polars
 
 # to test a specific command
 # here we test only stats and use the

--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -225,3 +225,10 @@ impl From<reqwest::Error> for CliError {
         CliError::Network(err.to_string())
     }
 }
+
+#[cfg(feature = "polars")]
+impl From<polars::error::PolarsError> for CliError {
+    fn from(err: polars::error::PolarsError) -> CliError {
+        CliError::Other(format!("Polars error: {err:?}"))
+    }
+}

--- a/src/cmd/joinp.rs
+++ b/src/cmd/joinp.rs
@@ -186,7 +186,7 @@ use polars::{
 use serde::Deserialize;
 use tempfile::tempdir;
 
-use crate::{cmd::sqlp::compress_output_if_needed, config::Delimiter, util, CliError, CliResult};
+use crate::{cmd::sqlp::compress_output_if_needed, config::Delimiter, util, CliResult};
 
 #[derive(Deserialize)]
 struct Args {
@@ -223,12 +223,6 @@ struct Args {
     flag_output:           Option<String>,
     flag_delimiter:        Option<Delimiter>,
     flag_quiet:            bool,
-}
-
-impl From<polars::error::PolarsError> for CliError {
-    fn from(err: polars::error::PolarsError) -> CliError {
-        CliError::Other(format!("Polars error: {err:?}"))
-    }
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -42,7 +42,7 @@ pub mod index;
 pub mod input;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 pub mod join;
-#[cfg(all(feature = "polars", feature = "feature_capable"))]
+#[cfg(feature = "polars")]
 pub mod joinp;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 pub mod jsonl;
@@ -70,7 +70,7 @@ pub mod sort;
 pub mod sortcheck;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 pub mod split;
-#[cfg(all(feature = "polars", feature = "feature_capable"))]
+#[cfg(feature = "polars")]
 pub mod sqlp;
 pub mod stats;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -67,6 +67,7 @@ macro_rules! command_list {
     help        Show this usage message
     index       Create CSV index for faster access
     input       Read CSVs w/ special quoting, skipping, trimming & transcoding rules
+    joinp       Join CSV files using the Pola.rs engine
     luau        Execute Luau script on CSV data
     pseudo      Pseudonymise the values of a column
     rename      Rename the columns of CSV data efficiently
@@ -82,6 +83,7 @@ macro_rules! command_list {
     sniff       Quickly sniff CSV metadata
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     sortcheck   Check if a CSV is sorted
+    sqlp        Run a SQL query against several CSVs using the Pola.rs engine
     stats       Infer data types and compute summary statistics
     validate    Validate CSV data for RFC4180-compliance or with JSON Schema
 
@@ -245,6 +247,8 @@ enum Command {
     Help,
     Index,
     Input,
+    #[cfg(feature = "polars")]
+    JoinP,
     #[cfg(feature = "luau")]
     Luau,
     Pseudo,
@@ -261,6 +265,8 @@ enum Command {
     Sniff,
     Sort,
     SortCheck,
+    #[cfg(feature = "polars")]
+    SqlP,
     Stats,
     Validate,
 }
@@ -298,6 +304,8 @@ impl Command {
             },
             Command::Index => cmd::index::run(argv),
             Command::Input => cmd::input::run(argv),
+            #[cfg(feature = "polars")]
+            Command::JoinP => cmd::joinp::run(argv),
             #[cfg(feature = "luau")]
             Command::Luau => cmd::luau::run(argv),
             Command::Pseudo => cmd::pseudo::run(argv),
@@ -314,6 +322,8 @@ impl Command {
             Command::Sniff => cmd::sniff::run(argv),
             Command::Sort => cmd::sort::run(argv),
             Command::SortCheck => cmd::sortcheck::run(argv),
+            #[cfg(feature = "polars")]
+            Command::SqlP => cmd::sqlp::run(argv),
             Command::Stats => cmd::stats::run(argv),
             Command::Validate => cmd::validate::run(argv),
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -74,7 +74,7 @@ mod test_index;
 mod test_input;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 mod test_join;
-#[cfg(all(feature = "feature_capable", feature = "polars"))]
+#[cfg(feature = "polars")]
 mod test_joinp;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 mod test_jsonl;
@@ -102,7 +102,7 @@ mod test_sort;
 mod test_sortcheck;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 mod test_split;
-#[cfg(all(feature = "feature_capable", feature = "polars"))]
+#[cfg(feature = "polars")]
 mod test_sqlp;
 mod test_stats;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]


### PR DESCRIPTION
No need to create a new qsvdp2 binary variant after all

Just make sure polars feature can be enabled for qsvdp

resolves #1657 