### PR TITLE
`contrib(completions)`: add `--literal` for `search` and `searchset`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -2338,7 +2338,7 @@ _qsv() {
             return 0
             ;;
         qsv__search)
-            opts="-h --ignore-case --select --invert-match --unicode --flag --quick --preview-match --count --size-limit --dfa-size-limit --json --not-one --output --no-headers --delimiter --progressbar --quiet --help"
+            opts="-h --ignore-case --literal --select --invert-match --unicode --flag --quick --preview-match --count --size-limit --dfa-size-limit --json --not-one --output --no-headers --delimiter --progressbar --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2352,7 +2352,7 @@ _qsv() {
             return 0
             ;;
         qsv__searchset)
-            opts="-h --ignore-case --select --invert-match --unicode --flag --flag-matches-only --unmatched-output --quick --count --json --not-one --size-limit --dfa-size-limit --output --no-headers --delimiter --progressbar --quiet --help"
+            opts="-h --ignore-case --literal --select --invert-match --unicode --flag --flag-matches-only --unmatched-output --quick --count --json --not-one --size-limit --dfa-size-limit --output --no-headers --delimiter --progressbar --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -712,6 +712,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
         }
         &'qsv;search'= {
             cand --ignore-case 'ignore-case'
+            cand --literal 'literal'
             cand --select 'select'
             cand --invert-match 'invert-match'
             cand --unicode 'unicode'
@@ -733,6 +734,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
         }
         &'qsv;searchset'= {
             cand --ignore-case 'ignore-case'
+            cand --literal 'literal'
             cand --select 'select'
             cand --invert-match 'invert-match'
             cand --unicode 'unicode'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -1662,6 +1662,9 @@ const completion: Fig.Spec = {
           name: "--ignore-case",
         },
         {
+          name: "--literal",
+        },
+        {
           name: "--select",
         },
         {
@@ -1720,6 +1723,9 @@ const completion: Fig.Spec = {
       options: [
         {
           name: "--ignore-case",
+        },
+        {
+          name: "--literal",
         },
         {
           name: "--select",

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -546,6 +546,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand schema" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand schema" -l memcheck
 complete -c qsv -n "__fish_qsv_using_subcommand schema" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand search" -l ignore-case
+complete -c qsv -n "__fish_qsv_using_subcommand search" -l literal
 complete -c qsv -n "__fish_qsv_using_subcommand search" -l select
 complete -c qsv -n "__fish_qsv_using_subcommand search" -l invert-match
 complete -c qsv -n "__fish_qsv_using_subcommand search" -l unicode
@@ -564,6 +565,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand search" -l progressbar
 complete -c qsv -n "__fish_qsv_using_subcommand search" -l quiet
 complete -c qsv -n "__fish_qsv_using_subcommand search" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l ignore-case
+complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l literal
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l select
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l invert-match
 complete -c qsv -n "__fish_qsv_using_subcommand searchset" -l unicode

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -633,6 +633,7 @@ module completions {
 
   export extern "qsv search" [
     --ignore-case
+    --literal
     --select
     --invert-match
     --unicode
@@ -654,6 +655,7 @@ module completions {
 
   export extern "qsv searchset" [
     --ignore-case
+    --literal
     --select
     --invert-match
     --unicode

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -776,6 +776,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         }
         'qsv;search' {
             [CompletionResult]::new('--ignore-case', 'ignore-case', [CompletionResultType]::ParameterName, 'ignore-case')
+            [CompletionResult]::new('--literal', 'literal', [CompletionResultType]::ParameterName, 'literal')
             [CompletionResult]::new('--select', 'select', [CompletionResultType]::ParameterName, 'select')
             [CompletionResult]::new('--invert-match', 'invert-match', [CompletionResultType]::ParameterName, 'invert-match')
             [CompletionResult]::new('--unicode', 'unicode', [CompletionResultType]::ParameterName, 'unicode')
@@ -798,6 +799,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         }
         'qsv;searchset' {
             [CompletionResult]::new('--ignore-case', 'ignore-case', [CompletionResultType]::ParameterName, 'ignore-case')
+            [CompletionResult]::new('--literal', 'literal', [CompletionResultType]::ParameterName, 'literal')
             [CompletionResult]::new('--select', 'select', [CompletionResultType]::ParameterName, 'select')
             [CompletionResult]::new('--invert-match', 'invert-match', [CompletionResultType]::ParameterName, 'invert-match')
             [CompletionResult]::new('--unicode', 'unicode', [CompletionResultType]::ParameterName, 'unicode')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -809,6 +809,7 @@ _arguments "${_arguments_options[@]}" : \
 (search)
 _arguments "${_arguments_options[@]}" : \
 '--ignore-case[]' \
+'--literal[]' \
 '--select[]' \
 '--invert-match[]' \
 '--unicode[]' \
@@ -832,6 +833,7 @@ _arguments "${_arguments_options[@]}" : \
 (searchset)
 _arguments "${_arguments_options[@]}" : \
 '--ignore-case[]' \
+'--literal[]' \
 '--select[]' \
 '--invert-match[]' \
 '--unicode[]' \

--- a/contrib/completions/src/cmd/search.rs
+++ b/contrib/completions/src/cmd/search.rs
@@ -3,6 +3,7 @@ use clap::{arg, Command};
 pub fn search_cmd() -> Command {
     Command::new("search").args([
         arg!(--"ignore-case"),
+        arg!(--literal),
         arg!(--select),
         arg!(--"invert-match"),
         arg!(--unicode),

--- a/contrib/completions/src/cmd/searchset.rs
+++ b/contrib/completions/src/cmd/searchset.rs
@@ -3,6 +3,7 @@ use clap::{arg, Command};
 pub fn searchset_cmd() -> Command {
     Command::new("searchset").args([
         arg!(--"ignore-case"),
+        arg!(--literal),
         arg!(--select),
         arg!(--"invert-match"),
         arg!(--unicode),


### PR DESCRIPTION
Adds the `--literal` flag to `qsv search` and `qsv searchset` in qsv completions.