### PR TITLE
`contrib(completions)`: add `--literal` completion to `replace`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -2268,7 +2268,7 @@ _qsv() {
             return 0
             ;;
         qsv__replace)
-            opts="-h --ignore-case --select --unicode --size-limit --dfa-size-limit --output --no-headers --delimiter --progressbar --quiet --help"
+            opts="-h --ignore-case --literal --select --unicode --size-limit --dfa-size-limit --output --no-headers --delimiter --progressbar --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -654,6 +654,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
         }
         &'qsv;replace'= {
             cand --ignore-case 'ignore-case'
+            cand --literal 'literal'
             cand --select 'select'
             cand --unicode 'unicode'
             cand --size-limit 'size-limit'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -1503,6 +1503,9 @@ const completion: Fig.Spec = {
           name: "--ignore-case",
         },
         {
+          name: "--literal",
+        },
+        {
           name: "--select",
         },
         {

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -503,6 +503,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand rename" -l no-headers
 complete -c qsv -n "__fish_qsv_using_subcommand rename" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand rename" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand replace" -l ignore-case
+complete -c qsv -n "__fish_qsv_using_subcommand replace" -l literal
 complete -c qsv -n "__fish_qsv_using_subcommand replace" -l select
 complete -c qsv -n "__fish_qsv_using_subcommand replace" -l unicode
 complete -c qsv -n "__fish_qsv_using_subcommand replace" -l size-limit

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -575,6 +575,7 @@ module completions {
 
   export extern "qsv replace" [
     --ignore-case
+    --literal
     --select
     --unicode
     --size-limit

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -713,6 +713,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         }
         'qsv;replace' {
             [CompletionResult]::new('--ignore-case', 'ignore-case', [CompletionResultType]::ParameterName, 'ignore-case')
+            [CompletionResult]::new('--literal', 'literal', [CompletionResultType]::ParameterName, 'literal')
             [CompletionResult]::new('--select', 'select', [CompletionResultType]::ParameterName, 'select')
             [CompletionResult]::new('--unicode', 'unicode', [CompletionResultType]::ParameterName, 'unicode')
             [CompletionResult]::new('--size-limit', 'size-limit', [CompletionResultType]::ParameterName, 'size-limit')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -741,6 +741,7 @@ _arguments "${_arguments_options[@]}" : \
 (replace)
 _arguments "${_arguments_options[@]}" : \
 '--ignore-case[]' \
+'--literal[]' \
 '--select[]' \
 '--unicode[]' \
 '--size-limit[]' \

--- a/contrib/completions/src/cmd/replace.rs
+++ b/contrib/completions/src/cmd/replace.rs
@@ -3,6 +3,7 @@ use clap::{arg, Command};
 pub fn replace_cmd() -> Command {
     Command::new("replace").args([
         arg!(--"ignore-case"),
+        arg!(--literal),
         arg!(--select),
         arg!(--unicode),
         arg!(--"size-limit"),


### PR DESCRIPTION
Adds `--literal` flag to `replace` in qsv completions.