### PR TITLE
`frequency`: add support for negative `--limit`s

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -640,7 +640,7 @@ fn get_unique_values(
     let freq_args = crate::cmd::frequency::Args {
         arg_input:        args.arg_input.clone(),
         flag_select:      crate::select::SelectColumns::parse(column_select_arg).unwrap(),
-        flag_limit:       args.flag_enum_threshold,
+        flag_limit:       args.flag_enum_threshold as isize,
         flag_unq_limit:   args.flag_enum_threshold,
         flag_asc:         false,
         flag_no_nulls:    true,

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -133,6 +133,17 @@ fn frequency_limit() {
 }
 
 #[test]
+fn frequency_negative_limit() {
+    let (wrk, mut cmd) = setup("frequency_negative_limit");
+    cmd.args(["--limit", "-4"]);
+
+    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    got.sort();
+    let expected = vec![svec!["field", "value", "count"], svec!["h1", "a", "4"]];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn frequency_asc() {
     let (wrk, mut cmd) = setup("frequency_asc");
     cmd.args(["--select", "h2"]).arg("--asc");


### PR DESCRIPTION
the abs value of the negative limit then becomes the occurence count filter, only returning values with an occurence count >= absolute value of the negative limit