### PR TITLE
`validate`: return delimiter detected upon successful CSV validation

### DIFF
--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -284,7 +284,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     }
                     let field_list = field_vec.join(r#"", ""#);
                     header_msg = format!(
-                        "{} columns (\"{field_list}\") and ",
+                        "{} Columns: (\"{field_list}\");",
                         HumanCount(header_len as u64)
                     );
                 },
@@ -450,8 +450,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 serde_json::to_string(&rfc4180).unwrap()
             }
         } else {
+            let delim_display = if rconfig.get_delimiter() == b'\t' {
+                "TAB".to_string()
+            } else {
+                (rconfig.get_delimiter() as char).to_string()
+            };
             format!(
-                "Valid: {header_msg}{} records detected.",
+                "Valid: {header_msg} Records: {}; Delimiter: {delim_display}",
                 HumanCount(record_idx)
             )
         };

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -26,6 +26,11 @@ fn validate_good_tab() {
     cmd.arg(tabfile);
 
     wrk.assert_success(&mut cmd);
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected =
+        r#"Valid: 29 Columns: ("case_enquiry_id", "open_dt", "target_dt", "closed_dt", "ontime", "case_status", "closure_reason", "case_title", "subject", "reason", "type", "queue", "department", "submittedphoto", "closedphoto", "location", "fire_district", "pwd_district", "city_council_district", "police_district", "neighborhood", "neighborhood_services_district", "ward", "precinct", "location_street_name", "location_zipcode", "latitude", "longitude", "source"); Records: 100; Delimiter: TAB"#;
+    assert_eq!(got, expected);
 }
 
 #[test]
@@ -55,7 +60,7 @@ fn validate_good_csv_msg() {
 
     let got: String = wrk.stdout(&mut cmd);
     let expected =
-        r#"Valid: 3 columns ("title", "name", "real age (earth years)") and 3 records detected."#;
+        r#"Valid: 3 Columns: ("title", "name", "real age (earth years)"); Records: 3; Delimiter: ,"#;
     assert_eq!(got, expected);
 }
 
@@ -71,7 +76,7 @@ fn validate_empty_csv_msg() {
 
     let got: String = wrk.stdout(&mut cmd);
     let expected =
-        r#"Valid: 3 columns ("title", "name", "real age (earth years)") and 0 records detected."#;
+        r#"Valid: 3 Columns: ("title", "name", "real age (earth years)"); Records: 0; Delimiter: ,"#;
     assert_eq!(got, expected);
 }
 

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -28,8 +28,7 @@ fn validate_good_tab() {
     wrk.assert_success(&mut cmd);
 
     let got: String = wrk.stdout(&mut cmd);
-    let expected =
-        r#"Valid: 29 Columns: ("case_enquiry_id", "open_dt", "target_dt", "closed_dt", "ontime", "case_status", "closure_reason", "case_title", "subject", "reason", "type", "queue", "department", "submittedphoto", "closedphoto", "location", "fire_district", "pwd_district", "city_council_district", "police_district", "neighborhood", "neighborhood_services_district", "ward", "precinct", "location_street_name", "location_zipcode", "latitude", "longitude", "source"); Records: 100; Delimiter: TAB"#;
+    let expected = r#"Valid: 29 Columns: ("case_enquiry_id", "open_dt", "target_dt", "closed_dt", "ontime", "case_status", "closure_reason", "case_title", "subject", "reason", "type", "queue", "department", "submittedphoto", "closedphoto", "location", "fire_district", "pwd_district", "city_council_district", "police_district", "neighborhood", "neighborhood_services_district", "ward", "precinct", "location_street_name", "location_zipcode", "latitude", "longitude", "source"); Records: 100; Delimiter: TAB"#;
     assert_eq!(got, expected);
 }
 
@@ -59,8 +58,7 @@ fn validate_good_csv_msg() {
     cmd.arg("data.csv");
 
     let got: String = wrk.stdout(&mut cmd);
-    let expected =
-        r#"Valid: 3 Columns: ("title", "name", "real age (earth years)"); Records: 3; Delimiter: ,"#;
+    let expected = r#"Valid: 3 Columns: ("title", "name", "real age (earth years)"); Records: 3; Delimiter: ,"#;
     assert_eq!(got, expected);
 }
 
@@ -75,8 +73,7 @@ fn validate_empty_csv_msg() {
     cmd.arg("data.csv");
 
     let got: String = wrk.stdout(&mut cmd);
-    let expected =
-        r#"Valid: 3 Columns: ("title", "name", "real age (earth years)"); Records: 0; Delimiter: ,"#;
+    let expected = r#"Valid: 3 Columns: ("title", "name", "real age (earth years)"); Records: 0; Delimiter: ,"#;
     assert_eq!(got, expected);
 }
 


### PR DESCRIPTION
the --json options already do, do this for the non-json successful validation msg as well