### PR TITLE
`frequency`: add `--lmt-threshold` option

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -638,18 +638,19 @@ fn get_unique_values(
 ) -> CliResult<AHashMap<String, Vec<String>>> {
     // prepare arg for invoking cmd::frequency
     let freq_args = crate::cmd::frequency::Args {
-        arg_input:        args.arg_input.clone(),
-        flag_select:      crate::select::SelectColumns::parse(column_select_arg).unwrap(),
-        flag_limit:       args.flag_enum_threshold as isize,
-        flag_unq_limit:   args.flag_enum_threshold,
-        flag_asc:         false,
-        flag_no_nulls:    true,
-        flag_ignore_case: args.flag_ignore_case,
-        flag_jobs:        Some(util::njobs(args.flag_jobs)),
-        flag_output:      None,
-        flag_no_headers:  args.flag_no_headers,
-        flag_delimiter:   args.flag_delimiter,
-        flag_memcheck:    args.flag_memcheck,
+        arg_input:          args.arg_input.clone(),
+        flag_select:        crate::select::SelectColumns::parse(column_select_arg).unwrap(),
+        flag_limit:         args.flag_enum_threshold as isize,
+        flag_unq_limit:     args.flag_enum_threshold,
+        flag_lmt_threshold: 0,
+        flag_asc:           false,
+        flag_no_nulls:      true,
+        flag_ignore_case:   args.flag_ignore_case,
+        flag_jobs:          Some(util::njobs(args.flag_jobs)),
+        flag_output:        None,
+        flag_no_headers:    args.flag_no_headers,
+        flag_delimiter:     args.flag_delimiter,
+        flag_memcheck:      args.flag_memcheck,
     };
 
     let (headers, ftables) = match freq_args.rconfig().indexed()? {

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -144,6 +144,37 @@ fn frequency_negative_limit() {
 }
 
 #[test]
+fn frequency_limit_threshold() {
+    let (wrk, mut cmd) = setup("frequency_limit_threshold");
+    cmd.args(["--limit", "-4"]).args(["--lmt-threshold", "4"]);
+
+    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    got.sort();
+    let expected = vec![svec!["field", "value", "count"], svec!["h1", "a", "4"]];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn frequency_limit_threshold_notmet() {
+    let (wrk, mut cmd) = setup("frequency_limit_threshold_notmet");
+    cmd.args(["--limit", "-2"]).args(["--lmt-threshold", "3"]);
+
+    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    got.sort();
+    let expected = vec![
+        svec!["field", "value", "count"],
+        svec!["h1", "(NULL)", "1"],
+        svec!["h1", "(NULL)", "1"],
+        svec!["h1", "a", "4"],
+        svec!["h1", "b", "1"],
+        svec!["h2", "Y", "1"],
+        svec!["h2", "x", "1"],
+        svec!["h2", "y", "2"],
+        svec!["h2", "z", "3"],
+    ];
+    assert_eq!(got, expected);
+}
+#[test]
 fn frequency_asc() {
     let (wrk, mut cmd) = setup("frequency_asc");
     cmd.args(["--select", "h2"]).arg("--asc");


### PR DESCRIPTION
The --lmt-threshold option allows you to apply the --limit and --unq-limit options only when the number of unique items in a column is greater than or equal to the threshold. This is useful when you want to apply limits only to columns with a large number of unique items and not to columns with a small number of unique items.