### PR TITLE
`searchset`: add `--not-one` flag

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -2352,7 +2352,7 @@ _qsv() {
             return 0
             ;;
         qsv__searchset)
-            opts="-h --ignore-case --select --invert-match --unicode --flag --flag-matches-only --unmatched-output --quick --count --json --size-limit --dfa-size-limit --output --no-headers --delimiter --progressbar --quiet --help"
+            opts="-h --ignore-case --select --invert-match --unicode --flag --flag-matches-only --unmatched-output --quick --count --json --not-one --size-limit --dfa-size-limit --output --no-headers --delimiter --progressbar --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -739,6 +739,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --quick 'quick'
             cand --count 'count'
             cand --json 'json'
+            cand --not-one 'not-one'
             cand --size-limit 'size-limit'
             cand --dfa-size-limit 'dfa-size-limit'
             cand --output 'output'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -1740,6 +1740,9 @@ const completion: Fig.Spec = {
           name: "--json",
         },
         {
+          name: "--not-one",
+        },
+        {
           name: "--size-limit",
         },
         {

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -570,6 +570,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l unmatched-output
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l quick
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l count
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l json
+complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l not-one
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l size-limit
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l dfa-size-limit
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l output

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -660,6 +660,7 @@ module completions {
     --quick
     --count
     --json
+    --not-one
     --size-limit
     --dfa-size-limit
     --output

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -804,6 +804,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             [CompletionResult]::new('--quick', 'quick', [CompletionResultType]::ParameterName, 'quick')
             [CompletionResult]::new('--count', 'count', [CompletionResultType]::ParameterName, 'count')
             [CompletionResult]::new('--json', 'json', [CompletionResultType]::ParameterName, 'json')
+            [CompletionResult]::new('--not-one', 'not-one', [CompletionResultType]::ParameterName, 'not-one')
             [CompletionResult]::new('--size-limit', 'size-limit', [CompletionResultType]::ParameterName, 'size-limit')
             [CompletionResult]::new('--dfa-size-limit', 'dfa-size-limit', [CompletionResultType]::ParameterName, 'dfa-size-limit')
             [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'output')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -838,6 +838,7 @@ _arguments "${_arguments_options[@]}" : \
 '--quick[]' \
 '--count[]' \
 '--json[]' \
+'--not-one[]' \
 '--size-limit[]' \
 '--dfa-size-limit[]' \
 '--output[]' \

--- a/contrib/completions/src/cmd/searchset.rs
+++ b/contrib/completions/src/cmd/searchset.rs
@@ -12,6 +12,7 @@ pub fn searchset_cmd() -> Command {
         arg!(--quick),
         arg!(--count),
         arg!(--json),
+        arg!(--"not-one"),
         arg!(--"size-limit"),
         arg!(--"dfa-size-limit"),
         arg!(--output),

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -14,7 +14,7 @@ The columns to search can be limited with the '--select' flag (but the full row
 is still written to the output if there is a match).
 
 Returns exitcode 0 when matches are found, returning number of matches to stderr.
-Returns exitcode 1 when no match is found.
+Returns exitcode 1 when no match is found, unless the '--not-one' flag is used.
 
 When --quick is enabled, no output is produced and exitcode 0 is returned on 
 the first match.
@@ -62,6 +62,7 @@ search options:
                                expression engine's Discrete Finite Automata.
                                Modify this only if you're getting regular expression
                                compilation errors. [default: 10]
+    --not-one                  Use exit code 0 instead of 1 for no match found.
 
 Common options:
     -h, --help                 Display this message
@@ -113,6 +114,7 @@ struct Args {
     flag_quick:             bool,
     flag_count:             bool,
     flag_json:              bool,
+    flag_not_one:           bool,
     flag_progressbar:       bool,
     flag_quiet:             bool,
 }
@@ -129,6 +131,7 @@ fn read_regexset(filename: &String) -> io::Result<Vec<String>> {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
+    let flag_not_one = args.flag_not_one;
 
     if args.flag_flag.is_none() && args.flag_flag_matches_only {
         return fail_incorrectusage_clierror!("Cannot use --flag-matches-only without --flag",);
@@ -318,7 +321,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             info!("matches: {match_row_ctr}");
         }
 
-        if match_row_ctr == 0 {
+        if match_row_ctr == 0 && !flag_not_one {
             return Err(CliError::NoMatch());
         } else if args.flag_quick {
             if !args.flag_quiet {


### PR DESCRIPTION
Adds a `--not-one` flag to `qsv searchset` similar to the `--not-one` flag in `qsv search`.