### PR TITLE
`describegpt`: remove `--ollama` since Ollama v0.1.49 has endpoints

### DIFF
--- a/docs/Describegpt.md
+++ b/docs/Describegpt.md
@@ -119,7 +119,6 @@ Here is an example of a prompt:
     "json": true,
     "jsonl": false,
     "base_url": "https://api.openai.com/v1",
-    "ollama": false,
     "model": "gpt-3.5-turbo-16k",
     "timeout": 60
 }
@@ -127,16 +126,14 @@ Here is an example of a prompt:
 
 Note that this example has `tokens` set to `50` by default but you may want to increase this value to not result in errors as mentioned in the [`--json`](#json) & [`--max-tokens`](#max-tokens-value) section.
 
-## `--ollama`
+## Running LLMs locally with Ollama
 
-This is a required flag for when you're using the Ollama API, so make sure you pass it when using Ollama as your server. This is due to Ollama's API not being 1-1 compatible with the OpenAI API specification (particularly the `/models` endpoint may not be implemented yet, see https://github.com/ollama/ollama/issues/2430).
-
-You may find the Ollama OpenAI compatibility documentation here: https://github.com/ollama/ollama/blob/main/docs/openai.md.
+Since the release of Ollama v0.149.0, Ollama provides the necessary OpenAI compatible endpoints to work with describegpt. You may find the Ollama OpenAI compatibility documentation here: https://github.com/ollama/ollama/blob/main/docs/openai.md.
 
 An example command for getting an inferred description is as follows:
 
 ```bash
-qsv describegpt <filepath> --ollama --base-url http://localhost:11434 --api-key ollama --model <model> --max-tokens <number> --description
+qsv describegpt <filepath> --base-url http://localhost:11434/v1 --api-key ollama --model <model> --max-tokens <number> --description
 ```
 
 Remove the arrow brackets `<>` and replace `filepath` with your file's path, `<model>` with the model you want to use, and `number` with the max tokens you want to set based on your model's context size.

--- a/docs/Describegpt.md
+++ b/docs/Describegpt.md
@@ -128,7 +128,7 @@ Note that this example has `tokens` set to `50` by default but you may want to i
 
 ## Running LLMs locally with Ollama
 
-Since the release of Ollama v0.149.0, Ollama provides the necessary OpenAI compatible endpoints to work with describegpt. You may find the Ollama OpenAI compatibility documentation here: https://github.com/ollama/ollama/blob/main/docs/openai.md.
+Since the release of Ollama v0.1.49, Ollama provides the necessary OpenAI compatible endpoints to work with describegpt. You may find the Ollama OpenAI compatibility documentation here: https://github.com/ollama/ollama/blob/main/docs/openai.md.
 
 An example command for getting an inferred description is as follows:
 

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -4,7 +4,7 @@ Infers extended metadata about a CSV using a large language model.
 Note that this command uses LLMs for inferencing and is therefore prone to
 inaccurate information being produced. Verify output results before using them.
 
-Let's say you have Ollama installed (must be v0.149.0 or above) to run LLMs locally.
+Let's say you have Ollama installed (must be v0.1.49 or above) to use LLMs locally with qsv describegpt.
 To attempt generating a data dictionary of a spreadsheet file you may run (replace <> values):
 
 qsv describegpt <filepath> --base-url http://localhost:11434/v1 --api-key ollama --model <model> --max-tokens <number> --dictionary


### PR DESCRIPTION
Once Ollama v0.1.49 is released, the [/v1/chat/completions](https://github.com/ollama/ollama/pull/2376) and more recently [/v1/models](https://github.com/ollama/ollama/pull/5007) endpoints should be available which then makes Ollama have the necessary OpenAI API compatible endpoints to not need a `--ollama` flag passed when using Ollama with qsv describegpt. The common base URL used with Ollama should therefore be `http://localhost:11434/v1`.

Tested with local debug version of qsvlite using Ollama v0.1.49-rc8.

Other future ideas:

- Include a `--ollama` flag for ease of use that sets `--base-url http://localhost:11434/v1` and `--api-key ollama`.
- Explore other available features including streaming mode, JSON mode, config, etc.