### PR TITLE
Make init_logger more robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ filetime = "0.2"
 flexi_logger = { version = "0.28", features = [
     "async",
     "compress",
+    "dont_minimize_extra_stacks",
 ], default-features = false }
 futures = "0.3"
 futures-util = "0.3"

--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -232,3 +232,9 @@ impl From<polars::error::PolarsError> for CliError {
         CliError::Other(format!("Polars error: {err:?}"))
     }
 }
+
+impl From<flexi_logger::FlexiLoggerError> for CliError {
+    fn from(err: flexi_logger::FlexiLoggerError) -> CliError {
+        CliError::Other(format!("FlexiLogger error: {err:?}"))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,13 @@ fn main() -> QsvExitCode {
     let num_commands = enabled_commands.split('\n').count();
 
     let now = Instant::now();
-    let (qsv_args, _logger_handle) = util::init_logger();
+    let (qsv_args, _logger_handle) = match util::init_logger() {
+        Ok((qsv_args, _logger_handle)) => (qsv_args, _logger_handle),
+        Err(e) => {
+            eprintln!("{e}");
+            return QsvExitCode::Bad;
+        },
+    };
 
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,8 +195,8 @@ fn main() -> QsvExitCode {
     let num_commands = enabled_commands.split('\n').count();
 
     let now = Instant::now();
-    let (qsv_args, _logger_handle) = match util::init_logger() {
-        Ok((qsv_args, _logger_handle)) => (qsv_args, _logger_handle),
+    let (qsv_args, _) = match util::init_logger() {
+        Ok((qsv_args, logger_handle)) => (qsv_args, logger_handle),
         Err(e) => {
             eprintln!("{e}");
             return QsvExitCode::Bad;

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -129,8 +129,8 @@ struct Args {
 
 fn main() -> QsvExitCode {
     let now = Instant::now();
-    let (qsv_args, _logger_handle) = match util::init_logger() {
-        Ok((qsv_args, _logger_handle)) => (qsv_args, _logger_handle),
+    let (qsv_args, _) = match util::init_logger() {
+        Ok((qsv_args, logger_handle)) => (qsv_args, logger_handle),
         Err(e) => {
             eprintln!("{e}");
             return QsvExitCode::Bad;

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -129,7 +129,13 @@ struct Args {
 
 fn main() -> QsvExitCode {
     let now = Instant::now();
-    let (qsv_args, _logger_handle) = util::init_logger();
+    let (qsv_args, _logger_handle) = match util::init_logger() {
+        Ok((qsv_args, _logger_handle)) => (qsv_args, _logger_handle),
+        Err(e) => {
+            eprintln!("{e}");
+            return QsvExitCode::Bad;
+        },
+    };
 
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -107,7 +107,13 @@ struct Args {
 
 fn main() -> QsvExitCode {
     let now = Instant::now();
-    let (qsv_args, _logger_handle) = util::init_logger();
+    let (qsv_args, _logger_handle) = match util::init_logger() {
+        Ok((qsv_args, _logger_handle)) => (qsv_args, _logger_handle),
+        Err(e) => {
+            eprintln!("{e}");
+            return QsvExitCode::Bad;
+        },
+    };
 
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -107,8 +107,8 @@ struct Args {
 
 fn main() -> QsvExitCode {
     let now = Instant::now();
-    let (qsv_args, _logger_handle) = match util::init_logger() {
-        Ok((qsv_args, _logger_handle)) => (qsv_args, _logger_handle),
+    let (qsv_args, _) = match util::init_logger() {
+        Ok((qsv_args, logger_handle)) => (qsv_args, logger_handle),
         Err(e) => {
             eprintln!("{e}");
             return QsvExitCode::Bad;


### PR DESCRIPTION
By adding error-handling.

Also enabled flexi_logger's `don't_minimize_extra_stacks` feature to prevent the error that was causing panics when initializing the error logger in musl builds.