### PR TITLE
`.ssv` (semicolon separated values) automatic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,11 @@ If you want to test your regular expressions, [regex101](https://regex101.com) s
 
 ## File formats
 
-qsv recognizes UTF-8/ASCII encoded, CSV (`.csv`) & TSV files (`.tsv` & `.tab`). CSV files are assumed to have "," (comma) as a delimiter,
+qsv recognizes UTF-8/ASCII encoded, CSV (`.csv`), SSV (`.ssv`) and TSV files (`.tsv` & `.tab`). CSV files are assumed to have "," (comma) as a delimiter, SSV files have ";" (semicolon) as a delimiter
 and TSV files, "\t" (tab) as a delimiter. The delimiter is a single ascii character that can be set either by the `--delimiter` command-line option or
 with the `QSV_DEFAULT_DELIMITER` environment variable or automatically detected when `QSV_SNIFF_DELIMITER` is set.
 
-When using the `--output` option, qsv will UTF-8 encode the file & automatically change the delimiter used in the generated file based on the file extension - i.e. comma for `.csv`, tab for `.tsv` & `.tab` files.
+When using the `--output` option, qsv will UTF-8 encode the file & automatically change the delimiter used in the generated file based on the file extension - i.e. comma for `.csv`, semicolon for `.ssv`, tab for `.tsv` & `.tab` files.
 
 [JSONL](https://jsonlines.org/)/[NDJSON](http://ndjson.org/) files are also recognized & converted to/from CSV with the [`jsonl`](/src/cmd/jsonl.rs#L11) and [`tojsonl`](/src/cmd/tojsonl.rs#L12) commands respectively.
 

--- a/src/cmd/joinp.rs
+++ b/src/cmd/joinp.rs
@@ -492,7 +492,7 @@ impl JoinStruct {
         let mut out_delim = self.delim;
         let mut out_writer = match self.output {
             Some(ref output_file) => {
-                out_delim = tsvtab_delim(output_file, self.delim);
+                out_delim = tsvssv_delim(output_file, self.delim);
 
                 // no need to use buffered writer here, as CsvWriter already does that
                 let path = Path::new(&output_file);
@@ -571,7 +571,7 @@ impl Args {
                 .with_has_header(true)
                 .with_missing_is_null(self.flag_nulls)
                 .with_comment_prefix(comment_char.as_deref())
-                .with_separator(tsvtab_delim(&self.arg_input1, delim))
+                .with_separator(tsvssv_delim(&self.arg_input1, delim))
                 .with_infer_schema_length(num_rows)
                 .with_try_parse_dates(try_parsedates)
                 .with_decimal_comma(self.flag_decimal_comma)
@@ -597,7 +597,7 @@ impl Args {
                 .with_has_header(true)
                 .with_missing_is_null(self.flag_nulls)
                 .with_comment_prefix(comment_char.as_deref())
-                .with_separator(tsvtab_delim(&self.arg_input2, delim))
+                .with_separator(tsvssv_delim(&self.arg_input2, delim))
                 .with_infer_schema_length(num_rows)
                 .with_try_parse_dates(try_parsedates)
                 .with_decimal_comma(self.flag_decimal_comma)
@@ -637,7 +637,7 @@ impl Args {
 
 /// if the file has a TSV or TAB extension, we automatically use tab as the delimiter
 /// otherwise, we use the delimiter specified by the user
-pub fn tsvtab_delim<P: AsRef<Path>>(file: P, orig_delim: u8) -> u8 {
+pub fn tsvssv_delim<P: AsRef<Path>>(file: P, orig_delim: u8) -> u8 {
     let inputfile_extension = file
         .as_ref()
         .extension()
@@ -648,6 +648,8 @@ pub fn tsvtab_delim<P: AsRef<Path>>(file: P, orig_delim: u8) -> u8 {
         || inputfile_extension.eq_ignore_ascii_case("tab")
     {
         b'\t'
+    } else if inputfile_extension.eq_ignore_ascii_case("ssv") {
+        b';'
     } else {
         orig_delim
     }

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -27,7 +27,7 @@ prompt options:
                            When using --fd-output, the default is "Save File As".
     -F, --filters <arg>    The filter to use for the INPUT file dialog. Set to "None" to
                            disable filters. Filters are comma-delimited file extensions.
-                           [default: csv,tsv,tab,xls,xlsx,ods]
+                           [default: csv,tsv,tab,ssv,xls,xlsx,ods]
     -d, --workdir <dir>    The directory to start the file dialog in.
                            [default: .]
     -f, --fd-output        Write output to a file by using a save file dialog.

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -273,7 +273,7 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::{
-    cmd::joinp::tsvtab_delim,
+    cmd::joinp::tsvssv_delim,
     config::{Config, Delimiter, DEFAULT_WTR_BUFFER_CAPACITY},
     util,
     util::process_input,
@@ -345,7 +345,7 @@ impl OutputMode {
 
             let w = match args.flag_output {
                 Some(path) => {
-                    delim = tsvtab_delim(path.clone(), delim);
+                    delim = tsvssv_delim(path.clone(), delim);
                     Box::new(File::create(path)?) as Box<dyn Write>
                 },
                 None => Box::new(io::stdout()) as Box<dyn Write>,
@@ -745,7 +745,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 .with_missing_is_null(true)
                 .with_comment_prefix(comment_char.as_deref())
                 .with_null_values(Some(NullValues::AllColumns(rnull_values.clone())))
-                .with_separator(tsvtab_delim(table, delim))
+                .with_separator(tsvssv_delim(table, delim))
                 .with_infer_schema_length(Some(args.flag_infer_len))
                 .with_try_parse_dates(args.flag_try_parsedates)
                 .with_ignore_errors(args.flag_ignore_errors)

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,8 @@ impl Config {
                 let mut snappy = false;
                 let delim = if file_extension == "tsv" || file_extension == "tab" {
                     b'\t'
+                } else if file_extension == "ssv" {
+                    b';'
                 } else if file_extension == "csv" {
                     b','
                 } else {
@@ -144,6 +146,9 @@ impl Config {
                     } else if filename.ends_with(".tsv.sz") || filename.ends_with(".tab.sz") {
                         snappy = true;
                         b'\t'
+                    } else if filename.ends_with(".ssv.sz") {
+                        snappy = true;
+                        b';'
                     } else {
                         default_delim
                     }

--- a/tests/test_count.rs
+++ b/tests/test_count.rs
@@ -56,6 +56,29 @@ fn count_simple_tsv() {
 }
 
 #[test]
+fn count_simple_ssv() {
+    let wrk = Workdir::new("count_simple_ssv");
+    wrk.create_with_delim(
+        "in.ssv",
+        vec![
+            svec!["letter", "number"],
+            svec!["alpha", "13"],
+            svec!["beta", "24"],
+            svec!["gamma", "37"],
+        ],
+        b';',
+    );
+
+    let mut cmd = wrk.command("count");
+    cmd.arg("in.ssv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "3";
+
+    assert_eq!(got, expected.to_string());
+}
+
+#[test]
 fn count_simple_custom_delimiter() {
     let wrk = Workdir::new("count_simple_custom_delimiter");
     wrk.create_with_delim(

--- a/tests/test_sqlp.rs
+++ b/tests/test_sqlp.rs
@@ -1369,6 +1369,37 @@ fn sqlp_sql_tsv() {
 }
 
 #[test]
+fn sqlp_sql_ssv() {
+    let wrk = Workdir::new("sqlp_sql_ssv");
+    wrk.create(
+        "test.csv",
+        vec![
+            svec!["idx", "val"],
+            svec!["0", "ABC"],
+            svec!["1", "abc"],
+            svec!["2", "000"],
+            svec!["3", "A0C"],
+            svec!["4", "a0c"],
+        ],
+    );
+
+    let output_file = wrk.path("output.ssv").to_string_lossy().to_string();
+
+    let mut cmd = wrk.command("sqlp");
+    cmd.arg("test.csv")
+        .arg("SELECT * FROM test")
+        .args(["--output", &output_file]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got = wrk.read_to_string(&output_file);
+
+    let expected = "idx;val\n0;ABC\n1;abc\n2;000\n3;A0C\n4;a0c\n";
+
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn sqlp_binary_functions() {
     let wrk = Workdir::new("sqlp_sql_binary_functions");
     wrk.create("dummy.csv", vec![svec!["dummy"], svec!["0"]]);

--- a/tests/test_table.rs
+++ b/tests/test_table.rs
@@ -40,6 +40,19 @@ fn table_tsv() {
 }
 
 #[test]
+fn table_ssv() {
+    let wrk = Workdir::new("table");
+    wrk.create_with_delim("in.ssv", data(), b';');
+
+    let mut cmd = wrk.command("table");
+    cmd.env("QSV_DEFAULT_DELIMITER", ";");
+    cmd.arg("in.ssv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(&*got, EXPECTED_TABLE)
+}
+
+#[test]
 fn table_default() {
     let wrk = Workdir::new("table");
     wrk.create_with_delim("in.file", data(), b'\t');


### PR DESCRIPTION
similar to `.csv`, `.tsv` & `.tab`, we autoset the delimiter to `;` if the input/output file has an `.ssv` extension.