### PR TITLE
`fetch` & `fetchpost`: replace jql with jaq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5379,7 +5379,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_stacker",
  "serde_urlencoded",
  "serial_test",
  "simd-json",
@@ -6296,16 +6295,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.81",
-]
-
-[[package]]
-name = "serde_stacker"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babfccff5773ff80657f0ecf553c7c516bdc2eb16389c0918b36b73e7015276e"
-dependencies = [
- "serde",
- "stacker",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -758,7 +758,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -775,7 +775,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1106,7 +1106,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1823,7 +1823,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1847,7 +1847,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1858,7 +1858,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1947,7 +1947,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1958,7 +1958,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1971,7 +1971,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2020,7 +2020,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2153,7 +2153,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2174,7 +2174,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2457,7 +2457,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2584,7 +2584,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3166,7 +3166,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3224,7 +3224,6 @@ checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
- "rayon",
  "serde",
 ]
 
@@ -3269,7 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
 dependencies = [
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3403,29 +3402,6 @@ name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
-
-[[package]]
-name = "jql-parser"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6c5d45258356a8b4ff8265b929cc95880be34fdc34c884e0ab4585d4a3f356"
-dependencies = [
- "thiserror",
- "winnow",
-]
-
-[[package]]
-name = "jql-runner"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d68343315f3a2668bf340993d0ae2686bed277d2fb74b28a083fc50fd1db44"
-dependencies = [
- "indexmap",
- "jql-parser",
- "rayon",
- "serde_json",
- "thiserror",
-]
 
 [[package]]
 name = "js-sys"
@@ -4540,7 +4516,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -4569,7 +4545,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5296,7 +5272,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5309,7 +5285,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5366,7 +5342,6 @@ dependencies = [
  "jaq-interpret",
  "jaq-parse",
  "jemallocator",
- "jql-runner",
  "json-objects-to-csv",
  "jsonschema",
  "local-encoding",
@@ -5763,7 +5738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5845,7 +5820,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6296,7 +6271,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6320,7 +6295,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6368,7 +6343,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6579,7 +6554,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6731,7 +6706,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6753,9 +6728,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.80"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e185e337f816bc8da115b8afcb3324006ccc82eeaddf35113888d3bd8e44ac"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6779,7 +6754,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6860,7 +6835,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6999,7 +6974,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7095,7 +7070,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7180,7 +7155,7 @@ checksum = "560b82d656506509d43abe30e0ba64c56b1953ab3d4fe7ba5902747a7a3cedd5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7476,7 +7451,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
  "wasm-bindgen-shared",
 ]
 
@@ -7510,7 +7485,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7788,7 +7763,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7799,7 +7774,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7810,7 +7785,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7821,7 +7796,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8105,7 +8080,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
  "synstructure",
 ]
 
@@ -8156,7 +8131,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
  "zvariant_utils",
 ]
 
@@ -8189,7 +8164,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8209,7 +8184,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
  "synstructure",
 ]
 
@@ -8230,7 +8205,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8252,7 +8227,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8359,7 +8334,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
  "zvariant_utils",
 ]
 
@@ -8371,5 +8346,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.81",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,6 @@ self_update = { version = "0.41", features = [
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-serde_stacker = { version = "0.1", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 simple-expand-tilde = { version = "0.4.3", optional = true }
 smallvec = "1"
@@ -357,7 +356,6 @@ fetch = [
     "hashbrown",
     "publicsuffix",
     "redis",
-    "serde_stacker",
     "serde_urlencoded",
     "simple-expand-tilde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,6 @@ jsonschema = { version = "0.23", features = [
     "resolve-file",
     "resolve-http",
 ], default-features = false }
-jql-runner = { version = "7.2", default-features = false, optional = true }
 local-encoding = { version = "0.2", optional = true }
 localzone = { version = "0.3", features = ["auto_validation"] }
 log = "0.4"
@@ -356,7 +355,6 @@ fetch = [
     "flate2",
     "governor",
     "hashbrown",
-    "jql-runner",
     "publicsuffix",
     "redis",
     "serde_stacker",

--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -1208,7 +1208,7 @@ _qsv() {
             return 0
             ;;
         qsv__fetch)
-            opts="-h --url-template --new-column --jql --jqlfile --pretty --rate-limit --timeout --http-header --max-retries --max-errors --store-error --cookies --user-agent --report --no-cache --mem-cache-size --disk-cache --disk-cache-dir --redis-cache --cache-error --flush-cache --output --no-headers --delimiter --progressbar --help"
+            opts="-h --url-template --new-column --jaq --jaqfile --pretty --rate-limit --timeout --http-header --max-retries --max-errors --store-error --cookies --user-agent --report --no-cache --mem-cache-size --disk-cache --disk-cache-dir --redis-cache --cache-error --flush-cache --output --no-headers --delimiter --progressbar --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1222,7 +1222,7 @@ _qsv() {
             return 0
             ;;
         qsv__fetchpost)
-            opts="-h --new-column --jql --jqlfile --pretty --rate-limit --timeout --http-header --compress --max-retries --max-errors --store-error --cookies --user-agent --report --no-cache --mem-cache-size --disk-cache --disk-cache-dir --redis-cache --cache-error --flush-cache --output --no-headers --delimiter --progressbar --help"
+            opts="-h --new-column --jaq --jaqfile --pretty --rate-limit --timeout --http-header --compress --max-retries --max-errors --store-error --cookies --user-agent --report --no-cache --mem-cache-size --disk-cache --disk-cache-dir --redis-cache --cache-error --flush-cache --output --no-headers --delimiter --progressbar --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -413,8 +413,8 @@ set edit:completion:arg-completer[qsv] = {|@words|
         &'qsv;fetch'= {
             cand --url-template 'url-template'
             cand --new-column 'new-column'
-            cand --jql 'jql'
-            cand --jqlfile 'jqlfile'
+            cand --jaq 'jaq'
+            cand --jaqfile 'jaqfile'
             cand --pretty 'pretty'
             cand --rate-limit 'rate-limit'
             cand --timeout 'timeout'
@@ -441,8 +441,8 @@ set edit:completion:arg-completer[qsv] = {|@words|
         }
         &'qsv;fetchpost'= {
             cand --new-column 'new-column'
-            cand --jql 'jql'
-            cand --jqlfile 'jqlfile'
+            cand --jaq 'jaq'
+            cand --jaqfile 'jaqfile'
             cand --pretty 'pretty'
             cand --rate-limit 'rate-limit'
             cand --timeout 'timeout'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -834,10 +834,10 @@ const completion: Fig.Spec = {
           name: "--new-column",
         },
         {
-          name: "--jql",
+          name: "--jaq",
         },
         {
-          name: "--jqlfile",
+          name: "--jaqfile",
         },
         {
           name: "--pretty",
@@ -915,10 +915,10 @@ const completion: Fig.Spec = {
           name: "--new-column",
         },
         {
-          name: "--jql",
+          name: "--jaq",
         },
         {
-          name: "--jqlfile",
+          name: "--jaqfile",
         },
         {
           name: "--pretty",

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -325,8 +325,8 @@ complete -c qsv -n "__fish_qsv_using_subcommand explode" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand explode" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l url-template
 complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l new-column
-complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l jql
-complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l jqlfile
+complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l jaq
+complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l jaqfile
 complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l pretty
 complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l rate-limit
 complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l timeout
@@ -350,8 +350,8 @@ complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand fetch" -l progressbar
 complete -c qsv -n "__fish_qsv_using_subcommand fetch" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l new-column
-complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l jql
-complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l jqlfile
+complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l jaq
+complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l jaqfile
 complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l pretty
 complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l rate-limit
 complete -c qsv -n "__fish_qsv_using_subcommand fetchpost" -l timeout

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -331,8 +331,8 @@ module completions {
   export extern "qsv fetch" [
     --url-template
     --new-column
-    --jql
-    --jqlfile
+    --jaq
+    --jaqfile
     --pretty
     --rate-limit
     --timeout
@@ -359,8 +359,8 @@ module completions {
 
   export extern "qsv fetchpost" [
     --new-column
-    --jql
-    --jqlfile
+    --jaq
+    --jaqfile
     --pretty
     --rate-limit
     --timeout

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -451,8 +451,8 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         'qsv;fetch' {
             [CompletionResult]::new('--url-template', 'url-template', [CompletionResultType]::ParameterName, 'url-template')
             [CompletionResult]::new('--new-column', 'new-column', [CompletionResultType]::ParameterName, 'new-column')
-            [CompletionResult]::new('--jql', 'jql', [CompletionResultType]::ParameterName, 'jql')
-            [CompletionResult]::new('--jqlfile', 'jqlfile', [CompletionResultType]::ParameterName, 'jqlfile')
+            [CompletionResult]::new('--jaq', 'jaq', [CompletionResultType]::ParameterName, 'jaq')
+            [CompletionResult]::new('--jaqfile', 'jaqfile', [CompletionResultType]::ParameterName, 'jaqfile')
             [CompletionResult]::new('--pretty', 'pretty', [CompletionResultType]::ParameterName, 'pretty')
             [CompletionResult]::new('--rate-limit', 'rate-limit', [CompletionResultType]::ParameterName, 'rate-limit')
             [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'timeout')
@@ -480,8 +480,8 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         }
         'qsv;fetchpost' {
             [CompletionResult]::new('--new-column', 'new-column', [CompletionResultType]::ParameterName, 'new-column')
-            [CompletionResult]::new('--jql', 'jql', [CompletionResultType]::ParameterName, 'jql')
-            [CompletionResult]::new('--jqlfile', 'jqlfile', [CompletionResultType]::ParameterName, 'jqlfile')
+            [CompletionResult]::new('--jaq', 'jaq', [CompletionResultType]::ParameterName, 'jaq')
+            [CompletionResult]::new('--jaqfile', 'jaqfile', [CompletionResultType]::ParameterName, 'jaqfile')
             [CompletionResult]::new('--pretty', 'pretty', [CompletionResultType]::ParameterName, 'pretty')
             [CompletionResult]::new('--rate-limit', 'rate-limit', [CompletionResultType]::ParameterName, 'rate-limit')
             [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'timeout')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -455,8 +455,8 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '--url-template[]' \
 '--new-column[]' \
-'--jql[]' \
-'--jqlfile[]' \
+'--jaq[]' \
+'--jaqfile[]' \
 '--pretty[]' \
 '--rate-limit[]' \
 '--timeout[]' \
@@ -485,8 +485,8 @@ _arguments "${_arguments_options[@]}" : \
 (fetchpost)
 _arguments "${_arguments_options[@]}" : \
 '--new-column[]' \
-'--jql[]' \
-'--jqlfile[]' \
+'--jaq[]' \
+'--jaqfile[]' \
 '--pretty[]' \
 '--rate-limit[]' \
 '--timeout[]' \

--- a/resources/test/fetch_jaq_multiple.jaq
+++ b/resources/test/fetch_jaq_multiple.jaq
@@ -1,0 +1,1 @@
+[ ."places"[0]."place name" ,."places"[0]."state abbreviation" ]

--- a/resources/test/fetch_jaq_single.jaq
+++ b/resources/test/fetch_jaq_single.jaq
@@ -1,0 +1,1 @@
+."places"[0]."place name"

--- a/resources/test/fetch_jql_multiple.jql
+++ b/resources/test/fetch_jql_multiple.jql
@@ -1,1 +1,0 @@
-"places"[0]"place name","places"[0]"state abbreviation"

--- a/resources/test/fetch_jql_single.jql
+++ b/resources/test/fetch_jql_single.jql
@@ -1,1 +1,0 @@
-"places"[0]"place name"

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -11,9 +11,9 @@ fn fetch_simple() {
         vec![
             svec!["URL"],
             svec!["https://api.zippopotam.us/us/99999"],
-            svec!["  http://api.zippopotam.us/us/90210      "],
+            svec!["  https://api.zippopotam.us/us/90210      "],
             svec!["https://api.zippopotam.us/us/94105"],
-            svec!["http://api.zippopotam.us/us/92802      "],
+            svec!["https://api.zippopotam.us/us/92802      "],
             // svec!["https://query.wikidata.org/sparql?query=SELECT%20?dob%20WHERE%20{wd:Q42%20wdt:P569%20?dob.}&format=json"],
         ],
     );
@@ -43,9 +43,9 @@ fn fetch_simple_pretty_json() {
         vec![
             svec!["URL"],
             svec!["https://api.zippopotam.us/us/99999"],
-            svec!["  http://api.zippopotam.us/us/90210      "],
+            svec!["  https://api.zippopotam.us/us/90210      "],
             svec!["https://api.zippopotam.us/us/94105"],
-            svec!["http://api.zippopotam.us/us/92802      "],
+            svec!["https://api.zippopotam.us/us/92802      "],
             // svec!["https://query.wikidata.org/sparql?query=SELECT%20?dob%20WHERE%20{wd:Q42%20wdt:P569%20?dob.}&format=json"],
         ],
     );
@@ -62,7 +62,7 @@ fn fetch_simple_pretty_json() {
 
     let expected = r#"URL,pretty_response
 https://api.zippopotam.us/us/99999,
-http://api.zippopotam.us/us/90210,"{
+https://api.zippopotam.us/us/90210,"{
   ""post code"": ""90210"",
   ""country"": ""United States"",
   ""country abbreviation"": ""US"",
@@ -90,7 +90,7 @@ https://api.zippopotam.us/us/94105,"{
     }
   ]
 }"
-http://api.zippopotam.us/us/92802,"{
+https://api.zippopotam.us/us/92802,"{
   ""post code"": ""92802"",
   ""country"": ""United States"",
   ""country abbreviation"": ""US"",
@@ -116,9 +116,9 @@ fn fetch_simple_new_col() {
         vec![
             svec!["URL", "col2", "col3"],
             svec!["https://api.zippopotam.us/us/99999", "a", "1"],
-            svec!["  http://api.zippopotam.us/us/90210      ", "b", "2"],
+            svec!["  https://api.zippopotam.us/us/90210      ", "b", "2"],
             svec!["https://api.zippopotam.us/us/94105", "c", "3"],
-            svec!["http://api.zippopotam.us/us/92802      ", "d", "4"],
+            svec!["https://api.zippopotam.us/us/92802      ", "d", "4"],
             // svec!["https://query.wikidata.org/sparql?query=SELECT%20?dob%20WHERE%20{wd:Q42%20wdt:P569%20?dob.}&format=json", "Scott Adams", "42"],
         ],
     );
@@ -137,7 +137,7 @@ fn fetch_simple_new_col() {
         svec!["URL", "col2", "col3", "response"],
         svec!["https://api.zippopotam.us/us/99999", "a", "1", ""],
         svec![
-            "http://api.zippopotam.us/us/90210",
+            "https://api.zippopotam.us/us/90210",
             "b",
             "2",
             r#"{"post code":"90210","country":"United States","country abbreviation":"US","places":[{"place name":"Beverly Hills","longitude":"-118.4065","state":"California","state abbreviation":"CA","latitude":"34.0901"}]}"#
@@ -149,7 +149,7 @@ fn fetch_simple_new_col() {
             r#"{"post code":"94105","country":"United States","country abbreviation":"US","places":[{"place name":"San Francisco","longitude":"-122.3892","state":"California","state abbreviation":"CA","latitude":"37.7864"}]}"#
         ],
         svec![
-            "http://api.zippopotam.us/us/92802",
+            "https://api.zippopotam.us/us/92802",
             "d",
             "4",
             r#"{"post code":"92802","country":"United States","country abbreviation":"US","places":[{"place name":"Anaheim","longitude":"-117.9228","state":"California","state abbreviation":"CA","latitude":"33.8085"}]}"#
@@ -266,9 +266,9 @@ fn fetch_simple_redis() {
         vec![
             svec!["URL"],
             svec!["https://api.zippopotam.us/us/99999"],
-            svec!["  http://api.zippopotam.us/us/90210"],
+            svec!["  https://api.zippopotam.us/us/90210"],
             svec!["https://api.zippopotam.us/us/94105"],
-            svec!["http://api.zippopotam.us/us/92802"],
+            svec!["https://api.zippopotam.us/us/92802"],
             svec!["thisisnotaurl"],
             // svec!["https://query.wikidata.org/sparql?query=SELECT%20?dob%20WHERE%20{wd:Q42%20wdt:P569%20?dob.}&format=json"],
         ],
@@ -288,7 +288,6 @@ fn fetch_simple_redis() {
 {"post code":"94105","country":"United States","country abbreviation":"US","places":[{"place name":"San Francisco","longitude":"-122.3892","state":"California","state abbreviation":"CA","latitude":"37.7864"}]}
 {"post code":"92802","country":"United States","country abbreviation":"US","places":[{"place name":"Anaheim","longitude":"-117.9228","state":"California","state abbreviation":"CA","latitude":"33.8085"}]}
 {"errors":[{"title":"Invalid URL","detail":"relative URL without a base"}]}"#;
-    // {"head":{"vars":["dob"]},"results":{"bindings":[{"dob":{"datatype":"http://www.w3.org/2001/XMLSchema#dateTime","type":"literal","value":"1952-03-11T00:00:00Z"}}]}}"#;
 
     assert_eq!(got, expected);
 }
@@ -332,7 +331,6 @@ fn fetch_simple_diskcache() {
 {"post code":"94105","country":"United States","country abbreviation":"US","places":[{"place name":"San Francisco","longitude":"-122.3892","state":"California","state abbreviation":"CA","latitude":"37.7864"}]}
 {"post code":"92802","country":"United States","country abbreviation":"US","places":[{"place name":"Anaheim","longitude":"-117.9228","state":"California","state abbreviation":"CA","latitude":"33.8085"}]}
 {"errors":[{"title":"Invalid URL","detail":"relative URL without a base"}]}"#;
-    // {"head":{"vars":["dob"]},"results":{"bindings":[{"dob":{"datatype":"http://www.w3.org/2001/XMLSchema#dateTime","type":"literal","value":"1952-03-11T00:00:00Z"}}]}}"#;
 
     assert_eq!(got, expected);
 
@@ -340,15 +338,16 @@ fn fetch_simple_diskcache() {
 
     assert!(temp_dir.join("fetch_v1/conf").exists());
 
-    let mut cmd2 = wrk.command("fetch");
-    cmd2.arg("URL")
+    let mut cmd_2 = wrk.command("fetch");
+    cmd_2
+        .arg("URL")
         .arg("data.csv")
         .arg("--store-error")
         .arg("--disk-cache")
         .args(&["--disk-cache-dir", dc_dir])
         .args(&["--report", "short"]);
 
-    let got = wrk.stdout::<String>(&mut cmd2);
+    let got = wrk.stdout::<String>(&mut cmd_2);
     assert_eq!(got, expected);
 
     // sleep for a bit to make sure the cache is written to disk
@@ -376,14 +375,14 @@ thisisnotaurl,404,1,0,"{""errors"":[{""title"":""Invalid URL"",""detail"":""rela
 
 #[test]
 // #[ignore = "Temporarily skip this as it seems https://zippopotam.us is not currently available"]
-fn fetch_jql_single() {
+fn fetch_jaq_single() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
         vec![
             svec!["URL"],
-            svec!["http://api.zippopotam.us/us/90210"],
-            svec!["http://api.zippopotam.us/us/94105"],
+            svec!["https://api.zippopotam.us/us/90210"],
+            svec!["https://api.zippopotam.us/us/94105"],
             svec!["thisisnotaurl"],
             svec!["https://api.zippopotam.us/us/92802"],
         ],
@@ -392,15 +391,15 @@ fn fetch_jql_single() {
     cmd.arg("URL")
         .arg("--new-column")
         .arg("City")
-        .arg("--jql")
-        .arg(r#""places"[0]"place name""#)
+        .arg("--jaq")
+        .arg(r#"."places"[0]."place name""#)
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["URL", "City"],
-        svec!["http://api.zippopotam.us/us/90210", "\"Beverly Hills\""],
-        svec!["http://api.zippopotam.us/us/94105", "\"San Francisco\""],
+        svec!["https://api.zippopotam.us/us/90210", "\"Beverly Hills\""],
+        svec!["https://api.zippopotam.us/us/94105", "\"San Francisco\""],
         svec!["thisisnotaurl", ""],
         svec!["https://api.zippopotam.us/us/92802", "\"Anaheim\""],
     ];
@@ -410,14 +409,14 @@ fn fetch_jql_single() {
 
 #[test]
 // #[ignore = "Temporarily skip this as it seems https://zippopotam.us is not currently available"]
-fn fetch_jql_single_file() {
+fn fetch_jaq_single_file() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
         vec![
             svec!["URL"],
-            svec!["http://api.zippopotam.us/us/90210"],
-            svec!["http://api.zippopotam.us/us/94105"],
+            svec!["https://api.zippopotam.us/us/90210"],
+            svec!["https://api.zippopotam.us/us/94105"],
             svec!["https://api.zippopotam.us/us/92802"],
         ],
     );
@@ -425,18 +424,18 @@ fn fetch_jql_single_file() {
     cmd.arg("URL")
         .arg("--new-column")
         .arg("City")
-        .arg("--jqlfile")
+        .arg("--jaqfile")
         .arg(concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/resources/test/fetch_jql_single.jql"
+            "/resources/test/fetch_jaq_single.jaq"
         ))
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["URL", "City"],
-        svec!["http://api.zippopotam.us/us/90210", "\"Beverly Hills\""],
-        svec!["http://api.zippopotam.us/us/94105", "\"San Francisco\""],
+        svec!["https://api.zippopotam.us/us/90210", "\"Beverly Hills\""],
+        svec!["https://api.zippopotam.us/us/94105", "\"San Francisco\""],
         svec!["https://api.zippopotam.us/us/92802", "\"Anaheim\""],
     ];
     assert_eq!(got, expected);
@@ -444,14 +443,14 @@ fn fetch_jql_single_file() {
 
 #[test]
 // #[ignore = "Temporarily skip this as it seems https://zippopotam.us is not currently available"]
-fn fetch_jqlfile_doesnotexist_error() {
+fn fetch_jaqfile_doesnotexist_error() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
         vec![
             svec!["URL"],
-            svec!["http://api.zippopotam.us/us/90210"],
-            svec!["http://api.zippopotam.us/us/94105"],
+            svec!["http://api.zippopotam.us/us/90210"], // DevSkim: ignore DS137138
+            svec!["http://api.zippopotam.us/us/94105"], // DevSkim: ignore DS137138
             svec!["https://api.zippopotam.us/us/92802"],
         ],
     );
@@ -459,10 +458,10 @@ fn fetch_jqlfile_doesnotexist_error() {
     cmd.arg("URL")
         .arg("--new-column")
         .arg("City")
-        .arg("--jqlfile")
+        .arg("--jaqfile")
         .arg(concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/resources/test/doesnotexist.jql"
+            "/resources/test/doesnotexist.jaq"
         ))
         .arg("data.csv");
 
@@ -471,21 +470,21 @@ fn fetch_jqlfile_doesnotexist_error() {
 
 #[test]
 // #[ignore = "Temporarily skip this as it seems https://zippopotam.us is not currently available"]
-fn fetch_jql_jqlfile_error() {
+fn fetch_jaq_jaqfile_error() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
-        vec![svec!["URL"], svec!["http://api.zippopotam.us/us/90210"]],
+        vec![svec!["URL"], svec!["https://api.zippopotam.us/us/90210"]],
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL")
-        .arg("--jqlfile")
+        .arg("--jaqfile")
         .arg(concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/resources/test/fetch_jql_single.jql"
+            "/resources/test/fetch_jaq_single.jaq"
         ))
-        .arg("--jql")
-        .arg(r#""places"[0]"place name""#)
+        .arg("--jaq")
+        .arg(r#"."places"[0]."place name""#)
         .arg("data.csv");
 
     let got: String = wrk.output_stderr(&mut cmd);
@@ -496,14 +495,14 @@ fn fetch_jql_jqlfile_error() {
 
 #[test]
 // #[ignore = "Temporarily skip this as it seems https://zippopotam.us is not currently available"]
-fn fetch_jql_multiple() {
+fn fetch_jaq_multiple() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
         vec![
             svec!["URL"],
-            svec!["http://api.zippopotam.us/us/90210"],
-            svec!["http://api.zippopotam.us/us/94105"],
+            svec!["http://api.zippopotam.us/us/90210"], // DevSkim: ignore DS137138
+            svec!["http://api.zippopotam.us/us/94105"], // DevSkim: ignore DS137138
             svec!["https://api.zippopotam.us/us/92802"],
         ],
     );
@@ -511,19 +510,19 @@ fn fetch_jql_multiple() {
     cmd.arg("URL")
         .arg("--new-column")
         .arg("CityState")
-        .arg("--jql")
-        .arg(r#""places"[0]"place name","places"[0]"state abbreviation""#)
+        .arg("--jaq")
+        .arg(r#"[ ."places"[0]."place name", ."places"[0]."state abbreviation" ]"#)
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["URL", "CityState"],
         svec![
-            "http://api.zippopotam.us/us/90210",
+            "http://api.zippopotam.us/us/90210", // DevSkim: ignore DS137138
             "[\"Beverly Hills\",\"CA\"]"
         ],
         svec![
-            "http://api.zippopotam.us/us/94105",
+            "http://api.zippopotam.us/us/94105", // DevSkim: ignore DS137138
             "[\"San Francisco\",\"CA\"]"
         ],
         svec!["https://api.zippopotam.us/us/92802", "[\"Anaheim\",\"CA\"]"],
@@ -533,14 +532,14 @@ fn fetch_jql_multiple() {
 
 #[test]
 // #[ignore = "Temporarily skip this as it seems https://zippopotam.us is not currently available"]
-fn fetch_jql_multiple_file() {
+fn fetch_jaq_multiple_file() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
         vec![
             svec!["URL"],
-            svec!["http://api.zippopotam.us/us/90210"],
-            svec!["http://api.zippopotam.us/us/94105"],
+            svec!["http://api.zippopotam.us/us/90210"], // DevSkim: ignore DS137138
+            svec!["http://api.zippopotam.us/us/94105"], // DevSkim: ignore DS137138
             svec!["https://api.zippopotam.us/us/92802"],
         ],
     );
@@ -548,10 +547,10 @@ fn fetch_jql_multiple_file() {
     cmd.arg("URL")
         .arg("--new-column")
         .arg("CityState")
-        .arg("--jqlfile")
+        .arg("--jaqfile")
         .arg(concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/resources/test/fetch_jql_multiple.jql"
+            "/resources/test/fetch_jaq_multiple.jaq"
         ))
         .arg("data.csv");
 
@@ -559,11 +558,11 @@ fn fetch_jql_multiple_file() {
     let expected = vec![
         svec!["URL", "CityState"],
         svec![
-            "http://api.zippopotam.us/us/90210",
+            "http://api.zippopotam.us/us/90210", // DevSkim: ignore DS137138
             "[\"Beverly Hills\",\"CA\"]"
         ],
         svec![
-            "http://api.zippopotam.us/us/94105",
+            "http://api.zippopotam.us/us/94105", // DevSkim: ignore DS137138
             "[\"San Francisco\",\"CA\"]"
         ],
         svec!["https://api.zippopotam.us/us/92802", "[\"Anaheim\",\"CA\"]"],
@@ -577,7 +576,7 @@ fn fetch_custom_header() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
-        vec![svec!["URL"], svec!["http://httpbin.org/get"]],
+        vec![svec!["URL"], svec!["http://httpbin.org/get"]], // DevSkim: ignore DS137138
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL")
@@ -585,8 +584,8 @@ fn fetch_custom_header() {
         .arg(" X-Api-Key :  DEMO_KEY")
         .arg("-H")
         .arg("X-Api-Secret :ABC123XYZ")
-        .arg("--jql")
-        .arg(r#""headers""X-Api-Key","headers""X-Api-Secret""#)
+        .arg("--jaq")
+        .arg(r#"[ ."headers"."X-Api-Key", ."headers"."X-Api-Secret" ]"#)
         .arg("data.csv");
 
     let got = wrk.stdout::<String>(&mut cmd);
@@ -600,7 +599,7 @@ fn fetch_custom_invalid_header_error() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
-        vec![svec!["URL"], svec!["http://httpbin.org/get"]],
+        vec![svec!["URL"], svec!["http://httpbin.org/get"]], // DevSkim: ignore DS137138
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL")
@@ -619,7 +618,7 @@ fn fetch_custom_invalid_user_agent_error() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
-        vec![svec!["URL"], svec!["http://httpbin.org/get"]],
+        vec![svec!["URL"], svec!["http://httpbin.org/get"]], // DevSkim: ignore DS137138
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL")
@@ -640,7 +639,7 @@ fn fetch_custom_user_agent() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
-        vec![svec!["URL"], svec!["http://httpbin.org/get"]],
+        vec![svec!["URL"], svec!["http://httpbin.org/get"]], // DevSkim: ignore DS137138
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL")
@@ -661,7 +660,7 @@ fn fetch_user_agent() {
     let wrk = Workdir::new("fetch_user_agent");
     wrk.create(
         "data.csv",
-        vec![svec!["URL"], svec!["http://httpbin.org/get"]],
+        vec![svec!["URL"], svec!["http://httpbin.org/get"]], // DevSkim: ignore DS137138
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL").arg("data.csv");
@@ -679,7 +678,7 @@ fn fetch_custom_invalid_value_error() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
-        vec![svec!["URL"], svec!["http://httpbin.org/get"]],
+        vec![svec!["URL"], svec!["http://httpbin.org/get"]], // DevSkim: ignore DS137138
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL")
@@ -917,8 +916,8 @@ fn fetch_ratelimit() {
     cmd.arg("URL")
         .arg("--new-column")
         .arg("Fullname")
-        .arg("--jql")
-        .arg(r#""fullname""#)
+        .arg("--jaq")
+        .arg(r#"."fullname""#)
         .arg("--rate-limit")
         .arg("4")
         .arg("data.csv");
@@ -1011,8 +1010,8 @@ fn fetch_complex_url_template() {
         ))
         .arg("--new-column")
         .arg("Fullname")
-        .arg("--jql")
-        .arg(r#""fullname""#)
+        .arg("--jaq")
+        .arg(r#"."fullname""#)
         .arg("--rate-limit")
         .arg("4")
         .arg("data.csv");
@@ -1067,8 +1066,8 @@ fn fetchpost_simple_test() {
     let mut cmd = wrk.command("fetchpost");
     cmd.arg("URL")
         .arg("bool_col,col1,number col")
-        .arg("--jql")
-        .arg(r#""form""#)
+        .arg("--jaq")
+        .arg(r#"."form""#)
         .arg("--new-column")
         .arg("response")
         .arg("data.csv");
@@ -1150,8 +1149,8 @@ fn fetchpost_simple_diskcache() {
     let mut cmd = wrk.command("fetchpost");
     cmd.arg("URL")
         .arg("bool_col,col1,number col")
-        .arg("--jql")
-        .arg(r#""form""#)
+        .arg("--jaq")
+        .arg(r#"."form""#)
         .arg("--new-column")
         .arg("response")
         .arg("--disk-cache")
@@ -1215,7 +1214,7 @@ fn fetchpost_simple_diskcache() {
     // let mut cmd2 = wrk.command("fetchpost");
     // cmd.arg("URL")
     //     .arg("bool_col,col1,number col")
-    //     .arg("--jql")
+    //     .arg("--jaq")
     //     .arg(r#""form""#)
     //     .arg("--new-column")
     //     .arg("response")
@@ -1283,8 +1282,8 @@ fn fetchpost_compress_test() {
     let mut cmd = wrk.command("fetchpost");
     cmd.arg("URL")
         .arg("bool_col,col1,number col")
-        .arg("--jql")
-        .arg(r#""form""#)
+        .arg("--jaq")
+        .arg(r#"."form""#)
         .arg("--new-column")
         .arg("response")
         .arg("--compress")
@@ -1356,7 +1355,7 @@ fn fetchpost_compress_test() {
 
 #[test]
 // #[ignore = "Temporarily skip this as it seems httpbin.org is not currently available"]
-fn fetchpost_jqlfile_doesnotexist_error() {
+fn fetchpost_jaqfile_doesnotexist_error() {
     let wrk = Workdir::new("fetch");
     wrk.create(
         "data.csv",
@@ -1372,10 +1371,10 @@ fn fetchpost_jqlfile_doesnotexist_error() {
     let mut cmd = wrk.command("fetchpost");
     cmd.arg("URL")
         .arg("bool_col,col1,number col")
-        .arg("--jqlfile")
+        .arg("--jaqfile")
         .arg(concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/resources/test/doesnotexist.jql"
+            "/resources/test/doesnotexist.jaq"
         ))
         .arg("--new-column")
         .arg("response")
@@ -1400,8 +1399,8 @@ fn fetchpost_literalurl_test() {
     let mut cmd = wrk.command("fetchpost");
     cmd.arg("https://httpbin.org/post")
         .arg("bool_col,col1,number col")
-        .arg("--jql")
-        .arg(r#""form""#)
+        .arg("--jaq")
+        .arg(r#"."form""#)
         .arg("--new-column")
         .arg("response")
         .arg("data.csv");
@@ -1462,8 +1461,8 @@ fn fetchpost_simple_report() {
     let mut cmd = wrk.command("fetchpost");
     cmd.arg("https://httpbin.org/post")
         .arg("bool_col,col1,number_col")
-        .arg("--jql")
-        .arg(r#""form""#)
+        .arg("--jaq")
+        .arg(r#"."form""#)
         .arg("--new-column")
         .arg("response")
         .arg("--report")


### PR DESCRIPTION
jaq was introduced with the `json` command, which has the same functionality as jql.

jaq is a jq clone, which is a widely used JSON parser.

So just standardize on jaq for the qsv suite and remove jql.

Resolves #1981 
