### PR TITLE
contrib(bashly): add `--hash <columns>` option to `enum`

### DIFF
--- a/contrib/bashly/completions.bash
+++ b/contrib/bashly/completions.bash
@@ -405,7 +405,7 @@ _qsv_completions() {
       ;;
 
     *'enum'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--constant --copy --delimiter --help --increment --new-column --no-headers --output --start --uuid -h")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--constant --copy --delimiter --hash --help --increment --new-column --no-headers --output --start --uuid -h")" -- "$cur" )
       ;;
 
     *'cat'*)

--- a/contrib/bashly/src/bashly.yml
+++ b/contrib/bashly/src/bashly.yml
@@ -301,6 +301,8 @@ commands:
           - long: --copy
             arg: column
           - long: --uuid
+          - long: --hash
+            arg: columns
           - *output
           - *no-headers
           - *delimiter


### PR DESCRIPTION
Adds `--hash <columns>` option for `qsv enum` to Bash completions in `contrib/bashly`.