### PR TITLE
`stats`: add `--cache-threshold` autoindex creation/deletion  logic

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -145,8 +145,10 @@ stats options:
                               Set to 0 to suppress caching. 
                               Set to 1 to force caching.
                               Set to a negative number to automatically create an index
-                              when the input file size is greater than abs(arg) in bytes
-                              AND to force caching.
+                              when the input file size is greater than abs(arg) in bytes.
+                              If the negative number ends with 5, it will delete the index
+                              file and the stats cache file after the stats run. Otherwise,
+                              the index file and the cache files are kept.
                               [default: 5000]
 
 Common options:
@@ -379,6 +381,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut compute_stats = true;
     let mut create_cache = args.flag_cache_threshold > 0 || args.flag_stats_binout;
+    let mut autoindex_set = false;
 
     let write_stats_binout = args.flag_stats_binout;
 
@@ -484,8 +487,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
             // check if flag_cache_threshold is a negative number,
             // if so, set the autoindex_size to absolute of the number
-            if args.flag_cache_threshold < 0 {
+            if args.flag_cache_threshold.is_negative() {
                 fconfig.autoindex_size = args.flag_cache_threshold.unsigned_abs() as u64;
+                autoindex_set = true;
             }
 
             // we need to count the number of records in the file to calculate sparsity
@@ -544,7 +548,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     // ensure create_cache is also true if the user specified --cache-threshold 1
-    create_cache = create_cache || args.flag_cache_threshold == 1 || args.flag_cache_threshold < 0;
+    create_cache =
+        create_cache || args.flag_cache_threshold == 1 || args.flag_cache_threshold.is_negative();
 
     wtr.flush()?;
 
@@ -582,6 +587,20 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         if currstats_filename != stats_pathbuf.to_str().unwrap() {
             // if the stats file is not the same as the input file, copy it
             fs::copy(currstats_filename.clone(), stats_pathbuf.clone())?;
+        }
+
+        if args.flag_cache_threshold.is_negative() && args.flag_cache_threshold % 10 == -5 {
+            // if the cache threshold is a negative number ending in 5,
+            // delete both the index file and the stats cache file
+            if autoindex_set {
+                let index_file = path.with_extension("csv.idx");
+                log::debug!("deleting index file: {}", index_file.display());
+                if std::fs::remove_file(index_file.clone()).is_err() {
+                    // fails silently if it can't remove the index file
+                    log::warn!("Could not remove index file: {}", index_file.display());
+                }
+            }
+            create_cache = false;
         }
 
         if !create_cache {

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,26 +72,26 @@ impl<'de> Deserialize<'de> for Delimiter {
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub path:          Option<PathBuf>, // None implies <stdin>
-    idx_path:          Option<PathBuf>,
-    select_columns:    Option<SelectColumns>,
-    delimiter:         u8,
-    pub no_headers:    bool,
-    pub flexible:      bool,
-    terminator:        csv::Terminator,
-    pub quote:         u8,
-    quote_style:       csv::QuoteStyle,
-    double_quote:      bool,
-    escape:            Option<u8>,
-    quoting:           bool,
-    pub preamble_rows: u64,
-    trim:              csv::Trim,
-    autoindex_size:    u64,
-    prefer_dmy:        bool,
-    pub comment:       Option<u8>,
-    snappy:            bool, // flag to enable snappy compression/decompression
-    pub read_buffer:   u32,
-    pub write_buffer:  u32,
+    pub path:           Option<PathBuf>, // None implies <stdin>
+    idx_path:           Option<PathBuf>,
+    select_columns:     Option<SelectColumns>,
+    delimiter:          u8,
+    pub no_headers:     bool,
+    pub flexible:       bool,
+    terminator:         csv::Terminator,
+    pub quote:          u8,
+    quote_style:        csv::QuoteStyle,
+    double_quote:       bool,
+    escape:             Option<u8>,
+    quoting:            bool,
+    pub preamble_rows:  u64,
+    trim:               csv::Trim,
+    pub autoindex_size: u64,
+    prefer_dmy:         bool,
+    pub comment:        Option<u8>,
+    snappy:             bool, // flag to enable snappy compression/decompression
+    pub read_buffer:    u32,
+    pub write_buffer:   u32,
 }
 
 // Empty trait as an alias for Seek and Read that avoids auto trait errors

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -896,11 +896,86 @@ fn stats_cache() {
     cmd.arg("--infer-dates")
         .arg("--dates-whitelist")
         .arg("all")
-        // set cache threshold to 1 byte to force cache creation
+        // set cache threshold to 1 to force cache creation
         .args(["--cache-threshold", "1"])
         .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    wrk.create("in2.csv", got);
+
+    // removed variance & stddev columns as its causing flaky CI test for float values
+    let mut cmd = wrk.command("select");
+    cmd.arg("1-9,12-").arg("in2.csv");
+
+    let got2: String = wrk.stdout(&mut cmd);
+    let expected2 = wrk.load_test_resource("boston311-100-stats.csv");
+
+    assert_eq!(dos2unix(&got2), dos2unix(&expected2).trim_end());
+
+    // check that the stats cache files were created
+    assert!(Path::new(&wrk.path("boston311-100.stats.csv")).exists());
+    assert!(Path::new(&wrk.path("boston311-100.stats.csv.json")).exists());
+}
+
+#[test]
+fn stats_cache_negative_threshold() {
+    use std::path::Path;
+
+    let wrk = Workdir::new("stats_cache_negative_threshold");
+    let test_file = wrk.load_test_file("boston311-100.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-dates")
+        .arg("--dates-whitelist")
+        .arg("all")
+        // set cache threshold to -10240 to set autoindex_size to 10 kb
+        // and to force cache creation
+        .args(["-c", "-10240"])
+        .arg(test_file.clone());
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    // the index file SHOULD have been created as the input file size > 10 kb
+    assert!(Path::new(&format!("{test_file}.idx")).exists());
+    // assert!(Path::new(&format!("{test_file}.idx")).exists());
+
+    wrk.create("in2.csv", got);
+
+    // removed variance & stddev columns as its causing flaky CI test for float values
+    let mut cmd = wrk.command("select");
+    cmd.arg("1-9,12-").arg("in2.csv");
+
+    let got2: String = wrk.stdout(&mut cmd);
+    let expected2 = wrk.load_test_resource("boston311-100-stats.csv");
+
+    assert_eq!(dos2unix(&got2), dos2unix(&expected2).trim_end());
+
+    // check that the stats cache files were created
+    assert!(Path::new(&wrk.path("boston311-100.stats.csv")).exists());
+    assert!(Path::new(&wrk.path("boston311-100.stats.csv.json")).exists());
+}
+
+#[test]
+fn stats_cache_negative_threshold_unmet() {
+    use std::path::Path;
+
+    let wrk = Workdir::new("stats_cache_negative_threshold_unmet");
+    let test_file = wrk.load_test_file("boston311-100.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-dates")
+        .arg("--dates-whitelist")
+        .arg("all")
+        // set cache threshold to -51200 to set autoindex_size to 50 kb
+        // and to force cache creation
+        .args(["--cache-threshold", "-51200"])
+        .arg(test_file.clone());
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    // the index file SHOULD NOT have been created as the input file < 50 kb
+    assert!(!Path::new(&format!("{test_file}.idx")).exists());
 
     wrk.create("in2.csv", got);
 


### PR DESCRIPTION
As `stats` runs much faster with an index as it enables multithreading, when `--cache-threshold` is negative, it enables autoindex creation when the input's size is greater than the absolute value of the `--cache-threshold` argument in bytes.

However, some users may not want the index file to hang around after computing stats, so when the `--cache-threshold` negative arg ends with a 5, `stats` now also auto-deletes the index file it auto-created.