### PR TITLE
apply new `clippy::ref_option` lint to Config::new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@
 ## Installation Options
 
 ### Option 0: TLDR Quick Install
-qsv's big brother - [qsv pro](https://qsvpro.dathere.com) is available for download from its website and on the [Microsoft App Store](https://apps.microsoft.com/detail/xpffdj3f1jsztf?hl=en-us&gl=US). Apart from a Graphical User Inteface, it's superpowered with additional features and capabilities - an API, [CKAN](https://ckan.org) integration, a Natural Language interface and more!
+qsv's big brother - [qsv pro](https://qsvpro.dathere.com) is available for download from its website and on the [Microsoft App Store](https://apps.microsoft.com/detail/xpffdj3f1jsztf?hl=en-us&gl=US). Apart from a Graphical User Interface, it's superpowered with additional features and capabilities - an API, [CKAN](https://ckan.org) integration, a Natural Language interface and more!
 
 ### Option 1: Download Prebuilt Binaries
 

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -444,13 +444,13 @@ enum ApplySubCmd {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -310,7 +310,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         dynfmt_fields.sort_unstable();
 
         // now, get the indices of the columns for the lookup vec
-        let (safe_headers, _) = util::safe_header_names(&headers, false, false, &None, "", true);
+        let (safe_headers, _) = util::safe_header_names(&headers, false, false, None, "", true);
         for (i, field) in safe_headers.iter().enumerate() {
             if dynfmt_fields.binary_search(&field.as_str()).is_ok() {
                 let field_with_curly = format!("{{{field}}}");

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -260,13 +260,13 @@ const NULL_VALUE: &str = "<null>";
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;

--- a/src/cmd/behead.rs
+++ b/src/cmd/behead.rs
@@ -25,11 +25,13 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let conf = Config::new(&args.arg_input).no_headers(false);
+    let conf = Config::new(args.arg_input.as_ref()).no_headers(false);
 
     let mut rdr = conf.flexible(args.flag_flexible).reader()?;
     // write is always flexible for performance
-    let mut wtr = Config::new(&args.flag_output).flexible(true).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref())
+        .flexible(true)
+        .writer()?;
     let mut record = csv::ByteRecord::new();
 
     while rdr.read_byte_record(&mut record)? {

--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -158,7 +158,7 @@ impl Args {
 
     fn cat_rows(&self) -> CliResult<()> {
         let mut row = csv::ByteRecord::new();
-        let mut wtr = Config::new(&self.flag_output)
+        let mut wtr = Config::new(self.flag_output.as_ref())
             .flexible(self.flag_flexible)
             .writer()?;
         let mut rdr;
@@ -254,7 +254,9 @@ impl Args {
         // set flexible to true for faster writes
         // as we know that all columns are already in columns_global and we don't need to
         // validate that the number of columns are the same every time we write a row
-        let mut wtr = Config::new(&self.flag_output).flexible(true).writer()?;
+        let mut wtr = Config::new(self.flag_output.as_ref())
+            .flexible(true)
+            .writer()?;
         let mut new_row = csv::ByteRecord::with_capacity(500, num_columns_global);
 
         // write the header
@@ -276,7 +278,7 @@ impl Args {
 
         for conf in self.configs()? {
             if conf.is_stdin() {
-                rdr = Config::new(&Some(stdin_tempfilename.to_string_lossy().to_string()))
+                rdr = Config::new(Some(stdin_tempfilename.to_string_lossy().to_string()).as_ref())
                     .reader()?;
                 conf_path = Some(stdin_tempfilename.clone());
             } else {
@@ -361,7 +363,7 @@ impl Args {
     }
 
     fn cat_columns(&self) -> CliResult<()> {
-        let mut wtr = Config::new(&self.flag_output).writer()?;
+        let mut wtr = Config::new(self.flag_output.as_ref()).writer()?;
         let mut rdrs = self
             .configs()?
             .into_iter()

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -110,7 +110,7 @@ struct WidthStats {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let conf = Config::new(&args.arg_input)
+    let conf = Config::new(args.arg_input.as_ref())
         .no_headers(args.flag_no_headers)
         // we also want to count the quotes when computing width
         .quoting(!args.flag_width || !args.flag_width_no_delims)

--- a/src/cmd/datefmt.rs
+++ b/src/cmd/datefmt.rs
@@ -195,13 +195,13 @@ fn unix_timestamp(input: &str, resolution: TimestampResolution) -> Option<DateTi
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -98,15 +98,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         ComparisonMode::Normal
     };
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_select);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let dupes_output = args.flag_dupes_output.is_some();
-    let mut dupewtr = Config::new(&args.flag_dupes_output).writer()?;
+    let mut dupewtr = Config::new(args.flag_dupes_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?;
     if dupes_output {

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -134,11 +134,11 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    let rconfig_left = Config::new(&args.arg_input_left)
+    let rconfig_left = Config::new(args.arg_input_left.as_ref())
         .delimiter(args.flag_delimiter_left)
         .no_headers(args.flag_no_headers_left);
 
-    let rconfig_right = Config::new(&args.arg_input_right)
+    let rconfig_right = Config::new(args.arg_input_right.as_ref())
         .delimiter(args.flag_delimiter_right)
         .no_headers(args.flag_no_headers_right);
 
@@ -244,7 +244,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         })
         .transpose()?;
 
-    let wtr = Config::new(&args.flag_output)
+    let wtr = Config::new(args.flag_output.as_ref())
         .delimiter(args.flag_delimiter_output)
         .writer()?;
 

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -63,9 +63,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let no_headers = args.flag_no_headers;
 
     // Build the CSV reader and iterate over each record.
-    let conf = Config::new(&input).no_headers(true);
+    let conf = Config::new(input.as_ref()).no_headers(true);
     let mut rdr = conf.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.headers()?;
     let mut column_index: Option<usize> = None;

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -131,12 +131,12 @@ enum EnumOperation {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let mut rconfig = Config::new(&args.arg_input)
+    let mut rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let mut headers = rdr.byte_headers()?.clone();
     let mut hash_index = None;

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -333,7 +333,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
     let num_sheets = sheet_names.len();
 
-    let mut wtr = Config::new(&args.flag_output)
+    let mut wtr = Config::new(args.flag_output.as_ref())
         .flexible(args.flag_flexible)
         .delimiter(args.flag_delimiter)
         .writer()?;

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -130,11 +130,11 @@ impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
 
 impl Args {
     fn new_io_state(&self) -> CliResult<IoState<fs::File, Box<dyn io::Write + 'static>>> {
-        let rconf1 = Config::new(&Some(self.arg_input1.clone()))
+        let rconf1 = Config::new(Some(self.arg_input1.clone()).as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
             .select(self.arg_columns1.clone());
-        let rconf2 = Config::new(&Some(self.arg_input2.clone()))
+        let rconf2 = Config::new(Some(self.arg_input2.clone()).as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
             .select(self.arg_columns2.clone());
@@ -143,7 +143,7 @@ impl Args {
         let mut rdr2 = rconf2.reader_file()?;
         let (sel1, sel2) = self.get_selections(&rconf1, &mut rdr1, &rconf2, &mut rdr2)?;
         Ok(IoState {
-            wtr: Config::new(&self.flag_output).writer()?,
+            wtr: Config::new(self.flag_output.as_ref()).writer()?,
             rdr1,
             sel1,
             rdr2,

--- a/src/cmd/explode.rs
+++ b/src/cmd/explode.rs
@@ -53,13 +53,13 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -487,7 +487,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
     log::info!("Cache Type: {cache_type:?}");
 
-    let mut rconfig = Config::new(&args.arg_input)
+    let mut rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .trim(csv::Trim::All)
         .no_headers(args.flag_no_headers);
@@ -496,12 +496,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut wtr = if args.flag_new_column.is_some() {
         // when adding a new column for the response, the output
         // is a regular CSV file
-        Config::new(&args.flag_output).writer()?
+        Config::new(args.flag_output.as_ref()).writer()?
     } else {
         // otherwise, the output is a JSONL file. So we need to configure
         // the csv writer so it doesn't double double quote the JSON response
         // and its flexible (i.e. "column counts are different row to row")
-        Config::new(&args.flag_output)
+        Config::new(args.flag_output.as_ref())
             .quote_style(csv::QuoteStyle::Never)
             .flexible(true)
             .writer()?
@@ -682,7 +682,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let report_path;
     if report == ReportKind::None {
         // no report, point report_wtr to /dev/null (AKA sink)
-        report_wtr = Config::new(&Some("sink".to_string())).writer()?;
+        report_wtr = Config::new(Some("sink".to_string()).as_ref()).writer()?;
         report_path = String::new();
     } else {
         report_path = args
@@ -690,7 +690,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .clone()
             .unwrap_or_else(|| "stdin.csv".to_string());
 
-        report_wtr = Config::new(&Some(report_path.clone() + FETCH_REPORT_SUFFIX))
+        report_wtr = Config::new(Some(report_path.clone() + FETCH_REPORT_SUFFIX).as_ref())
             .delimiter(Some(Delimiter(b'\t')))
             .writer()?;
         let mut report_headers = if report == ReportKind::Detailed {

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -402,7 +402,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
     log::info!("Cache Type: {cache_type:?}");
 
-    let mut rconfig = Config::new(&args.arg_input)
+    let mut rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .trim(csv::Trim::All)
         .no_headers(args.flag_no_headers);
@@ -411,12 +411,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut wtr = if args.flag_new_column.is_some() {
         // when adding a new column for the response, the output
         // is a regular CSV file
-        Config::new(&args.flag_output).writer()?
+        Config::new(args.flag_output.as_ref()).writer()?
     } else {
         // otherwise, the output is a JSONL file. So we need to configure
         // the csv writer so it doesn't double double quote the JSON response
         // and its flexible (i.e. "column counts are different row to row")
-        Config::new(&args.flag_output)
+        Config::new(args.flag_output.as_ref())
             .quote_style(csv::QuoteStyle::Never)
             .flexible(true)
             .writer()?
@@ -439,7 +439,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
 
     // validate column-list is a list of valid column names
-    let cl_config = Config::new(&args.arg_input)
+    let cl_config = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .trim(csv::Trim::All)
         .no_headers(args.flag_no_headers)
@@ -598,7 +598,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let report_path;
     if report == ReportKind::None {
         // no report, point report_wtr to /dev/null (AKA sink)
-        report_wtr = Config::new(&Some("sink".to_string())).writer()?;
+        report_wtr = Config::new(Some("sink".to_string()).as_ref()).writer()?;
         report_path = String::new();
     } else {
         report_path = args
@@ -606,7 +606,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .clone()
             .unwrap_or_else(|| "stdin.csv".to_string());
 
-        report_wtr = Config::new(&Some(report_path.clone() + FETCHPOST_REPORT_SUFFIX)).writer()?;
+        report_wtr =
+            Config::new(Some(report_path.clone() + FETCHPOST_REPORT_SUFFIX).as_ref()).writer()?;
         let mut report_headers = if report == ReportKind::Detailed {
             headers.clone()
         } else {

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -83,12 +83,12 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_selection);
 
-    let wconfig = Config::new(&args.flag_output);
+    let wconfig = Config::new(args.flag_output.as_ref());
 
     let mut rdr = rconfig.reader()?;
     let mut wtr = wconfig.writer()?;

--- a/src/cmd/fixlengths.rs
+++ b/src/cmd/fixlengths.rs
@@ -57,7 +57,7 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let mut config = Config::new(&args.arg_input)
+    let mut config = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .quote(args.flag_quote.as_byte())
         .no_headers(true)
@@ -96,7 +96,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
 
     let mut rdr = config.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let mut record = csv::ByteRecord::new();
     let mut record_work = csv::ByteRecord::new();
     #[allow(unused_assignments)]

--- a/src/cmd/flatten.rs
+++ b/src/cmd/flatten.rs
@@ -59,7 +59,7 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/fmt.rs
+++ b/src/cmd/fmt.rs
@@ -65,10 +65,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         args.flag_out_delimiter = Some(Delimiter(b'\t'));
     }
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(true);
-    let mut wconfig = Config::new(&args.flag_output)
+    let mut wconfig = Config::new(args.flag_output.as_ref())
         .delimiter(args.flag_out_delimiter)
         .crlf(args.flag_crlf);
 

--- a/src/cmd/foreach.rs
+++ b/src/cmd/foreach.rs
@@ -106,13 +106,13 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&None).writer()?;
+    let mut wtr = Config::new(None).writer()?;
 
     #[allow(clippy::trivial_regex)]
     // template_pattern matches pairs of curly braces, e.g. "{}".

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -175,7 +175,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         util::mem_file_check(&path, false, args.flag_memcheck)?;
     }
 
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let (headers, tables) = match args.rconfig().indexed()? {
         Some(ref mut idx) if util::njobs(args.flag_jobs) > 1 => args.parallel_ftables(idx),
         _ => args.sequential_ftables(),
@@ -273,7 +273,7 @@ type FTables = Vec<Frequencies<Vec<u8>>>;
 
 impl Args {
     pub fn rconfig(&self) -> Config {
-        Config::new(&self.arg_input)
+        Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
             .select(self.flag_select.clone())

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -728,7 +728,7 @@ async fn geocode_main(args: Args) -> CliResult<()> {
         args.arg_input
     };
 
-    let rconfig = Config::new(&input)
+    let rconfig = Config::new(input.as_ref())
         .delimiter(args.flag_delimiter)
         .select(SelectColumns::parse(&args.arg_column)?);
 
@@ -932,7 +932,7 @@ async fn geocode_main(args: Args) -> CliResult<()> {
     let engine = load_engine(geocode_index_file.clone().into(), &progress).await?;
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output)
+    let mut wtr = Config::new(args.flag_output.as_ref())
         .quote_style(
             // if we're doing a now subcommand with JSON output, we don't want the CSV writer
             // to close quote the output as it will produce invalid JSON

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -57,7 +57,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         Some(p) => PathBuf::from(&p),
     };
 
-    let rconfig = Config::new(&Some(args.arg_input));
+    let rconfig = Config::new(Some(args.arg_input).as_ref());
     let mut rdr = rconfig.reader_file()?;
     let mut wtr =
         io::BufWriter::with_capacity(DEFAULT_WTR_BUFFER_CAPACITY, fs::File::create(pidx)?);

--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -132,7 +132,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         args.flag_comment.map(|char| char as u8)
     };
 
-    let mut rconfig = Config::new(&args.arg_input)
+    let mut rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(true)
         .quote(args.flag_quote.as_byte())
@@ -141,7 +141,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if args.flag_auto_skip {
         std::env::remove_var("QSV_SNIFF_PREAMBLE");
     }
-    let mut wconfig = Config::new(&args.flag_output);
+    let mut wconfig = Config::new(args.flag_output.as_ref());
 
     if let Some(escape) = args.flag_escape {
         rconfig = rconfig.escape(Some(escape.as_byte())).double_quote(false);

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -317,11 +317,11 @@ impl Args {
     fn new_io_state(
         &self,
     ) -> CliResult<IoState<Box<dyn SeekRead + 'static>, Box<dyn io::Write + 'static>>> {
-        let rconf1 = Config::new(&Some(self.arg_input1.clone()))
+        let rconf1 = Config::new(Some(self.arg_input1.clone()).as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
             .select(self.arg_columns1.clone());
-        let rconf2 = Config::new(&Some(self.arg_input2.clone()))
+        let rconf2 = Config::new(Some(self.arg_input2.clone()).as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
             .select(self.arg_columns2.clone());
@@ -330,7 +330,7 @@ impl Args {
         let mut rdr2 = rconf2.reader_file_stdin()?;
         let (sel1, sel2) = self.get_selections(&rconf1, &mut rdr1, &rconf2, &mut rdr2)?;
         Ok(IoState {
-            wtr: Config::new(&self.flag_output).writer()?,
+            wtr: Config::new(self.flag_output.as_ref()).writer()?,
             rdr1,
             sel1,
             rdr2,

--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -265,7 +265,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .flag_select
         .unwrap_or_else(|| SelectColumns::parse(&first_dict_headers.join(",")).unwrap());
 
-    let sel_rconfig = config::Config::new(&Some(intermediate_csv)).no_headers(false);
+    let sel_rconfig = config::Config::new(Some(intermediate_csv).as_ref()).no_headers(false);
     let mut intermediate_csv_rdr = sel_rconfig.reader()?;
     let byteheaders = intermediate_csv_rdr.byte_headers()?;
 
@@ -273,7 +273,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let sel = sel_rconfig.select(sel_cols).selection(byteheaders)?;
     let mut read_record = csv::ByteRecord::new();
     let mut write_record = csv::ByteRecord::new();
-    let mut final_csv_wtr = config::Config::new(&args.flag_output)
+    let mut final_csv_wtr = config::Config::new(args.flag_output.as_ref())
         .no_headers(false)
         .writer()?;
     final_csv_wtr.write_record(sel.iter().map(|&i| &byteheaders[i]))?;

--- a/src/cmd/jsonl.rs
+++ b/src/cmd/jsonl.rs
@@ -149,7 +149,7 @@ fn json_line_to_csv_record(value: &Value, headers: &[Vec<String>]) -> csv::Strin
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let mut wtr = Config::new(&args.flag_output)
+    let mut wtr = Config::new(args.flag_output.as_ref())
         .delimiter(args.flag_delimiter)
         .writer()?;
 

--- a/src/cmd/lens.rs
+++ b/src/cmd/lens.rs
@@ -69,7 +69,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // we do config here to get the delimiter, just in case
     // QSV_SNIFF_DELIMITER or QSV_DELIMITER is set
-    let config: Config = Config::new(&Some(input));
+    let config: Config = Config::new(Some(input).as_ref());
 
     if let Some(delimiter) = &args.flag_delimiter {
         lens_args.extend_from_slice(&["--delimiter".to_string(), delimiter.to_string()]);

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -339,7 +339,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         Ordering::Relaxed,
     );
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 
@@ -633,7 +633,7 @@ fn sequential_mode(
     globals.raw_set("cols", "{}")?;
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let mut headers = rdr.headers()?.clone();
     let mut remap_headers = csv::StringRecord::new();
     let mut new_column_count = 0_u8;
@@ -963,7 +963,7 @@ fn random_access_mode(
         row_count += 1;
     }
 
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let mut headers = idx_file.headers()?.clone();
     let mut remap_headers = csv::StringRecord::new();
     let mut new_column_count = 0_u8;
@@ -1423,7 +1423,7 @@ fn create_index(arg_input: Option<&String>) -> Result<bool, CliError> {
     let pidx = util::idx_path(Path::new(&input));
     debug!("Creating index file {pidx:?} for {input:?}.");
 
-    let rconfig = Config::new(&Some(input.to_string()));
+    let rconfig = Config::new(Some((*input).to_string()).as_ref());
     let mut rdr = rconfig.reader_file()?;
     let mut wtr =
         io::BufWriter::with_capacity(DEFAULT_WTR_BUFFER_CAPACITY, fs::File::create(pidx)?);
@@ -1715,7 +1715,7 @@ fn setup_helpers(
             #[allow(unused_assignments)]
             let mut record = csv::StringRecord::new();
 
-            let conf = Config::new(&Some(filepath.clone()))
+            let conf = Config::new(Some(filepath.clone()).as_ref())
                 .delimiter(delimiter)
                 .comment(Some(b'#'))
                 .no_headers(false);
@@ -2347,7 +2347,7 @@ fn setup_helpers(
         let lookup_table = luau.create_table()?;
         let mut record: csv::StringRecord;
 
-        let conf = Config::new(&Some(lookup_table_uri.clone()))
+        let conf = Config::new(Some(lookup_table_uri.clone()).as_ref())
             .delimiter(delimiter)
             .comment(Some(b'#'))
             .no_headers(false);

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -99,7 +99,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 impl Args {
     /// Configuration for our reader.
     fn rconfig(&self) -> Config {
-        Config::new(&self.arg_input)
+        Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
             .select(self.arg_column.clone())

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -95,13 +95,13 @@ type ValuesNum = AHashMap<String, u64>;
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_column);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?.clone();
     let column_index = match rconfig.selection(&headers) {

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -183,12 +183,12 @@ impl From<PyErr> for CliError {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     if log_enabled!(Debug) {
         Python::with_gil(|py| {

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -57,12 +57,12 @@ struct Args {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: Args = util::get_args(USAGE, argv)?;
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let headers = rdr.byte_headers()?;
 
     if args.arg_headers.to_lowercase() == "_all_generic" {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -116,13 +116,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     } else {
         args.arg_replacement.as_bytes()
     };
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_select);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;

--- a/src/cmd/reverse.rs
+++ b/src/cmd/reverse.rs
@@ -42,12 +42,12 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     if let Some(mut idx_file) = rconfig.indexed()? {
         // we have an index, no need to check avail mem,

--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -161,10 +161,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .map(str::to_lowercase)
         .collect();
 
-    let rconfig = Config::new(&args.arg_input).delimiter(args.flag_delimiter);
+    let rconfig = Config::new(args.arg_input.as_ref()).delimiter(args.flag_delimiter);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let old_headers = rdr.byte_headers()?;
 
     let mut headers = csv::StringRecord::from_byte_record_lossy(old_headers.clone());

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -146,14 +146,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         None => None,
     };
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .flexible(true);
 
     let mut sample_size = args.arg_sample_size;
 
-    let mut wtr = Config::new(&args.flag_output)
+    let mut wtr = Config::new(args.flag_output.as_ref())
         .delimiter(args.flag_delimiter)
         .writer()?;
 

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -561,7 +561,7 @@ fn generate_string_patterns(
     args: &util::SchemaArgs,
     properties_map: &Map<String, Value>,
 ) -> CliResult<AHashMap<String, String>> {
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_pattern_columns.clone());

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -138,7 +138,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .dfa_size_limit(args.flag_dfa_size_limit * (1 << 20))
         .build()?;
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_select);
@@ -152,7 +152,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let flag_not_one = args.flag_not_one;
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let mut json_wtr = if flag_json {
         util::create_json_writer(args.flag_output.as_ref(), DEFAULT_WTR_BUFFER_CAPACITY * 4)?

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -184,14 +184,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .build()?;
     debug!("Successfully compiled regex set!");
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_select);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
-    let mut unmatched_wtr = Config::new(&args.flag_unmatched_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
+    let mut unmatched_wtr = Config::new(args.flag_unmatched_output.as_ref()).writer()?;
 
     let mut headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;

--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -116,13 +116,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         return fail_clierror!("Cannot use both --random and --sort options.");
     }
 
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_selection);
 
     let mut rdr = rconfig.reader()?;
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
 
     let headers = rdr.byte_headers()?.clone();
     let sel = if args.flag_random {

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -187,12 +187,12 @@ impl Args {
     }
 
     fn rconfig(&self) -> Config {
-        Config::new(&self.arg_input)
+        Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
     }
 
     fn wconfig(&self) -> Config {
-        Config::new(&self.flag_output)
+        Config::new(self.flag_output.as_ref())
     }
 }

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -525,14 +525,14 @@ async fn get_file_to_sniff(args: &Args, tmpdir: &tempfile::TempDir) -> CliResult
                     // incomplete lines. We do this coz we streamed the download and the downloaded
                     // file may be more than the sample size, and the final line may be incomplete.
                     wtr_file_path = path.display().to_string();
-                    let mut wtr = Config::new(&Some(wtr_file_path.clone()))
+                    let mut wtr = Config::new(Some(wtr_file_path.clone()).as_ref())
                         .no_headers(false)
                         .flexible(true)
                         .quote_style(csv::QuoteStyle::NonNumeric)
                         .writer()?;
 
                     let retrieved_name = file.path().to_str().unwrap().to_string();
-                    let config = Config::new(&Some(retrieved_name))
+                    let config = Config::new(Some(retrieved_name).as_ref())
                         .delimiter(args.flag_delimiter)
                         // we say no_headers so we can just copy the downloaded file over
                         // including headers, to the exact sample size file
@@ -807,7 +807,7 @@ async fn sniff_main(mut args: Args) -> CliResult<()> {
         );
     }
 
-    let conf = Config::new(&Some(sfile_info.file_to_sniff.clone()))
+    let conf = Config::new(Some(sfile_info.file_to_sniff.clone()).as_ref())
         .flexible(true)
         .delimiter(args.flag_delimiter);
     let n_rows = if sfile_info.downloaded_records == 0 {

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -115,7 +115,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let reverse = args.flag_reverse;
     let random = args.flag_random;
     let faster = args.flag_faster;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_select);
@@ -258,7 +258,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }),
     }
 
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
     let mut prev: Option<csv::ByteRecord> = None;
     rconfig.write_headers(&mut rdr, &mut wtr)?;
     for r in all {

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -93,7 +93,7 @@ struct SortCheckStruct {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let ignore_case = args.flag_ignore_case;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.flag_select);

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -336,7 +336,7 @@ impl Args {
         let dir = Path::new(&self.arg_outdir);
         let path = dir.join(self.flag_filename.filename(&format!("{start:0>width$}")));
         let spath = Some(path.display().to_string());
-        let mut wtr = Config::new(&spath).writer()?;
+        let mut wtr = Config::new(spath.as_ref()).writer()?;
         if !self.rconfig().no_headers {
             wtr.write_record(headers)?;
         }
@@ -344,7 +344,7 @@ impl Args {
     }
 
     fn rconfig(&self) -> Config {
-        Config::new(&self.arg_input)
+        Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
     }

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -631,9 +631,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // scanning the entire file with a 0 infer_len which triggers a full table scan.
     args.flag_infer_len =
         if args.flag_infer_len == 0 && !is_sql_script && !skip_input && args.arg_input.len() == 1 {
-            let rconfig = Config::new(&Some(args.arg_input[0].to_string_lossy().to_string()))
-                .delimiter(args.flag_delimiter)
-                .no_headers(false);
+            let rconfig =
+                Config::new(Some(args.arg_input[0].to_string_lossy().to_string()).as_ref())
+                    .delimiter(args.flag_delimiter)
+                    .no_headers(false);
             util::count_rows(&rconfig).unwrap_or(0) as usize
         } else {
             args.flag_infer_len

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -576,7 +576,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     );
 
     // we will write the stats to a temp file
-    let wconfig = Config::new(&Some(stats_csv_tempfile_fname.clone()))
+    let wconfig = Config::new(Some(stats_csv_tempfile_fname.clone()).as_ref())
         .delimiter(Some(Delimiter(output_delim)));
     let mut wtr = wconfig.writer()?;
     let mut rconfig = args.rconfig();
@@ -1032,7 +1032,7 @@ impl Args {
 
     #[inline]
     fn rconfig(&self) -> Config {
-        Config::new(&self.arg_input)
+        Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)
             .select(self.flag_select.clone())

--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -74,7 +74,7 @@ impl From<Align> for Alignment {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let rconfig = Config::new(&args.arg_input)
+    let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers(true)
         .flexible(true);
@@ -84,7 +84,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         util::mem_file_check(&path, false, args.flag_memcheck)?;
     }
 
-    let wconfig = Config::new(&args.flag_output).delimiter(Some(Delimiter(b'\t')));
+    let wconfig = Config::new(args.flag_output.as_ref()).delimiter(Some(Delimiter(b'\t')));
 
     let tw = TabWriter::new(wconfig.io_writer()?)
         .minwidth(args.flag_width)

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -106,7 +106,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .into_os_string()
         .into_string()
         .unwrap();
-    let conf = Config::new(&Some(input_filename.clone())).delimiter(args.flag_delimiter);
+    let conf = Config::new(Some(&input_filename)).delimiter(args.flag_delimiter);
 
     // we're loading the entire file into memory, we need to check avail mem
     util::mem_file_check(
@@ -155,7 +155,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // TODO: instead of abusing csv writer to write jsonl file
     // just use a normal buffered writer
-    let mut wtr = Config::new(&args.flag_output)
+    let mut wtr = Config::new(args.flag_output.as_ref())
         .flexible(true)
         .no_headers(true)
         .quote_style(csv::QuoteStyle::Never)

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -101,11 +101,11 @@ impl Args {
     }
 
     fn wconfig(&self) -> Config {
-        Config::new(&self.flag_output)
+        Config::new(self.flag_output.as_ref())
     }
 
     fn rconfig(&self) -> Config {
-        Config::new(&self.arg_input)
+        Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(true)
     }

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -324,7 +324,7 @@ fn dyn_enum_validator_factory<'a>(
 
         // read the first column into a HashSet
         let mut enum_set = HashSet::with_capacity(50);
-        let rconfig = Config::new(&Some(dynenum_path));
+        let rconfig = Config::new(Some(dynenum_path).as_ref());
         let mut rdr = rconfig.flexible(true).reader()?;
         for result in rdr.records() {
             match result {
@@ -356,7 +356,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         Ordering::Relaxed,
     );
 
-    let mut rconfig = Config::new(&args.arg_input).no_headers(args.flag_no_headers);
+    let mut rconfig = Config::new(args.arg_input.as_ref()).no_headers(args.flag_no_headers);
 
     if args.flag_delimiter.is_some() {
         rconfig = rconfig.delimiter(args.flag_delimiter);
@@ -746,7 +746,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 Some(valid_output)
             };
 
-            let mut valid_wtr = Config::new(&valid_path).writer()?;
+            let mut valid_wtr = Config::new(valid_path.as_ref()).writer()?;
             valid_wtr.write_byte_record(&headers)?;
 
             let mut rdr = rconfig.reader()?;
@@ -818,11 +818,12 @@ fn split_invalid_records(
     let mut split_row_num: usize = 0;
 
     // prepare output writers
-    let mut valid_wtr = Config::new(&Some(input_path.to_owned() + "." + valid_suffix)).writer()?;
+    let mut valid_wtr =
+        Config::new(Some(input_path.to_owned() + "." + valid_suffix).as_ref()).writer()?;
     valid_wtr.write_byte_record(headers)?;
 
     let mut invalid_wtr =
-        Config::new(&Some(input_path.to_owned() + "." + invalid_suffix)).writer()?;
+        Config::new(Some(input_path.to_owned() + "." + invalid_suffix).as_ref()).writer()?;
     invalid_wtr.write_byte_record(headers)?;
 
     let mut rdr = rconfig.reader()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,12 +101,12 @@ pub trait SeekRead: io::Seek + io::Read {}
 impl<T: io::Seek + io::Read> SeekRead for T {}
 
 impl Config {
-    pub fn new(path: &Option<String>) -> Config {
+    pub fn new(path: Option<&String>) -> Config {
         let default_delim = match env::var("QSV_DEFAULT_DELIMITER") {
             Ok(delim) => Delimiter::decode_delimiter(&delim).unwrap().as_byte(),
             _ => b',',
         };
-        let (path, mut delim, snappy) = match *path {
+        let (path, mut delim, snappy) = match path {
             None => (None, default_delim, false),
             // WIP: support remote files; currently only http(s) is supported
             // Some(ref s) if s.starts_with("http") && Url::parse(s).is_ok() => {
@@ -124,7 +124,7 @@ impl Config {
             //     util::download_file()
             //     (Some(PathBuf::from(s)), delim, snappy)
             // },
-            Some(ref s) if &**s == "-" => (None, default_delim, false),
+            Some(s) if s == "-" => (None, default_delim, false),
             Some(ref s) => {
                 let path = PathBuf::from(s);
                 let (file_extension, delim, snappy) = get_delim_by_extension(&path, default_delim);

--- a/src/util.rs
+++ b/src/util.rs
@@ -532,7 +532,7 @@ pub fn many_configs(
     let confs = inps
         .into_iter()
         .map(|p| {
-            Config::new(&Some(p))
+            Config::new(Some(p).as_ref())
                 .delimiter(delim)
                 .no_headers(no_headers)
                 .flexible(flexible)
@@ -776,7 +776,7 @@ impl FilenameTemplate {
             create_dir_all_threadsafe(parent)?;
         }
         let spath = Some(full_path.display().to_string());
-        Config::new(&spath).writer()
+        Config::new(spath.as_ref()).writer()
     }
 }
 


### PR DESCRIPTION
`Config::new` is universally used in qsv, affecting all commands.

https://rust-lang.github.io/rust-clippy/master/index.html#/ref_option

And this video makes a compelling case for it...
https://www.youtube.com/watch?v=6c7pZYP_iIE