### PR TITLE
`luau`: update vendored LuaDate library from 2.2.0 to 2.2.1

### DIFF
--- a/resources/luau/vendor/README.md
+++ b/resources/luau/vendor/README.md
@@ -1,0 +1,3 @@
+As date manipulation is an oft-used feature in many applications, qsv vendors the `LuaDate` library at https://github.com/Tieske/date. This library provides a comprehensive set of date manipulation functions in the `luau` command.
+
+See https://tieske.github.io/date/ for more information.

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -106,8 +106,8 @@ SPECIAL VARIABLES:
 
 For security and safety reasons as a purpose-built embeddable interpreter,
 Luau's standard library is relatively minimal (https://luau-lang.org/library).
-That's why qsv preloads the LuaDate library as date manipulation is a common task.
-See https://tieske.github.io/date/#date-id96473 on how to use the LuaDate library.
+That's why qsv bundles & preloads LuaDate v2.2.1 as date manipulation is a common task.
+See https://tieske.github.io/date/ on how to use the LuaDate library.
 
 Additional libraries can be loaded from the LUAU_PATH using luau's "require" function.
 See https://github.com/LewisJEllis/awesome-lua for a list of other libraries.


### PR DESCRIPTION
- also added README
- updated `luau` usage text