### PR TITLE
`contrib(fish)`: add fish completions prototype with `qsv.fish` and docs

### DIFF
--- a/contrib/fish/README.md
+++ b/contrib/fish/README.md
@@ -2,7 +2,14 @@
 
 The `contrib/fish/qsv.fish` file is available for fish shell completions.
 
-> Currently the completions are incomplete and can be improved so feel free to contribute.
+## Contributing
+
+Currently the completions are incomplete, may differ per qsv version (e.g., may be outdated), and can be improved so feel free to contribute.
+
+Here are some external docs:
+
+-   https://fishshell.com/docs/current/completions.html#writing-your-own-completions
+-   https://fishshell.com/docs/current/cmds/complete.html#complete-edit-command-specific-tab-completions
 
 ## Usage
 

--- a/contrib/fish/README.md
+++ b/contrib/fish/README.md
@@ -1,0 +1,9 @@
+# qsv fish completions
+
+The `contrib/fish/qsv.fish` file is available for fish shell completions.
+
+> Currently the completions are incomplete and can be improved so feel free to contribute.
+
+## Usage
+
+Download the `qsv.fish` file and move it to `~/.config/fish/completions/` (e.g., using the `mv` command) so that you have a file `~/.config/fish/completions/qsv.fish` available. Then launch the fish shell and the completions should be available (tried this on WSL2 Ubuntu). You can modify the file, save it, then relaunch the fish shell for the updated completions.

--- a/contrib/fish/qsv.fish
+++ b/contrib/fish/qsv.fish
@@ -1,0 +1,61 @@
+# Set all available subcommands for qsv
+set -l qsv_commands apply applydp behead cat count datefmt dedup describegpt diff enum excel exclude explode extdedup extsort fetch fetchpost fill fixlengths flatten fmt frequency geocode headers index input join joinp jsonl jsonp luau partition prompt pseudo py rename replace reverse safenames sample schema search searchset select slice snappy sniff sort sortcheck split sqlp stats table to tojsonl transpose validate
+
+# Enable completions for qsv
+complete -c qsv
+
+# qsv options
+complete -c qsv -n "not __fish_seen_subcommand_from $qsv_commands" -l list -d 'List all commands available'
+complete -c qsv -n "not __fish_seen_subcommand_from $qsv_commands" -l envlist -d 'List all qsv-relevant environment variables'
+complete -c qsv -n "not __fish_seen_subcommand_from $qsv_commands" -s u -l update -d 'Update qsv to the latest release from GitHub'
+complete -c qsv -n "not __fish_seen_subcommand_from $qsv_commands" -s U -l updatenow -d 'Update qsv to the latest release from GitHub without confirming'
+complete -c qsv -n "not __fish_seen_subcommand_from $qsv_commands" -s v -l version -d 'Print version info, mem allocator, features installed, max_jobs, num_cpus, build info then exit'
+
+# If no subcommands are provided yet, show subcommands
+complete -c qsv \
+    -n "not __fish_seen_subcommand_from $qsv_commands" -f -a "$qsv_commands"
+
+# qsv apply
+set -l apply_subcommands operations emptyreplace dynfmt calcconv
+complete -c qsv -n "__fish_seen_subcommand_from apply" -n "not __fish_seen_subcommand_from $apply_subcommands" -f -a "$apply_subcommands"
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l new-column
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l rename
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l comparand
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l replacement
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l formatstr
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l jobs
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l batch
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l output
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l no-headers
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l delimiter
+complete -c qsv -n "__fish_seen_subcommand_from apply" -l progressbar
+
+# qsv count
+complete -c qsv -n "__fish_seen_subcommand_from count" -s H -l human-readable -d 'Comma separate row count'
+complete -c qsv -n "__fish_seen_subcommand_from count" -l width
+complete -c qsv -n "__fish_seen_subcommand_from count" -l flexible
+complete -c qsv -n "__fish_seen_subcommand_from count" -l no-headers
+
+# qsv stats
+complete -c qsv -n "__fish_seen_subcommand_from stats" -xl select
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l everything
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l typesonly
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l infer-boolean
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l mode
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l cardinality
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l median
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l mad
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l quartiles
+complete -c qsv -n "__fish_seen_subcommand_from stats" -xl round
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l nulls
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l infer-dates
+complete -c qsv -n "__fish_seen_subcommand_from stats" -xl dates-whitelist
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l prefer-dmy
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l force
+complete -c qsv -n "__fish_seen_subcommand_from stats" -xl jobs
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l stats-binout
+complete -c qsv -n "__fish_seen_subcommand_from stats" -xl cache-threshold
+complete -c qsv -n "__fish_seen_subcommand_from stats" -rl output
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l no-headers
+complete -c qsv -n "__fish_seen_subcommand_from stats" -xl delimiter
+complete -c qsv -n "__fish_seen_subcommand_from stats" -l memcheck


### PR DESCRIPTION
Per #1690, a sample `qsv.fish` file is provided in `contrib/fish/` with docs (`contrib/fish/README.md`).

![qsv-fish-default-options-demo](https://github.com/jqnatividad/qsv/assets/30333942/00d6f59f-6389-474a-81fc-ea92a6780d49)

![qsv-fish-demo](https://github.com/jqnatividad/qsv/assets/30333942/f80bc748-e6a0-4c9e-87ff-56e4b97e2de5)

The completions are incomplete but serve as a foundation that may be improved/added to with completions available for the default qsv options and the following subcommands: `qsv stats`, `qsv count`, and `qsv apply` (these can also potentially be improved, such as not allowing reuse of an option).

An example of a small description for `qsv count -H` or `qsv count --human-readable` is provided which groups the short and long flags, however without a description they may be separate so only long flags for commands have been added aside from these two flags (similar to the Bashly completions).