### PR TITLE
contrib(bashly): add `--uuid4` & `--uuid4` for `qsv enum`

### DIFF
--- a/contrib/bashly/completions.bash
+++ b/contrib/bashly/completions.bash
@@ -405,7 +405,7 @@ _qsv_completions() {
       ;;
 
     *'enum'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--constant --copy --delimiter --hash --help --increment --new-column --no-headers --output --start --uuid -h")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--constant --copy --delimiter --hash --help --increment --new-column --no-headers --output --start --uuid4 --uuid7 -h")" -- "$cur" )
       ;;
 
     *'cat'*)

--- a/contrib/bashly/src/bashly.yml
+++ b/contrib/bashly/src/bashly.yml
@@ -300,7 +300,8 @@ commands:
             arg: value
           - long: --copy
             arg: column
-          - long: --uuid
+          - long: --uuid4
+          - long: --uuid7
           - long: --hash
             arg: columns
           - *output


### PR DESCRIPTION
Adds `--uuid4` and `--uuid7` to bash completions for `qsv enum`.

![qsv-enum-uuid-demo](https://github.com/jqnatividad/qsv/assets/30333942/22ed1f56-d51c-4fbe-82b9-ec5caf2d86dd)
