### PR TITLE
`deps`: we now track py-polars release, instead of rust-polars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 [[package]]
 name = "polars"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "getrandom",
  "polars-arrow",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "atoi",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "polars-compute"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "bytemuck",
  "either",
@@ -3724,7 +3724,7 @@ dependencies = [
 [[package]]
 name = "polars-core"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "polars-error"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "avro-schema",
  "polars-arrow-format",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "polars-expr"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "polars-io"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "polars-json"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "chrono",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "polars-lazy"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "polars-ops"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "argminmax",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "polars-parquet"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "async-stream",
@@ -3925,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "polars-pipe"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "polars-plan"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "bytemuck",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "polars-row"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "bytemuck",
  "polars-arrow",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "polars-sql"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "hex",
  "once_cell",
@@ -4008,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "polars-time"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "atoi",
  "bytemuck",
@@ -4028,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "polars-utils"
 version = "0.40.0"
-source = "git+https://github.com/pola-rs/polars?rev=d7b4f72#d7b4f7232aeb17c28785f2c052d32b203605a3c1"
+source = "git+https://github.com/pola-rs/polars?tag=py-0.20.31#318ec405632410a41f634de7aeff46e89a25eab9"
 dependencies = [
  "ahash 0.8.11",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,9 +249,10 @@ dynfmt = { git = "https://github.com/jqnatividad/dynfmt", branch = "2021-clippy_
 grex = { git = "https://github.com/pemistahl/grex", rev = "0c8ab87" }
 # calamine 0.25.0 with unreleased fixes
 calamine = { git = "https://github.com/tafia/calamine", rev = "6b41309" }
-# polars 0.40.0 with unreleased fixes
-polars     = { git = "https://github.com/pola-rs/polars", rev = "d7b4f72" }
-polars-ops = { git = "https://github.com/pola-rs/polars", rev = "d7b4f72" }
+# latest Rust polars with unreleased fixes
+# we track Python polars which has a much faster release cycle than Rust polars
+polars     = { git = "https://github.com/pola-rs/polars", tag = "py-0.20.31" }
+polars-ops = { git = "https://github.com/pola-rs/polars", tag = "py-0.20.31" }
 
 [features]
 default = ["mimalloc"]

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -6,9 +6,11 @@ Polars SQL is a SQL dialect, converting SQL queries to fast Polars LazyFrame exp
 (see https://docs.pola.rs/user-guide/sql/intro/).
 
 For a list of SQL functions and keywords supported by Polars SQL, see
-https://github.com/pola-rs/polars/blob/rs-0.40.0/crates/polars-sql/src/functions.rs
-https://github.com/pola-rs/polars/blob/rs-0.40.0/crates/polars-sql/src/keywords.rs and
-https://github.com/pola-rs/polars/issues/7227
+https://github.com/pola-rs/polars/blob/rs-0.40.0/crates/polars-sql/src/functions.rs and
+https://github.com/pola-rs/polars/blob/rs-0.40.0/crates/polars-sql/src/keywords.rs.
+https://docs.pola.rs/py-polars/html/reference/sql/index.html also provides a more readable
+version of the SQL functions and keywords, though be aware that it's for the Python version
+of Polars, so there will be some minor syntax differences.
 
 Returns the shape of the query result (number of rows, number of columns) to stderr.
 

--- a/tests/test_sqlp.rs
+++ b/tests/test_sqlp.rs
@@ -95,24 +95,24 @@ sqlp_test!(
         cmd.arg("select * from cities full outer join places on cities.city = places.city");
         let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
         let expected1 = vec![
-            svec!["city", "state", "city_right", "place"],
+            svec!["city", "state", "city:places", "place"],
             svec!["Boston", "MA", "Boston", "Logan Airport"],
             svec!["Boston", "MA", "Boston", "Boston Garden"],
             svec!["Buffalo", "NY", "Buffalo", "Ralph Wilson Stadium"],
             svec!["", "", "Orlando", "Disney World"],
-            svec!["San Francisco", "CA", "", ""],
             svec!["New York", "NY", "", ""],
+            svec!["San Francisco", "CA", "", ""],
         ];
         let expected2 = vec![
-            svec!["city", "state", "city_right", "place"],
+            svec!["city", "state", "city:places", "place"],
             svec!["Boston", "MA", "Boston", "Logan Airport"],
             svec!["Boston", "MA", "Boston", "Boston Garden"],
             svec!["Buffalo", "NY", "Buffalo", "Ralph Wilson Stadium"],
             svec!["", "", "Orlando", "Disney World"],
-            svec!["New York", "NY", "", ""],
             svec!["San Francisco", "CA", "", ""],
+            svec!["New York", "NY", "", ""],
         ];
-        // assert!(got == expected1 || got == expected2);
+        assert!(got == expected1 || got == expected2);
     }
 );
 


### PR DESCRIPTION
as py-polars has a much faster release cycle.