### PR TITLE
`slice`: support negative `--index` option values

### DIFF
--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -109,7 +109,7 @@ impl Args {
         let index = if let Some(flag_index) = self.flag_index {
             if flag_index < 0 {
                 let index = (util::count_rows(&self.rconfig()).unwrap() as usize)
-                    .abs_diff(flag_index.unsigned_abs() as usize);
+                    .abs_diff(flag_index.unsigned_abs());
                 Some(index)
             } else {
                 Some(flag_index as usize)

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -24,6 +24,7 @@ slice options:
     -l, --len <arg>        The length of the slice (can be used instead
                            of --end).
     -i, --index <arg>      Slice a single record (shortcut for -s N -l 1).
+                           If negative, starts from the last record.
 
 Common options:
     -h, --help             Display this message
@@ -51,7 +52,7 @@ struct Args {
     flag_start:      Option<isize>,
     flag_end:        Option<usize>,
     flag_len:        Option<usize>,
-    flag_index:      Option<usize>,
+    flag_index:      Option<isize>,
     flag_output:     Option<String>,
     flag_no_headers: bool,
     flag_delimiter:  Option<Delimiter>,
@@ -105,7 +106,18 @@ impl Args {
                 start = Some(start_arg as usize);
             }
         }
-        util::range(start, self.flag_end, self.flag_len, self.flag_index)
+        let index = if let Some(flag_index) = self.flag_index {
+            if flag_index < 0 {
+                let index = (util::count_rows(&self.rconfig()).unwrap() as usize)
+                    .abs_diff(flag_index.unsigned_abs() as usize);
+                Some(index)
+            } else {
+                Some(flag_index as usize)
+            }
+        } else {
+            None
+        };
+        util::range(start, self.flag_end, self.flag_len, index)
     }
 
     fn rconfig(&self) -> Config {

--- a/tests/test_slice.rs
+++ b/tests/test_slice.rs
@@ -117,7 +117,7 @@ fn test_slice(
     assert_eq!(got, expected);
 }
 
-fn test_index(name: &str, idx: usize, expected: &str, headers: bool, use_index: bool) {
+fn test_index(name: &str, idx: isize, expected: &str, headers: bool, use_index: bool) {
     let (wrk, mut cmd) = setup(name, headers, use_index);
     cmd.arg("--index").arg(&idx.to_string());
     if !headers {
@@ -185,4 +185,21 @@ fn slice_index_withindex() {
 #[test]
 fn slice_index_no_headers_withindex() {
     test_index("slice_index_no_headers_withindex", 1, "b", false, true);
+}
+
+#[test]
+fn slice_neg_index() {
+    test_index("slice_neg_index", -1, "e", true, false);
+}
+#[test]
+fn slice_neg_index_no_headers() {
+    test_index("slice_neg_index_no_headers", -1, "e", false, false);
+}
+#[test]
+fn slice_neg_index_withindex() {
+    test_index("slice_neg_index_withindex", -2, "d", true, true);
+}
+#[test]
+fn slice_neg_index_no_headers_withindex() {
+    test_index("slice_neg_index_no_headers_withindex", -2, "d", false, true);
 }


### PR DESCRIPTION
similar to `--start`, means start from the last record