### PR TITLE
`docs`: fix completions for `--stats-jsonl` and qsv pro installation text update

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@
 ## Installation Options
 
 ### Option 0: TLDR Quick Install
-[qsv pro](https://qsvpro.dathere.com) will be available in the App Stores soon (Microsoft is currently reviewing v1.0 for Windows; Apple App Store for v2.0)! In the meantime, you can quickly install qsv using these package manager one-liners[^1]:
+[qsv pro](https://qsvpro.dathere.com) is already available for download from its website, and is also planned for availability within the Microsoft Store and Apple App Store at later dates! In the meantime, you can quickly install qsv using these package manager one-liners[^1]:
 
 [^1]: Option 0 is actually a quick-start version of Option 2. Of course, the package manager has to be installed first.  
 

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -929,7 +929,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --prefer-dmy 'prefer-dmy'
             cand --force 'force'
             cand --jobs 'jobs'
-            cand --stats-jsonl 'stats-binout'
+            cand --stats-jsonl 'stats-jsonl'
             cand --cache-threshold 'cache-threshold'
             cand --output 'output'
             cand --no-headers 'no-headers'

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -709,7 +709,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand stats" -l infer-dates
 complete -c qsv -n "__fish_qsv_using_subcommand stats" -l prefer-dmy
 complete -c qsv -n "__fish_qsv_using_subcommand stats" -l force
 complete -c qsv -n "__fish_qsv_using_subcommand stats" -l jobs
-complete -c qsv -n "__fish_qsv_using_subcommand stats" -l stats-binout
+complete -c qsv -n "__fish_qsv_using_subcommand stats" -l stats-jsonl
 complete -c qsv -n "__fish_qsv_using_subcommand stats" -l cache-threshold
 complete -c qsv -n "__fish_qsv_using_subcommand stats" -l output
 complete -c qsv -n "__fish_qsv_using_subcommand stats" -l no-headers

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -1013,7 +1013,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             [CompletionResult]::new('--prefer-dmy', 'prefer-dmy', [CompletionResultType]::ParameterName, 'prefer-dmy')
             [CompletionResult]::new('--force', 'force', [CompletionResultType]::ParameterName, 'force')
             [CompletionResult]::new('--jobs', 'jobs', [CompletionResultType]::ParameterName, 'jobs')
-            [CompletionResult]::new('--stats-jsonl', 'stats-binout', [CompletionResultType]::ParameterName, 'stats-binout')
+            [CompletionResult]::new('--stats-jsonl', 'stats-jsonl', [CompletionResultType]::ParameterName, 'stats-jsonl')
             [CompletionResult]::new('--cache-threshold', 'cache-threshold', [CompletionResultType]::ParameterName, 'cache-threshold')
             [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'output')
             [CompletionResult]::new('--no-headers', 'no-headers', [CompletionResultType]::ParameterName, 'no-headers')

--- a/contrib/completions/src/cmd/stats.rs
+++ b/contrib/completions/src/cmd/stats.rs
@@ -17,7 +17,7 @@ pub fn stats_cmd() -> Command {
         arg!(--"prefer-dmy"),
         arg!(--force),
         arg!(--jobs),
-        arg!(--"stats-binout"),
+        arg!(--"stats-jsonl"),
         arg!(--"cache-threshold"),
         arg!(--output),
         arg!(--"no-headers"),


### PR DESCRIPTION
Fixes the completions for `--stats-jsonl` (you can just modify the `contrib/completions/src` section then run `bash generate_examples.bash` to generate them all automatically) and updated qsv pro installation text.