### PR TITLE
foreach: add sample Windows implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -1158,7 +1158,7 @@ checksum = "622892f5635ce1fc38c8f16dfc938553ed64af482edb5e150bf4caedbfcb2304"
 dependencies = [
  "libc",
  "num_cpus",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "parking_lot 0.12.3",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1359,7 +1359,7 @@ dependencies = [
  "pdatastructs",
  "petgraph",
  "postgres",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rusqlite",
  "serde_json",
@@ -1923,7 +1923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1933,8 +1933,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -2107,6 +2113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,7 +2161,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -2651,6 +2666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "kiddo"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +2894,17 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "local-waker",
+]
+
+[[package]]
+name = "local-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
+dependencies = [
+ "kernel32-sys",
+ "skeptic",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -3171,7 +3207,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3181,7 +3217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3378,7 +3414,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3420,7 +3456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3457,7 +3493,7 @@ dependencies = [
  "bytecount",
  "fixedbitset",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3520,7 +3556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3530,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3742,7 +3778,7 @@ dependencies = [
  "polars-error",
  "polars-row",
  "polars-utils",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rayon",
  "regex",
@@ -3998,7 +4034,7 @@ dependencies = [
  "polars-error",
  "polars-lazy",
  "polars-plan",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sqlparser",
@@ -4077,7 +4113,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -4208,6 +4244,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
+dependencies = [
+ "getopts",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,6 +4365,7 @@ dependencies = [
  "jemallocator",
  "jql-runner",
  "jsonschema",
+ "local-encoding",
  "localzone",
  "log",
  "mimalloc",
@@ -4339,7 +4385,7 @@ dependencies = [
  "qsv_currency",
  "qsv_docopt",
  "quickcheck",
- "rand",
+ "rand 0.8.5",
  "rand_hc",
  "rand_xoshiro",
  "rayon",
@@ -4452,7 +4498,7 @@ dependencies = [
  "raw-cpuid",
  "wasi",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4480,7 +4526,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4511,13 +4557,26 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4527,8 +4586,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4546,7 +4620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4555,7 +4629,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4564,7 +4638,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4600,6 +4674,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4731,6 +4814,15 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "rend"
@@ -4885,7 +4977,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -5226,7 +5318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5282,6 +5374,16 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "skeptic"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ebf8a06f5f8bae61ae5bbc7af7aac4ef6907ae975130faba1199e5fe82256a"
+dependencies = [
+ "pulldown-cmark",
+ "tempdir",
+]
 
 [[package]]
 name = "slab"
@@ -5416,7 +5518,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5616,6 +5718,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5786,7 +5898,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "socket2",
  "tokio",
  "tokio-util",
@@ -6306,6 +6418,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -6313,6 +6431,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ uuid = { version = "1", features = ["v4"] }
 url = "2.5"
 vader_sentiment = { version = "0.1", optional = true }
 whatlang = { version = "0.16", optional = true }
+local-encoding = { version = "0.2.0", optional = true }
 
 [target.'cfg(not(target_arch = "aarch64"))'.dependencies]
 simdutf8    = "0.1"
@@ -294,7 +295,7 @@ fetch = [
     "serde_urlencoded",
     "simple-expand-tilde",
 ]
-foreach = []
+foreach = ["local-encoding"]
 geocode = [
     "anyhow",
     "cached",

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -32,7 +32,7 @@ pub mod fixlengths;
 pub mod flatten;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 pub mod fmt;
-#[cfg(all(feature = "foreach", target_family = "unix", not(feature = "lite")))]
+#[cfg(all(feature = "foreach", not(feature = "lite")))]
 pub mod foreach;
 pub mod frequency;
 #[cfg(all(feature = "geocode", feature = "feature_capable"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,7 +342,7 @@ enum Command {
     FixLengths,
     Flatten,
     Fmt,
-    #[cfg(all(feature = "foreach", target_family = "unix", not(feature = "lite")))]
+    #[cfg(all(feature = "foreach", not(feature = "lite")))]
     ForEach,
     Frequency,
     #[cfg(all(feature = "geocode", feature = "feature_capable"))]
@@ -422,7 +422,7 @@ impl Command {
             Command::Fetch => cmd::fetch::run(argv),
             #[cfg(all(feature = "fetch", feature = "feature_capable"))]
             Command::FetchPost => cmd::fetchpost::run(argv),
-            #[cfg(all(feature = "foreach", target_family = "unix", not(feature = "lite")))]
+            #[cfg(all(feature = "foreach", not(feature = "lite")))]
             Command::ForEach => cmd::foreach::run(argv),
             Command::Fill => cmd::fill::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),

--- a/tests/test_foreach.rs
+++ b/tests/test_foreach.rs
@@ -1,7 +1,7 @@
-#![cfg(target_family = "unix")]
 use crate::workdir::Workdir;
 
 #[test]
+#[cfg(target_family = "unix")]
 fn foreach() {
     let wrk = Workdir::new("foreach");
     wrk.create(
@@ -36,6 +36,7 @@ echo NAME = Mary"#;
 }
 
 #[test]
+#[cfg(target_family = "unix")]
 fn foreach_multiple_braces() {
     let wrk = Workdir::new("foreach");
     wrk.create(
@@ -76,6 +77,7 @@ echo NAME = Mary, Mary, Mary"#;
 }
 
 #[test]
+#[cfg(target_family = "unix")]
 fn foreach_special_chars_1171() {
     let wrk = Workdir::new("foreach_special_chars");
     wrk.create(
@@ -133,6 +135,7 @@ echo dig +short https://civic-data-ecosystem.github.io a"#;
 }
 
 #[test]
+#[cfg(target_family = "unix")]
 fn foreach_unify() {
     let wrk = Workdir::new("foreach_unify");
     wrk.create(
@@ -156,6 +159,7 @@ fn foreach_unify() {
 }
 
 #[test]
+#[cfg(target_family = "unix")]
 fn foreach_new_column() {
     let wrk = Workdir::new("foreach_nc");
     wrk.create(
@@ -181,6 +185,7 @@ fn foreach_new_column() {
 }
 
 #[test]
+#[cfg(target_family = "unix")]
 fn foreach_multiple_commands_with_shell_script() {
     let wrk = Workdir::new("foreach_multiple_commands_with_shell_script");
     wrk.create(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -64,7 +64,7 @@ mod test_fixlengths;
 mod test_flatten;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 mod test_fmt;
-#[cfg(all(feature = "foreach", target_family = "unix"))]
+#[cfg(all(feature = "foreach"))]
 mod test_foreach;
 mod test_frequency;
 #[cfg(all(feature = "feature_capable", feature = "geocode"))]


### PR DESCRIPTION
This is a proof of concept implementation for #1736, attempting to use `foreach` on Windows (preferred use with Git Bash).

![qsv-foreach-windows-poc-demo](https://github.com/jqnatividad/qsv/assets/30333942/b1635678-6c49-4301-aee2-05447c5ed3d3)

- There may need to be more changes for better usage with default terminals like cmd and powershell (though they are possible to try using within the command parameter of `foreach`). Therefore a recommendation to use Git Bash is provided.
- Some tests are also set to unix-only to allow tests to pass but they can be improved with conditional compilation (e.g., `rev` isn't available on Windows so an alternative could be considered).
- The code could also be refactored such as the multiple conditional checks for Windows being used (e.g., using [cfg-if](https://github.com/rust-lang/cfg-if)).
- Perhaps there's a way to remove the `local-encoding` crate used for this implementation and also making `local-encoding` a Windows-only dependency.
- Not sure if `Cargo.lock` is in its expected state.

Feel free to improve it further.