### PR TITLE
fix: refresh_cpu_all() -> refresh_cpu_list(sysinfo::CpuRefreshKind::n…

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -516,7 +516,7 @@ pub fn version() -> String {
     let max_file_size = mem_file_check(Path::new(""), true, false).unwrap_or(0) as u64;
 
     // we also get System info to help with debugging and logging.
-    // we just need the CPU model name and physical core count, so we ask for nothing
+    // we just need the CPU model name, so we ask for nothing
     sys.refresh_cpu_list(sysinfo::CpuRefreshKind::nothing());
     let os_version = System::long_os_version().unwrap_or_else(|| "Unknown".to_string());
     let kernel_version = System::kernel_long_version();


### PR DESCRIPTION
…othing())

we only need the make/model of the CPU for version, we don't need any more metadata for CPUs. Apparently, for systems with a lot of CPUs, this fetches so much metadata that it vastly increases startup time when --version is used.

resolves #3260