### PR TITLE
`frequency`: add `--unq-limit` option

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -641,6 +641,7 @@ fn get_unique_values(
         arg_input:        args.arg_input.clone(),
         flag_select:      crate::select::SelectColumns::parse(column_select_arg).unwrap(),
         flag_limit:       args.flag_enum_threshold,
+        flag_unq_limit:   args.flag_enum_threshold,
         flag_asc:         false,
         flag_no_nulls:    true,
         flag_ignore_case: args.flag_ignore_case,

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -240,7 +240,10 @@ fn param_prop_frequency(name: &str, rows: CsvData, idx: bool) -> bool {
     }
 
     let mut cmd = wrk.command("frequency");
-    cmd.arg("in.csv").args(["-j", "4"]).args(["--limit", "0"]);
+    cmd.arg("in.csv")
+        .args(["-j", "4"])
+        .args(["--limit", "0"])
+        .args(["--unq-limit", "0"]);
 
     let stdout = wrk.stdout::<String>(&mut cmd);
     let got_ftables = ftables_from_csv_string(stdout);


### PR DESCRIPTION
This is particularly useful when compiling a frequency table for a column with all unique values (e.g. an ID or Sequence column) as without it, and if --limit is set to zero, the frequency table will be return all the unique values.

There are times when --limit is set to zero when you want to compile all the unique values for a column, but you want to exclude ID/sequence columns from the comprehensive frequency table.