### PR TITLE
fix(validate): update for jsonschema 0.39 API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1233,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1339d398d44e506d9b72c1af2f6f51a41c9c64f9a0738eb9aedede47ed1f683"
+checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
 
 [[package]]
 name = "codepage"
@@ -2349,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fixedbitset"
@@ -2726,7 +2726,7 @@ dependencies = [
  "anyhow",
  "futures",
  "geosuggest-core",
- "reqwest",
+ "reqwest 0.12.28",
  "rkyv 0.8.14",
  "serde",
  "tokio",
@@ -3515,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f50532ce4a0ba3ae930212908d8ec50e7806065c059fe9c75da2ece6132294"
+checksum = "757e9e064986e27b3b33ef3f0926a08637745002a8aa1d5c178291061a4530e6"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -3534,7 +3534,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -4340,7 +4340,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "serde",
  "serde_json",
@@ -4916,7 +4916,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "simd-json",
@@ -5601,7 +5601,7 @@ dependencies = [
  "rayon",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rfd",
  "rust_decimal",
  "sanitize-filename",
@@ -6116,9 +6116,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a8af0c6bb8eaf8b07cb06fc31ff30ca6fe19fb99afa476c276d8b24f365b0b"
+checksum = "d279220464be12a6e0c5612ea460bf1fd8407f701447dcb3875463fdda4c3dbf"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",
@@ -6226,6 +6226,39 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6478,9 +6511,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6488,9 +6521,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6622,7 +6655,7 @@ dependencies = [
  "log",
  "quick-xml",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "self-replace",
  "semver",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ jaq-core = "2"
 jaq-json = { version = "1", features = ["serde_json"] }
 jaq-std = "2"
 json-objects-to-csv = "0.1.3"
-jsonschema = { version = "0.38", features = [
+jsonschema = { version = "0.39", features = [
     "resolve-file",
     "resolve-http",
 ], default-features = false }

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -1539,7 +1539,8 @@ fn validate_invalid_json_schema_file() {
         got,
         "JSON Schema Meta-Reference Error: Resource \
          'https://json-schema.org/draft/2020-25/schema' is not present in a registry and \
-         retrieving it failed: error decoding response body\n"
+         retrieving it failed: error sending request for url \
+         (https://json-schema.org/draft/2020-25/schema)\n"
     );
 
     // Create schema with format validation
@@ -1751,7 +1752,8 @@ fn validate_schema_subcommand_invalid_draft() {
     let expected =
         "JSON Schema Meta-Reference Error: Resource \
          'https://json-schema.org/draft/2020-25/schema' is not present in a registry and \
-         retrieving it failed: error decoding response body\n";
+         retrieving it failed: error sending request for url \
+         (https://json-schema.org/draft/2020-25/schema)\n";
     assert_eq!(got, expected);
 }
 


### PR DESCRIPTION
Update validate command to work with jsonschema 0.39.0 which introduced breaking changes to the Keyword and ValidationError APIs.

Changes:
- Update Keyword::validate method signature (removed instance_path parameter)
- Simplify ValidationError::custom calls (now only takes message parameter)
- Remove unused LazyLocation import
- Update test expectations for new error format
- Fix all validator factories (DynEnumValidator, UniqueCombinedWithValidator)

All tests pass across all three binary variants (lite, all_features, datapusher_plus).