### PR TITLE
feat: add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,9 @@ keywords:
   - data wrangling
   - spreadsheet
   - rust
-license: Unlicense
+license:
+  - Unlicense
+  - MIT
 commit: 1b160d0903e808f0cf335b69c97bc3b6dfd20256
 version: 11.0.2
 date-released: '2025-12-08'


### PR DESCRIPTION
Adds an initial version of `CITATION.cff`. Feel free to improve this and parts of it could probably be automated. For example at the bottom we include `commit`, `version`, and `date-released` which should probably be automated or removed for now (also not sure how this would be handled as someone may use a different commit like the `master` branch). Also for the `authors` section perhaps a way to add GitHub contributors but for now I put "The qsv project" as per the schema guide to start with, or perhaps "The qsv Project Developers" might look better. Also perhaps `command-line tool` could be added as a keyword.

Here's a schema guide for the file that could be useful: https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md

You can try out the "Cite this repository" button on the sidebar here: https://github.com/dathere/qsv/tree/citation