### PR TITLE
`json`: remove necessity for `polars` feature & fix `--list` formatting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,8 +143,8 @@ fn main() -> QsvExitCode {
 
     enabled_commands.push_str("    jsonl       Convert newline-delimited JSON files to CSV\n");
 
-    #[cfg(all(feature = "polars", feature = "feature_capable"))]
-    enabled_commands.push_str("    json       Convert non-nested JSON to CSV\n");
+    #[cfg(feature = "feature_capable")]
+    enabled_commands.push_str("    json        Convert non-nested JSON to CSV\n");
 
     #[cfg(all(feature = "luau", feature = "feature_capable"))]
     enabled_commands.push_str("    luau        Execute Luau script on CSV data\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,10 +141,10 @@ fn main() -> QsvExitCode {
     #[cfg(all(feature = "polars", feature = "feature_capable"))]
     enabled_commands.push_str("    joinp       Join CSV files using the Pola.rs engine\n");
 
-    enabled_commands.push_str("    jsonl       Convert newline-delimited JSON files to CSV\n");
-
-    #[cfg(feature = "feature_capable")]
-    enabled_commands.push_str("    json        Convert non-nested JSON to CSV\n");
+    enabled_commands.push_str(
+        "    json        Convert non-nested JSON to CSV
+    jsonl       Convert newline-delimited JSON files to CSV\n",
+    );
 
     #[cfg(all(feature = "luau", feature = "feature_capable"))]
     enabled_commands.push_str("    luau        Execute Luau script on CSV data\n");


### PR DESCRIPTION
Removes necessity to have `polars` as an enabled feature for `qsv json` and fixes `--list` formatting by adding a space and putting `json` before `jsonl`.