### PR TITLE
`validate`: add `dynamicEnum` lookup support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_urlencoded = { version = "0.7", optional = true }
-simple-expand-tilde = { version = "0.4.3", optional = true }
+simple-expand-tilde = "0.4"
 smallvec = "1"
 snap = "1"
 strsim = { version = "0.11", optional = true }
@@ -357,18 +357,10 @@ fetch = [
     "publicsuffix",
     "redis",
     "serde_urlencoded",
-    "simple-expand-tilde",
 ]
 foreach = ["local-encoding"]
-geocode = [
-    "bytemuck",
-    "cached",
-    "geosuggest-core",
-    "geosuggest-utils",
-    "phf",
-    "simple-expand-tilde",
-]
-luau = ["mlua", "sanitize-filename", "simple-expand-tilde"]
+geocode = ["bytemuck", "cached", "geosuggest-core", "geosuggest-utils", "phf"]
+luau = ["mlua", "sanitize-filename"]
 polars = ["dep:polars", "bytemuck"]
 prompt = ["rfd"]
 python = ["pyo3"]

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -250,11 +250,11 @@ use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{debug, info, log_enabled};
 use mlua::{Lua, LuaSerdeExt, Value};
 use serde::Deserialize;
-use simple_expand_tilde::expand_tilde;
 
+// use simple_expand_tilde::expand_tilde;
 use crate::{
     config::{Config, Delimiter, DEFAULT_WTR_BUFFER_CAPACITY},
-    util, CliError, CliResult,
+    lookup, util, CliError, CliResult,
 };
 
 #[allow(dead_code)]
@@ -570,25 +570,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // check if qsv_registerlookup_used is set, if it is, setup the qsv_cache directory
     if qsv_register_lookup_used {
-        let qsv_cache_dir = if let Ok(cache_path) = std::env::var("QSV_CACHE_DIR") {
-            // if QSV_CACHE_DIR env var is set, check if it exists. If it doesn't, create it.
-            if cache_path.starts_with('~') {
-                // expand the tilde
-                let expanded_dir = expand_tilde(&cache_path).unwrap();
-                expanded_dir.to_string_lossy().to_string()
-            } else {
-                cache_path
-            }
-        } else if args.flag_cache_dir.starts_with('~') {
-            // expand the tilde
-            let expanded_dir = expand_tilde(&args.flag_cache_dir).unwrap();
-            expanded_dir.to_string_lossy().to_string()
-        } else {
-            args.flag_cache_dir.clone()
-        };
-        if !Path::new(&qsv_cache_dir).exists() {
-            fs::create_dir_all(&qsv_cache_dir)?;
-        }
+        let qsv_cache_dir = lookup::set_qsv_cache_dir(&args.flag_cache_dir)?;
 
         info!("Using cache directory: {qsv_cache_dir}");
         globals.raw_set(QSV_CACHE_DIR, qsv_cache_dir)?;

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -74,6 +74,7 @@ mod clitypes;
 mod cmd;
 mod config;
 mod index;
+mod lookup;
 mod odhtcache;
 mod select;
 mod util;

--- a/tests/test_schema.rs
+++ b/tests/test_schema.rs
@@ -52,7 +52,7 @@ fn generate_schema_with_defaults_and_validate_trim_with_no_errors() {
 
     // not expecting any invalid rows, so confirm there are NO output files generated
     let validation_error_path = &wrk.path("adur-public-toilets.csv.validation-errors.tsv");
-    println!("not expecting validation error file at: {validation_error_path:?}");
+    // println!("not expecting validation error file at: {validation_error_path:?}");
     assert!(!Path::new(validation_error_path).exists());
     assert!(!Path::new(&wrk.path("adur-public-toilets.csv.valid")).exists());
     assert!(!Path::new(&wrk.path("adur-public-toilets.csv.invalid")).exists());
@@ -125,7 +125,7 @@ fn generate_schema_with_optional_flags_notrim_and_validate_with_errors() {
 
     // expecting invalid rows, so confirm there ARE output files generated
     let validation_error_path = &wrk.path("adur-public-toilets.csv.validation-errors.tsv");
-    println!("expecting validation error file at: {validation_error_path:?}");
+    // println!("expecting validation error file at: {validation_error_path:?}");
 
     assert!(Path::new(validation_error_path).exists());
     assert!(Path::new(&wrk.path("adur-public-toilets.csv.valid")).exists());
@@ -210,7 +210,7 @@ fn generate_schema_with_optional_flags_trim_and_validate_with_errors() {
 
     // expecting invalid rows, so confirm there ARE output files generated
     let validation_error_path = &wrk.path("adur-public-toilets.csv.validation-errors.tsv");
-    println!("expecting validation error file at: {validation_error_path:?}");
+    // println!("expecting validation error file at: {validation_error_path:?}");
 
     assert!(Path::new(validation_error_path).exists());
     assert!(Path::new(&wrk.path("adur-public-toilets.csv.valid")).exists());


### PR DESCRIPTION
dynamicEnum, in addition to local and remote (http, https) files, can now be set to CKAN and datHere sources, using the cached-back lookup module