### PR TITLE
`apply` & `applydp`: use smallvec for operations vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arbitrary"
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -5410,6 +5410,7 @@ dependencies = [
  "simd-json",
  "simdutf8",
  "simple-expand-tilde",
+ "smallvec",
  "snap",
  "strsim",
  "strum",
@@ -6300,9 +6301,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.130"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f75ff4a8e3cb29b85da56eabdd1bff5b06739059a4b8e2967fef32e5d9944"
+checksum = "67d42a0bd4ac281beff598909bb56a86acaf979b84483e1c79c10dcaf98f8cf3"
 dependencies = [
  "indexmap",
  "itoa",
@@ -7255,12 +7256,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_stacker = { version = "0.1", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 simple-expand-tilde = { version = "0.4.3", optional = true }
+smallvec = "1"
 snap = "1"
 strsim = { version = "0.11", optional = true }
 strum = { version = "0.26", features = ["phf"] }

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -321,6 +321,7 @@ use rayon::{
 };
 use regex::Regex;
 use serde::Deserialize;
+use smallvec::SmallVec;
 use strsim::{
     damerau_levenshtein, hamming, jaro_winkler, normalized_damerau_levenshtein, osa_distance,
     sorensen_dice,
@@ -508,7 +509,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         String::new()
     };
 
-    let mut ops_vec: Vec<Operations> = Vec::new();
+    let mut ops_vec = SmallVec::<[Operations; 4]>::new();
 
     let apply_cmd = if args.cmd_operations {
         match validate_operations(
@@ -727,7 +728,7 @@ fn validate_operations(
     flag_replacement: &str,
     flag_new_column: Option<&String>,
     flag_formatstr: &str,
-) -> Result<Vec<Operations>, CliError> {
+) -> Result<SmallVec<[Operations; 4]>, CliError> {
     let mut censor_invokes = 0_u8;
     let mut copy_invokes = 0_u8;
     let mut eudex_invokes = 0_u8;
@@ -738,7 +739,7 @@ fn validate_operations(
     let mut strip_invokes = 0_u8;
     let mut whatlang_invokes = 0_u8;
 
-    let mut ops_vec: Vec<Operations> = Vec::with_capacity(operations.len());
+    let mut ops_vec = SmallVec::with_capacity(operations.len());
 
     for op in operations {
         let Ok(operation) = Operations::from_str(op) else {
@@ -960,7 +961,7 @@ fn validate_operations(
 
 #[inline]
 fn apply_operations(
-    ops_vec: &Vec<Operations>,
+    ops_vec: &SmallVec<[Operations; 4]>,
     cell: &mut String,
     comparand: &str,
     replacement: &str,

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -193,6 +193,7 @@ use rayon::{
 };
 use regex::Regex;
 use serde::Deserialize;
+use smallvec::SmallVec;
 use strum_macros::EnumString;
 
 use crate::{
@@ -331,7 +332,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         EmptyReplace,
     }
 
-    let mut ops_vec: Vec<Operations> = Vec::new();
+    let mut ops_vec = SmallVec::<[Operations; 4]>::new();
 
     let applydp_cmd = if args.cmd_operations {
         match validate_operations(
@@ -496,13 +497,13 @@ fn validate_operations(
     flag_replacement: &str,
     flag_new_column: &Option<String>,
     flag_formatstr: &str,
-) -> Result<Vec<Operations>, CliError> {
+) -> Result<SmallVec<[Operations; 4]>, CliError> {
     let mut copy_invokes = 0_u8;
     let mut regex_replace_invokes = 0_u8;
     let mut replace_invokes = 0_u8;
     let mut strip_invokes = 0_u8;
 
-    let mut ops_vec: Vec<Operations> = Vec::with_capacity(operations.len());
+    let mut ops_vec = SmallVec::with_capacity(operations.len());
 
     for op in operations {
         let Ok(operation) = Operations::from_str(op) else {
@@ -587,7 +588,7 @@ fn validate_operations(
 
 #[inline]
 fn applydp_operations(
-    ops_vec: &Vec<Operations>,
+    ops_vec: &SmallVec<[Operations; 4]>,
     cell: &mut String,
     comparand: &str,
     replacement: &str,


### PR DESCRIPTION
use smallvec for operations_vec which is normally very small so we can store it inline rather than allocating on the heap