### PR TITLE
`json`: add empty single JSON object logic & empty tests

### DIFF
--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -131,6 +131,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .as_object()
             .ok_or_else(|| CliError::Other("Expected a JSON object".to_string()))?
     };
+    if first_dict.is_empty() {
+        return Err(CliError::Other(
+            "Expected a non-empty JSON object".to_string(),
+        ));
+    }
     let mut headers: Vec<&str> = Vec::new();
     for key in first_dict.keys() {
         headers.push(key.as_str());

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -49,6 +49,20 @@ fn json_array_first_object_empty() {
 }
 
 #[test]
+fn json_random() {
+    let wrk = Workdir::new("json_random");
+    wrk.create_from_string("data.json", "some random text");
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+
+    let got = wrk.output_stderr(&mut cmd);
+    let expected =
+        "Failed to parse JSON from file: expected value at line 1 column 1\n".to_string();
+
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn json_object_simple() {
     let wrk = Workdir::new("json_object_simple");
     wrk.create_from_string(

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -23,6 +23,32 @@ fn json_array_simple() {
 }
 
 #[test]
+fn json_array_empty() {
+    let wrk = Workdir::new("json_array_empty");
+    wrk.create_from_string("data.json", r#"[]"#);
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+
+    let got = wrk.output_stderr(&mut cmd);
+    let expected = "Expected an array of objects in JSON\n".to_string();
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn json_array_first_object_empty() {
+    let wrk = Workdir::new("json_array_first_object_empty");
+    wrk.create_from_string("data.json", r#"[{}]"#);
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+
+    let got = wrk.output_stderr(&mut cmd);
+    let expected = "Expected a non-empty JSON object\n".to_string();
+
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn json_object_simple() {
     let wrk = Workdir::new("json_object_simple");
     wrk.create_from_string(
@@ -37,6 +63,19 @@ fn json_object_simple() {
         svec!["id", "father", "mother", "oldest_child", "boy"],
         svec!["1", "Mark", "Charlotte", "Tom", "true"],
     ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn json_object_empty() {
+    let wrk = Workdir::new("json_object_empty");
+    wrk.create_from_string("data.json", r#"{}"#);
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+
+    let got = wrk.output_stderr(&mut cmd);
+    let expected = "Expected a non-empty JSON object\n".to_string();
+
     assert_eq!(got, expected);
 }
 


### PR DESCRIPTION
I think I somehow missed adding this snippet to check if the JSON object is empty. I also added tests for empty values and a random non-JSON value.