### PR TITLE
`json`: add support for single JSON object & add test

### DIFF
--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -1,8 +1,8 @@
 use crate::workdir::Workdir;
 
 #[test]
-fn json_simple() {
-    let wrk = Workdir::new("json_simple");
+fn json_array_simple() {
+    let wrk = Workdir::new("json_array_simple");
     wrk.create_from_string(
         "data.json",
         r#"[{"id":1,"father":"Mark","mother":"Charlotte","oldest_child":"Tom","boy":true},
@@ -18,6 +18,24 @@ fn json_simple() {
         svec!["1", "Mark", "Charlotte", "Tom", "true"],
         svec!["2", "John", "Ann", "Jessika", "false"],
         svec!["3", "Bob", "Monika", "Jerry", "true"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn json_object_simple() {
+    let wrk = Workdir::new("json_object_simple");
+    wrk.create_from_string(
+        "data.json",
+        r#"{"id":1,"father":"Mark","mother":"Charlotte","oldest_child":"Tom","boy":true}"#,
+    );
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["id", "father", "mother", "oldest_child", "boy"],
+        svec!["1", "Mark", "Charlotte", "Tom", "true"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
The expected usage has been with a JSON array (of objects) but didn't support a single JSON object. Also handling an empty first object in an array and an empty single object may be considered. This PR considers those options and errors on the empty cases (but potentially different behavior could be defined such as printing empty instead by returning `Ok(())` early, feel free to refactor if that's a more sensible default).

![image](https://github.com/jqnatividad/qsv/assets/30333942/106d5191-cc51-437c-a404-07cb92f44393)

Also added a test for the single JSON object and renamed the first test.