### PR TITLE
`docs`: cross-reference `split` & `partition` commands

### DIFF
--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -1,5 +1,8 @@
 static USAGE: &str = r#"
-Partitions the given CSV data into chunks based on the value of a column
+Partitions the given CSV data into chunks based on the value of a column.
+
+See `split` command to split a CSV data by row count, by number of chunks or
+by kb-size.
 
 The files are written to the output directory with filenames based on the
 values in the partition column and the `--filename` flag.

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -2,6 +2,8 @@ static USAGE: &str = r#"
 Splits the given CSV data into chunks. It has three modes: by size (rowcount),
 by number of chunks and by kb-size.
 
+See `partition` command for splitting by a column value.
+
 When splitting by size, the CSV data is split into chunks of the given number of
 rows. The last chunk may have fewer rows if the number of records is not evenly
 divisible by the given rowcount.


### PR DESCRIPTION

[skip ci]