### PR TITLE
feat(mcp): Add qsv_data_profile tips and pivotp guidance

### DIFF
--- a/.claude/skills/src/mcp-tools.ts
+++ b/.claude/skills/src/mcp-tools.ts
@@ -161,9 +161,9 @@ const ERROR_PREVENTION_HINTS: Record<string, string> = {
   dedup: "May OOM on files >1GB. Use qsv_extdedup for large files.",
   sort: "May OOM on files >1GB. Use qsv_extsort for large files.",
   frequency:
-    "High-cardinality columns (IDs, timestamps) produce huge output. Use qsv_data_profile first to check for <ALL_UNIQUE> markers.",
+    "High-cardinality columns (IDs, timestamps) can produce huge output. Use qsv_data_profile to inspect cardinality and uniqueness_ratio; <ALL_UNIQUE> is one strong signal of high cardinality.",
   pivotp:
-    "High-cardinality pivot columns create wide output. Use qsv_data_profile to check cardinality first.",
+    "High-cardinality pivot columns create wide output. Use qsv_data_profile to check cardinality and uniqueness_ratio of potential pivot columns; treat <ALL_UNIQUE> as just one strong signal.",
   sqlp: "When encountering errors with sqlp, use DuckDB when available instead for complex queries.",
   moarstats:
     "Run stats first to create cache. Slower than stats but richer output.",


### PR DESCRIPTION
Add recommendations to run qsv_data_profile before expensive operations and introduce pivotp guidance. Updated WHEN_TO_USE_GUIDANCE entries (frequency, joinp, dedup, sort) to suggest profiling for cardinality/uniqueness and optimal ordering or to avoid unnecessary work. Added pivotp usage note (agg options and cardinality check). Expanded COMMON_PATTERNS and ERROR_PREVENTION_HINTS with profile→join/pivot advice and a pivotp warning about high-cardinality pivots. Also register pivotp in COMMANDS_WITH_COMMON_MISTAKES.