### PR TITLE
`select`: use underscore char (_) to indicate last column, replacing 9999 sentinel value

### DIFF
--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -21,11 +21,11 @@ selected using regular expressions.
   Select the third column named 'Foo':
   $ qsv select 'Foo[2]'
 
-  Select the first and last columns, 9999 is a special index for the last column:
-  $ qsv select 1,9999
+  Select the first and last columns, _ is a special character for the last column:
+  $ qsv select 1,_
 
   Reverse the order of columns:
-  $ qsv select 9999-1
+  $ qsv select _-1
 
   Sort the columns lexicographically. Note that you must provide a dummy selector:
   $ qsv select 1 --sort

--- a/src/select.rs
+++ b/src/select.rs
@@ -157,6 +157,10 @@ impl SelectorParser {
             self.bump();
             self.parse_quoted_name()?
         } else {
+            if self.cur() == Some('_') {
+                self.bump();
+                return Ok(OneSelector::End);
+            }
             self.parse_name()
         };
         Ok(if self.cur() == Some('[') {
@@ -318,13 +322,9 @@ impl OneSelector {
             } else {
                 first_record.len() - 1
             }),
-            OneSelector::Index(mut i) => {
+            OneSelector::Index(i) => {
                 if first_record.is_empty() {
                     return fail!("Input is empty.");
-                }
-                // 9999 is a sentinel value that means "last column".
-                if i == 9999 {
-                    i = first_record.len();
                 }
                 if i < 1 || i > first_record.len() {
                     fail_format!(

--- a/tests/test_select.rs
+++ b/tests/test_select.rs
@@ -180,7 +180,7 @@ select_test!(
 
 select_test!(
     select_reverse_sentinel,
-    r#"9999-1"#,
+    r#"_-1"#,
     "5-1",
     ["h1", "h4", "h[]3", "h2", "h1"],
     ["e", "d", "c", "b", "a"]


### PR DESCRIPTION
First installment to implementing #1871 