### PR TITLE
`contrib(completions)`: add `--table` option to `qsv excel`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -1138,7 +1138,7 @@ _qsv() {
             return 0
             ;;
         qsv__excel)
-            opts="-h --sheet --metadata --error-format --flexible --trim --date-format --keep-zero-time --range --jobs --output --delimiter --quiet --help"
+            opts="-h --sheet --metadata --error-format --flexible --trim --date-format --keep-zero-time --table --range --jobs --output --delimiter --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -360,6 +360,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --trim 'trim'
             cand --date-format 'date-format'
             cand --keep-zero-time 'keep-zero-time'
+            cand --table 'table'
             cand --range 'range'
             cand --jobs 'jobs'
             cand --output 'output'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -690,6 +690,9 @@ const completion: Fig.Spec = {
           name: "--keep-zero-time",
         },
         {
+          name: "--table",
+        },
+        {
           name: "--range",
         },
         {

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -287,6 +287,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand excel" -l flexible
 complete -c qsv -n "__fish_qsv_using_subcommand excel" -l trim
 complete -c qsv -n "__fish_qsv_using_subcommand excel" -l date-format
 complete -c qsv -n "__fish_qsv_using_subcommand excel" -l keep-zero-time
+complete -c qsv -n "__fish_qsv_using_subcommand excel" -l table
 complete -c qsv -n "__fish_qsv_using_subcommand excel" -l range
 complete -c qsv -n "__fish_qsv_using_subcommand excel" -l jobs
 complete -c qsv -n "__fish_qsv_using_subcommand excel" -l output

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -278,6 +278,7 @@ module completions {
     --trim
     --date-format
     --keep-zero-time
+    --table
     --range
     --jobs
     --output

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -393,6 +393,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             [CompletionResult]::new('--trim', 'trim', [CompletionResultType]::ParameterName, 'trim')
             [CompletionResult]::new('--date-format', 'date-format', [CompletionResultType]::ParameterName, 'date-format')
             [CompletionResult]::new('--keep-zero-time', 'keep-zero-time', [CompletionResultType]::ParameterName, 'keep-zero-time')
+            [CompletionResult]::new('--table', 'table', [CompletionResultType]::ParameterName, 'table')
             [CompletionResult]::new('--range', 'range', [CompletionResultType]::ParameterName, 'range')
             [CompletionResult]::new('--jobs', 'jobs', [CompletionResultType]::ParameterName, 'jobs')
             [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'output')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -392,6 +392,7 @@ _arguments "${_arguments_options[@]}" : \
 '--trim[]' \
 '--date-format[]' \
 '--keep-zero-time[]' \
+'--table[]' \
 '--range[]' \
 '--jobs[]' \
 '--output[]' \

--- a/contrib/completions/src/cmd/excel.rs
+++ b/contrib/completions/src/cmd/excel.rs
@@ -9,6 +9,7 @@ pub fn excel_cmd() -> Command {
         arg!(--trim),
         arg!(--"date-format"),
         arg!(--"keep-zero-time"),
+        arg!(--table),
         arg!(--"range"),
         arg!(--jobs),
         arg!(--output),


### PR DESCRIPTION
Adds `--table` option to `qsv excel` completions.