### PR TITLE
`contrib(completions)`: add `--select` for `json`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -2156,7 +2156,7 @@ _qsv() {
             return 0
             ;;
         qsv__json)
-            opts="-h --jaq --output --help"
+            opts="-h --jaq --select --output --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -570,6 +570,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
         }
         &'qsv;json'= {
             cand --jaq 'jaq'
+            cand --select 'select'
             cand --output 'output'
             cand -h 'Print help'
             cand --help 'Print help'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -1275,6 +1275,9 @@ const completion: Fig.Spec = {
           name: "--jaq",
         },
         {
+          name: "--select",
+        },
+        {
           name: "--output",
         },
         {

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -443,6 +443,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand joinp" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand joinp" -l quiet
 complete -c qsv -n "__fish_qsv_using_subcommand joinp" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand json" -l jaq
+complete -c qsv -n "__fish_qsv_using_subcommand json" -l select
 complete -c qsv -n "__fish_qsv_using_subcommand json" -l output
 complete -c qsv -n "__fish_qsv_using_subcommand json" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand jsonl" -l ignore-errors

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -491,6 +491,7 @@ module completions {
 
   export extern "qsv json" [
     --jaq
+    --select
     --output
     --help(-h)                # Print help
   ]

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -621,6 +621,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         }
         'qsv;json' {
             [CompletionResult]::new('--jaq', 'jaq', [CompletionResultType]::ParameterName, 'jaq')
+            [CompletionResult]::new('--select', 'select', [CompletionResultType]::ParameterName, 'select')
             [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'output')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -641,6 +641,7 @@ _arguments "${_arguments_options[@]}" : \
 (json)
 _arguments "${_arguments_options[@]}" : \
 '--jaq[]' \
+'--select[]' \
 '--output[]' \
 '-h[Print help]' \
 '--help[Print help]' \

--- a/contrib/completions/src/cmd/json.rs
+++ b/contrib/completions/src/cmd/json.rs
@@ -1,5 +1,5 @@
 use clap::{arg, Command};
 
 pub fn json_cmd() -> Command {
-    Command::new("json").args([arg!(--jaq), arg!(--output)])
+    Command::new("json").args([arg!(--jaq), arg!(--select), arg!(--output)])
 }


### PR DESCRIPTION
Adds `--select` for `qsv json` to the completions.