### PR TITLE
feat: update completions for qsv v5.1.0

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -3278,7 +3278,7 @@ _qsv() {
             return 0
             ;;
         qsv__lens)
-            opts="-h --delimiter --tab-separated --no-headers --columns --filter --find --ignore-case --freeze-columns --echo-column --debug --help"
+            opts="-h --delimiter --tab-separated --no-headers --columns --filter --find --ignore-case --freeze-columns --monochrome --prompt --echo-column --debug --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4286,7 +4286,7 @@ _qsv() {
             return 0
             ;;
         qsv__validate)
-            opts="-h --trim --fail-fast --valid --invalid --json --pretty-json --valid-output --jobs --batch --timeout --cache-dir --ckan-api --ckan-token --no-headers --delimiter --progressbar --quiet --help"
+            opts="-h --trim --no-format-validation --fail-fast --valid --invalid --json --pretty-json --valid-output --jobs --batch --timeout --cache-dir --ckan-api --ckan-token --no-headers --delimiter --progressbar --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -1037,6 +1037,8 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --find 'find'
             cand --ignore-case 'ignore-case'
             cand --freeze-columns 'freeze-columns'
+            cand --monochrome 'monochrome'
+            cand --prompt 'prompt'
             cand --echo-column 'echo-column'
             cand --debug 'debug'
             cand -h 'Print help'
@@ -1763,6 +1765,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
         }
         &'qsv;validate'= {
             cand --trim 'trim'
+            cand --no-format-validation 'no-format-validation'
             cand --fail-fast 'fail-fast'
             cand --valid 'valid'
             cand --invalid 'invalid'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -2496,6 +2496,12 @@ const completion: Fig.Spec = {
           name: "--freeze-columns",
         },
         {
+          name: "--monochrome",
+        },
+        {
+          name: "--prompt",
+        },
+        {
           name: "--echo-column",
         },
         {
@@ -4360,6 +4366,9 @@ const completion: Fig.Spec = {
       options: [
         {
           name: "--trim",
+        },
+        {
+          name: "--no-format-validation",
         },
         {
           name: "--fail-fast",

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -834,6 +834,8 @@ complete -c qsv -n "__fish_qsv_using_subcommand lens" -l filter
 complete -c qsv -n "__fish_qsv_using_subcommand lens" -l find
 complete -c qsv -n "__fish_qsv_using_subcommand lens" -l ignore-case
 complete -c qsv -n "__fish_qsv_using_subcommand lens" -l freeze-columns
+complete -c qsv -n "__fish_qsv_using_subcommand lens" -l monochrome
+complete -c qsv -n "__fish_qsv_using_subcommand lens" -l prompt
 complete -c qsv -n "__fish_qsv_using_subcommand lens" -l echo-column
 complete -c qsv -n "__fish_qsv_using_subcommand lens" -l debug
 complete -c qsv -n "__fish_qsv_using_subcommand lens" -s h -l help -d 'Print help'
@@ -1370,6 +1372,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand transpose" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand transpose" -l memcheck
 complete -c qsv -n "__fish_qsv_using_subcommand transpose" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand validate" -l trim
+complete -c qsv -n "__fish_qsv_using_subcommand validate" -l no-format-validation
 complete -c qsv -n "__fish_qsv_using_subcommand validate" -l fail-fast
 complete -c qsv -n "__fish_qsv_using_subcommand validate" -l valid
 complete -c qsv -n "__fish_qsv_using_subcommand validate" -l invalid

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -942,6 +942,8 @@ module completions {
     --find
     --ignore-case
     --freeze-columns
+    --monochrome
+    --prompt
     --echo-column
     --debug
     --help(-h)                # Print help
@@ -1662,6 +1664,7 @@ module completions {
 
   export extern "qsv validate" [
     --trim
+    --no-format-validation
     --fail-fast
     --valid
     --invalid

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -1118,6 +1118,8 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             [CompletionResult]::new('--find', '--find', [CompletionResultType]::ParameterName, 'find')
             [CompletionResult]::new('--ignore-case', '--ignore-case', [CompletionResultType]::ParameterName, 'ignore-case')
             [CompletionResult]::new('--freeze-columns', '--freeze-columns', [CompletionResultType]::ParameterName, 'freeze-columns')
+            [CompletionResult]::new('--monochrome', '--monochrome', [CompletionResultType]::ParameterName, 'monochrome')
+            [CompletionResult]::new('--prompt', '--prompt', [CompletionResultType]::ParameterName, 'prompt')
             [CompletionResult]::new('--echo-column', '--echo-column', [CompletionResultType]::ParameterName, 'echo-column')
             [CompletionResult]::new('--debug', '--debug', [CompletionResultType]::ParameterName, 'debug')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
@@ -1916,6 +1918,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
         }
         'qsv;validate' {
             [CompletionResult]::new('--trim', '--trim', [CompletionResultType]::ParameterName, 'trim')
+            [CompletionResult]::new('--no-format-validation', '--no-format-validation', [CompletionResultType]::ParameterName, 'no-format-validation')
             [CompletionResult]::new('--fail-fast', '--fail-fast', [CompletionResultType]::ParameterName, 'fail-fast')
             [CompletionResult]::new('--valid', '--valid', [CompletionResultType]::ParameterName, 'valid')
             [CompletionResult]::new('--invalid', '--invalid', [CompletionResultType]::ParameterName, 'invalid')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -1160,6 +1160,8 @@ _arguments "${_arguments_options[@]}" : \
 '--find[]' \
 '--ignore-case[]' \
 '--freeze-columns[]' \
+'--monochrome[]' \
+'--prompt[]' \
 '--echo-column[]' \
 '--debug[]' \
 '-h[Print help]' \
@@ -2108,6 +2110,7 @@ _arguments "${_arguments_options[@]}" : \
 (validate)
 _arguments "${_arguments_options[@]}" : \
 '--trim[]' \
+'--no-format-validation[]' \
 '--fail-fast[]' \
 '--valid[]' \
 '--invalid[]' \

--- a/contrib/completions/src/cmd/lens.rs
+++ b/contrib/completions/src/cmd/lens.rs
@@ -10,6 +10,8 @@ pub fn lens_cmd() -> Command {
         arg!(--find),
         arg!(--"ignore-case"),
         arg!(--"freeze-columns"),
+        arg!(--monochrome),
+        arg!(--prompt),
         arg!(--"echo-column"),
         arg!(--debug),
     ])

--- a/contrib/completions/src/cmd/validate.rs
+++ b/contrib/completions/src/cmd/validate.rs
@@ -3,6 +3,7 @@ use clap::{arg, Command};
 pub fn validate_cmd() -> Command {
     Command::new("validate").args([
         arg!(--trim),
+        arg!(--"no-format-validation"),
         arg!(--"fail-fast"),
         arg!(--valid),
         arg!(--invalid),


### PR DESCRIPTION
Adds completions for qsv v5.1.0 (lens `--prompt` and `--monochrome` and validate `--no-format-validation`).