### PR TITLE
`search`: add `--not-one` flag for not using exit code 1 when no match

### DIFF
--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -57,6 +57,7 @@ search options:
                            JSON array. If --no-headers is set, then
                            the keys are the column indices (zero-based).
                            Automatically sets --quiet.
+    --not-one              Use exit code 0 instead of 1 for no match found.
                            
 Common options:
     -h, --help             Display this message
@@ -98,6 +99,7 @@ struct Args {
     flag_size_limit:     usize,
     flag_dfa_size_limit: usize,
     flag_json:           bool,
+    flag_not_one:        bool,
     flag_quick:          bool,
     flag_preview_match:  Option<u64>,
     flag_count:          bool,
@@ -133,6 +135,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let flag_quiet = args.flag_quiet || args.flag_json;
     let flag_json = args.flag_json;
     let flag_no_headers = args.flag_no_headers;
+    let flag_not_one = args.flag_not_one;
 
     let mut rdr = rconfig.reader()?;
     let mut wtr = Config::new(&args.flag_output).writer()?;
@@ -404,7 +407,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         info!("matches: {match_ctr}");
     }
 
-    if match_ctr == 0 {
+    if match_ctr == 0 && !flag_not_one {
         return Err(CliError::NoMatch());
     } else if args.flag_quick {
         if !args.flag_quiet {

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -8,7 +8,7 @@ The columns to search can be limited with the '--select' flag (but the full row
 is still written to the output if there is a match).
 
 Returns exitcode 0 when matches are found, returning number of matches to stderr.
-Returns exitcode 1 when no match is found.
+Returns exitcode 1 when no match is found, unless the '--not-one' flag is used.
 
 When --quick is enabled, no output is produced and exitcode 0 is returned on 
 the first match.


### PR DESCRIPTION
Allows a user to keep using exit code 0 even if there are no matches.

## Example

Say I have a file `data.csv`:

```csv
Name,Department,Salary,Phone
,IT,71000,
Alice Johnson,HR,65000,294-203-0222
Bob Anderson,IT,71000,
Jane Smith,Finance,75000,
John Doe,IT,60000,850-240-4924
```

Now I want to search a value but it doesn't exist:

```bash
qsv search 'Jake' data.csv
```

We'll get the headers back (so no matches):

```csv
Name,Department,Salary,Phone
```

And when we run:

```bash
echo $?
```

The value returned is the exit code, in this case `1`. But by using `--not-one` we get `0`.