### PR TITLE
feat(frequency): add --no-float flag to exclude Float columns

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -606,6 +606,7 @@ fn get_unique_values(
         flag_no_nulls:        true,
         flag_no_trim:         false,
         flag_ignore_case:     args.flag_ignore_case,
+        flag_no_float:        None,
         flag_all_unique_text: "<ALL UNIQUE>".to_string(),
         flag_jobs:            Some(util::njobs(args.flag_jobs)),
         flag_output:          None,


### PR DESCRIPTION
Add --no-float flag to exclude Float columns from frequency analysis. Floats typically contain continuous values where frequency tables are not meaningful.

Usage:
- `--no-float "*"`: Exclude all Float columns
- `--no-float "price,rate"`: Exclude Floats except specified columns

Requires stats cache for type detection (auto-created if not present).

Closes #3338