### PR TITLE
`contrib(bashly)`: remove `--ollama` from `qsv describegpt`

### DIFF
--- a/contrib/bashly/completions.bash
+++ b/contrib/bashly/completions.bash
@@ -149,7 +149,7 @@ _qsv_completions() {
       ;;
 
     *'describegpt'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--all --api-key --base-url --description --dictionary --help --json --jsonl --max-tokens --model --ollama --output --prompt --prompt-file --quiet --tags --timeout --user-agent -h")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_qsv_completions_filter "--all --api-key --base-url --description --dictionary --help --json --jsonl --max-tokens --model --output --prompt --prompt-file --quiet --tags --timeout --user-agent -h")" -- "$cur" )
       ;;
 
     *'cat'*'columns'*)

--- a/contrib/bashly/src/bashly.yml
+++ b/contrib/bashly/src/bashly.yml
@@ -251,7 +251,6 @@ commands:
                 - <file>
           - long: --base-url
             arg: url
-          - long: --ollama
           - long: --model
             arg: model
           - long: --timeout


### PR DESCRIPTION
Removes Bash completion for the `--ollama` flag from `qsv describegpt` due to #1946.