### PR TITLE
perf(mcp): lazy-load skills based on exposure mode

### DIFF
--- a/.claude/skills/src/loader.ts
+++ b/.claude/skills/src/loader.ts
@@ -90,14 +90,21 @@ export class SkillLoader {
   }
 
   /**
-   * Load multiple skills by name (batch loading)
+   * Load multiple skills by name (batch loading with parallel I/O)
    * Returns Map of successfully loaded skills
    */
   async loadByNames(skillNames: string[]): Promise<Map<string, QsvSkill>> {
     const results = new Map<string, QsvSkill>();
 
-    for (const name of skillNames) {
+    // Load all skills in parallel for better performance
+    const loadPromises = skillNames.map(async (name) => {
       const skill = await this.load(name);
+      return { name, skill };
+    });
+
+    const loadedResults = await Promise.all(loadPromises);
+
+    for (const { name, skill } of loadedResults) {
       if (skill) {
         results.set(name, skill);
       }

--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -303,9 +303,7 @@ class QsvMcpServer {
           // Expose all available skills as individual tools
           // Load all skills (cached after first call)
           if (!this.loader.isAllLoaded()) {
-            console.error(
-              "[Server] First request - loading all skills...",
-            );
+            console.error("[Server] First request - loading all skills...");
           } else {
             console.error(
               "[Server] Expose all tools mode - using cached skills",
@@ -357,6 +355,17 @@ class QsvMcpServer {
           console.error(
             `[Server] Loaded ${loadedSkills.size}/${filteredCommands.length} common skills`,
           );
+
+          // Log any skills that failed to load (requested but not returned)
+          const loadedSkillNames = new Set(loadedSkills.keys());
+          const failedSkillNames = skillNames.filter(
+            (name) => !loadedSkillNames.has(name),
+          );
+          if (failedSkillNames.length > 0) {
+            console.error(
+              `[Server] ⚠ Failed to load skills: ${failedSkillNames.join(", ")}`,
+            );
+          }
 
           for (const [skillName, skill] of loadedSkills) {
             try {

--- a/.claude/skills/src/mcp-tools.ts
+++ b/.claude/skills/src/mcp-tools.ts
@@ -982,7 +982,7 @@ export async function handleToolCall(
                   suggestions[0].distance <= inputFile.length / 2
                 ) {
                   errorMessage += "Did you mean one of these?\n";
-                  suggestions.forEach(({ name, distance }) => {
+                  suggestions.forEach(({ name }) => {
                     errorMessage += `  - ${name}\n`;
                   });
                 } else {


### PR DESCRIPTION
Defer skill loading from server startup to first ListTools request, loading only the skills needed for the current exposure mode.

- Add loadByNames() for batch loading specific skills
- Add isAllLoaded() to track loading state and enable caching
- Update loadAll() to return cached skills on subsequent calls
- Remove startup loading, defer to first request
- Common-tools mode now loads only 13 skills instead of all 60

Expected improvement: 77-87% faster startup time.