### PR TITLE
`json`: add error for empty key and update usage text

### DIFF
--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -8,7 +8,7 @@ The JSON data is expected to be non-empty and non-nested as either:
    B. Values are not objects or arrays.
 2. An object where values are not objects or arrays and the object is as described above.
 
-If there are duplicate keys then the last duplicate key and its values are used.
+Objects with duplicate keys are not recommended as only one key and its values may be used.
 
 If your JSON data is not in the expected format and/or is nested or complex, try using
 the --jaq option to pass a jq-like filter before parsing with the above constraints.

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -328,3 +328,50 @@ fn json_nested() {
 
     assert_eq!(got, expected);
 }
+
+#[test]
+#[serial]
+fn json_empty_keys_with_jaq() {
+    let wrk = Workdir::new("json_empty_keys_with_jaq");
+    let json_data = serde_json::json!({
+        "data": [
+            {
+                "fruit": "apple",
+                "": 0.50
+            },
+            {
+                "fruit": "banana",
+                "": 1.00
+            }
+        ]
+    });
+    let filter = ".data";
+
+    wrk.create_from_string("data.json", json_data.to_string().as_str());
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+    cmd.args(vec!["--jaq", filter]);
+
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+#[serial]
+fn json_empty_keys() {
+    let wrk = Workdir::new("json_empty_keys");
+    let json_data = serde_json::json!([
+            {
+                "fruit": "apple",
+                "": 0.50
+            },
+            {
+                "fruit": "banana",
+                "": 1.00
+            }
+    ]);
+    wrk.create_from_string("data.json", json_data.to_string().as_str());
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+
+    wrk.assert_err(&mut cmd);
+}


### PR DESCRIPTION
Outputs an error when there is an empty key in the first object, since the column with an empty key is not represented in the output. Also adds a note about not recommending usage for objects with duplicate keys, which in the future could be turned into an error when there are duplicate keys.

See both of the below images for examples.

## Example 1
<img src="https://github.com/user-attachments/assets/c1f01bd5-f4d0-483c-b317-8e0fda4492c6" alt="Explanation image" width="65%" />

## Example 2

<img src="https://github.com/user-attachments/assets/bfe29b73-cdc9-423a-a555-731418e99900" alt="Explanation image 2" width="65%" />
