### PR TITLE
`contrib(completions)`: add `--just-count` for `headers`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -1092,7 +1092,7 @@ _qsv() {
             return 0
             ;;
         qsv__headers)
-            opts="-h --just-names --intersect --trim --delimiter --help"
+            opts="-h --just-names --just-count --intersect --trim --delimiter --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -490,6 +490,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
         }
         &'qsv;headers'= {
             cand --just-names 'just-names'
+            cand --just-count 'just-count'
             cand --intersect 'intersect'
             cand --trim 'trim'
             cand --delimiter 'delimiter'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -1050,6 +1050,9 @@ const completion: Fig.Spec = {
           name: "--just-names",
         },
         {
+          name: "--just-count",
+        },
+        {
           name: "--intersect",
         },
         {

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -378,6 +378,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand geocode" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand geocode" -l progressbar
 complete -c qsv -n "__fish_qsv_using_subcommand geocode" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand headers" -l just-names
+complete -c qsv -n "__fish_qsv_using_subcommand headers" -l just-count
 complete -c qsv -n "__fish_qsv_using_subcommand headers" -l intersect
 complete -c qsv -n "__fish_qsv_using_subcommand headers" -l trim
 complete -c qsv -n "__fish_qsv_using_subcommand headers" -l delimiter

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -411,6 +411,7 @@ module completions {
 
   export extern "qsv headers" [
     --just-names
+    --just-count
     --intersect
     --trim
     --delimiter

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -536,6 +536,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         }
         'qsv;headers' {
             [CompletionResult]::new('--just-names', 'just-names', [CompletionResultType]::ParameterName, 'just-names')
+            [CompletionResult]::new('--just-count', 'just-count', [CompletionResultType]::ParameterName, 'just-count')
             [CompletionResult]::new('--intersect', 'intersect', [CompletionResultType]::ParameterName, 'intersect')
             [CompletionResult]::new('--trim', 'trim', [CompletionResultType]::ParameterName, 'trim')
             [CompletionResult]::new('--delimiter', 'delimiter', [CompletionResultType]::ParameterName, 'delimiter')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -551,6 +551,7 @@ _arguments "${_arguments_options[@]}" : \
 (headers)
 _arguments "${_arguments_options[@]}" : \
 '--just-names[]' \
+'--just-count[]' \
 '--intersect[]' \
 '--trim[]' \
 '--delimiter[]' \

--- a/contrib/completions/src/cmd/headers.rs
+++ b/contrib/completions/src/cmd/headers.rs
@@ -3,6 +3,7 @@ use clap::{arg, Command};
 pub fn headers_cmd() -> Command {
     Command::new("headers").args([
         arg!(--"just-names"),
+        arg!(--"just-count"),
         arg!(--intersect),
         arg!(--trim),
         arg!(--delimiter),


### PR DESCRIPTION
Adds completion for the `--just-count` flag for `qsv headers`.