### PR TITLE
`excel`: attempt to get `--error-format` option to work on Win/Linux GH action runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,15 +880,13 @@ source = "git+https://github.com/jaemk/cached?rev=7662b49#7662b494673f4a3982ef68
 [[package]]
 name = "calamine"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3a315226fdc5b1c3e33521073e1712a05944bc0664d665ff1f6ff0396334da"
+source = "git+https://github.com/tafia/calamine?rev=aaf297e#aaf297e6b10cdfd189a5fbe4630c5f05130dbb5a"
 dependencies = [
  "byteorder",
  "chrono",
  "codepage",
  "encoding_rs",
  "log",
- "once_cell",
  "quick-xml 0.31.0",
  "serde",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,8 @@ jsonschema = { git = "https://github.com/Stranger6667/jsonschema-rs", rev = "6cf
 self_update = { git = "https://github.com/jqnatividad/self_update", branch = "bump-reqwest_hyper-http2" }
 # use upstream rev with unreleased fixes and dependencies. We'll switch back to crates.io once released
 cached = { git = "https://github.com/jaemk/cached", rev = "7662b49" }
+# use unreleased version of calamine with fixes
+calamine = { git = "https://github.com/tafia/calamine", rev = "aaf297e" }
 
 [features]
 default = ["mimalloc"]

--- a/tests/test_excel.rs
+++ b/tests/test_excel.rs
@@ -46,7 +46,7 @@ fn excel_cellerrors() {
 
 // for now, only run this test on macos
 // as it cannot get the formula text on linux or windows
-#[cfg(target_os = "macos")]
+// #[cfg(target_os = "macos")]
 #[test]
 fn excel_cellerrors_formula() {
     let wrk = Workdir::new("excel_cellerrors_formula");
@@ -80,7 +80,7 @@ fn excel_cellerrors_formula() {
 
 // same as above, only run this test on macos
 // as it cannot get the formula text on linux or windows
-#[cfg(target_os = "macos")]
+// #[cfg(target_os = "macos")]
 #[test]
 fn excel_cellerrors_both() {
     let wrk = Workdir::new("excel_cellerrors_both");


### PR DESCRIPTION
which work fine on macOS