### PR TITLE
`contrib(completions)`: add `--max-size` completion for `sample`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -3462,7 +3462,7 @@ _qsv() {
             return 0
             ;;
         qsv__sample)
-            opts="-h --seed --rng --user-agent --timeout --output --no-headers --delimiter --help"
+            opts="-h --seed --rng --user-agent --timeout --max-size --output --no-headers --delimiter --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -1162,6 +1162,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --rng 'rng'
             cand --user-agent 'user-agent'
             cand --timeout 'timeout'
+            cand --max-size 'max-size'
             cand --output 'output'
             cand --no-headers 'no-headers'
             cand --delimiter 'delimiter'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -2784,6 +2784,9 @@ const completion: Fig.Spec = {
           name: "--timeout",
         },
         {
+          name: "--max-size",
+        },
+        {
           name: "--output",
         },
         {

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -897,6 +897,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand sample" -l seed
 complete -c qsv -n "__fish_qsv_using_subcommand sample" -l rng
 complete -c qsv -n "__fish_qsv_using_subcommand sample" -l user-agent
 complete -c qsv -n "__fish_qsv_using_subcommand sample" -l timeout
+complete -c qsv -n "__fish_qsv_using_subcommand sample" -l max-size
 complete -c qsv -n "__fish_qsv_using_subcommand sample" -l output
 complete -c qsv -n "__fish_qsv_using_subcommand sample" -l no-headers
 complete -c qsv -n "__fish_qsv_using_subcommand sample" -l delimiter

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -1072,6 +1072,7 @@ module completions {
     --rng
     --user-agent
     --timeout
+    --max-size
     --output
     --no-headers
     --delimiter

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -1267,6 +1267,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             [CompletionResult]::new('--rng', 'rng', [CompletionResultType]::ParameterName, 'rng')
             [CompletionResult]::new('--user-agent', 'user-agent', [CompletionResultType]::ParameterName, 'user-agent')
             [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'timeout')
+            [CompletionResult]::new('--max-size', 'max-size', [CompletionResultType]::ParameterName, 'max-size')
             [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'output')
             [CompletionResult]::new('--no-headers', 'no-headers', [CompletionResultType]::ParameterName, 'no-headers')
             [CompletionResult]::new('--delimiter', 'delimiter', [CompletionResultType]::ParameterName, 'delimiter')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -1394,6 +1394,7 @@ _arguments "${_arguments_options[@]}" : \
 '--rng[]' \
 '--user-agent[]' \
 '--timeout[]' \
+'--max-size[]' \
 '--output[]' \
 '--no-headers[]' \
 '--delimiter[]' \

--- a/contrib/completions/src/cmd/sample.rs
+++ b/contrib/completions/src/cmd/sample.rs
@@ -6,6 +6,7 @@ pub fn sample_cmd() -> Command {
         arg!(--rng),
         arg!(--"user-agent"),
         arg!(--timeout),
+        arg!(--"max-size"),
         arg!(--output),
         arg!(--"no-headers"),
         arg!(--delimiter),


### PR DESCRIPTION
Adds [qsv shell completions](https://github.com/jqnatividad/qsv/tree/master/contrib/completions) for the [`qsv sample`](https://github.com/jqnatividad/qsv/tree/master/src/cmd/sample.rs) command's `--max-size` option.