### PR TITLE
contrib(bashly): update completions.bash for qsv v0.127.0

### DIFF
--- a/contrib/bashly/completions.bash
+++ b/contrib/bashly/completions.bash
@@ -197,7 +197,7 @@ _qsv_completions() {
       ;;
 
     *'frequency'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--asc --delimiter --help --ignore-case --jobs --limit --lmt-threshold --memcheck --no-headers --no-nulls --output --select --unq-limit -h")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--asc --delimiter --help --ignore-case --jobs --limit --lmt-threshold --memcheck --no-headers --no-nulls --other-sorted --other-text --output --pct-dec-places --select --unq-limit -h")" -- "$cur" )
       ;;
 
     *'partition'*)

--- a/contrib/bashly/src/bashly.yml
+++ b/contrib/bashly/src/bashly.yml
@@ -1,6 +1,6 @@
 name: qsv
 # name: qsv.exe # Windows
-version: 0.126.0
+version: 0.127.0
 
 flags:
     - long: --list

--- a/contrib/bashly/src/bashly.yml
+++ b/contrib/bashly/src/bashly.yml
@@ -582,6 +582,11 @@ commands:
             arg: arg
           - long: --lmt-threshold
             arg: arg
+          - long: --pct-dec-places
+            arg: arg
+          - long: --other-sorted
+          - long: --other-text
+            arg: arg
           - long: --asc
           - long: --no-nulls
           - long: --ignore-case


### PR DESCRIPTION
Updates `contrib/bashly/completions.bash` and `contrib/bashly/bashly.yml` for qsv v0.127.0 (adds `qsv frequency` options).