### PR TITLE
`enum`: add `--uuid7` option to create UUID v7 identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4790f9e8961209112beb783d85449b508673cf4a6a419c8449b210743ac4dbe9"
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,7 +1261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "crossterm",
- "strum 0.26.3",
+ "strum 0.26.2",
  "strum_macros 0.26.4",
  "unicode-width",
 ]
@@ -4812,7 +4821,7 @@ dependencies = [
  "smartstring",
  "snap",
  "strsim",
- "strum 0.26.3",
+ "strum 0.26.2",
  "strum_macros 0.26.4",
  "sysinfo",
  "tabwriter",
@@ -6029,9 +6038,9 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
  "phf 0.10.1",
 ]
@@ -6655,6 +6664,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ea73390fe27785838dcbf75b91b1d84799e28f1ce71e6f372a5dc2200c80de5"
 dependencies = [
+ "atomic",
  "getrandom",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ thousands = { version = "0.2", optional = true }
 threadpool = "1.8"
 titlecase = { version = "3", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread"] }
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "v7"] }
 url = "2.5"
 vader_sentiment = { version = "0.1", optional = true }
 whatlang = { version = "0.16", optional = true }

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -31,7 +31,7 @@ The enum function has four modes of operation:
 
   Finally, note that you should also be able to shuffle the lines of a CSV file
   by sorting on the generated uuids:
-    $ qsv enum --uuid file.csv | qsv sort -s uuid > shuffled.csv
+    $ qsv enum --uuid4 file.csv | qsv sort -s uuid > shuffled.csv
 
 Usage:
     qsv enum [options] [<input>]


### PR DESCRIPTION
which are time-based and monotonically increasing now that the `uuid` v1.9.0 guarantees

```rust
let a = Uuid::now_v7();
let b = Uuid::now_v7();

assert!(a < b);
```

https://github.com/uuid-rs/uuid/releases/tag/1.9.0
https://buildkite.com/blog/goodbye-integers-hello-uuids
https://datatracker.ietf.org/doc/rfc9562/