### PR TITLE
`describegpt`: change min Ollama version from 0.1.49 to 0.2.0

### DIFF
--- a/docs/Describegpt.md
+++ b/docs/Describegpt.md
@@ -128,7 +128,7 @@ Note that this example has `tokens` set to `50` by default but you may want to i
 
 ## Running LLMs locally with Ollama
 
-Since the release of Ollama v0.1.49, Ollama provides the necessary OpenAI compatible endpoints to work with describegpt. You may find the Ollama OpenAI compatibility documentation here: https://github.com/ollama/ollama/blob/main/docs/openai.md.
+Since the release of Ollama v0.2.0, Ollama provides the necessary OpenAI compatible endpoints to work with describegpt. You may find the Ollama OpenAI compatibility documentation here: https://github.com/ollama/ollama/blob/main/docs/openai.md.
 
 An example command for getting an inferred description is as follows:
 

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -4,7 +4,7 @@ Infers extended metadata about a CSV using a large language model.
 Note that this command uses LLMs for inferencing and is therefore prone to
 inaccurate information being produced. Verify output results before using them.
 
-Let's say you have Ollama installed (must be v0.1.49 or above) to use LLMs locally with qsv describegpt.
+Let's say you have Ollama installed (must be v0.2.0 or above) to use LLMs locally with qsv describegpt.
 To attempt generating a data dictionary of a spreadsheet file you may run (replace <> values):
 
 qsv describegpt <filepath> --base-url http://localhost:11434/v1 --api-key ollama --model <model> --max-tokens <number> --dictionary


### PR DESCRIPTION
Seems like Ollama’s next release is 0.2.0 and not 0.1.49, but still in prerelease as of now.