### PR TITLE
refactor: Use foldhash HashMap/HashSet across codebase

### DIFF
--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -330,7 +330,6 @@ Common options:
 "#;
 
 use std::{
-    collections::HashMap,
     env, fs,
     io::Write,
     path::{Path, PathBuf},
@@ -342,6 +341,7 @@ use std::{
 use cached::{
     DiskCache, IOCached, RedisCache, Return, proc_macro::io_cached, stores::DiskCacheBuilder,
 };
+use foldhash::{HashMap, HashMapExt};
 use indexmap::{IndexMap, IndexSet};
 use indicatif::HumanCount;
 use minijinja::{Environment, context};

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -261,7 +261,6 @@ Common options:
 
 use std::{
     cell::RefCell,
-    collections::HashMap,
     fs, io,
     io::Write,
     path::{Path, PathBuf},
@@ -269,6 +268,7 @@ use std::{
 };
 
 use csv_index::RandomAccessSimple;
+use foldhash::{HashMap, HashMapExt};
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{debug, info, log_enabled};

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -69,9 +69,9 @@ Common options:
                              Must be a single character. (default: ,)
 "#;
 
-use std::{collections::HashSet, fs, io, path::Path};
+use std::{fs, io, path::Path};
 
-use foldhash::{HashMap, HashMapExt};
+use foldhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use regex::Regex;
 use serde::Deserialize;
 use sysinfo::System;

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -66,7 +66,6 @@ Common options:
 "#;
 
 use std::{
-    collections::HashSet,
     fs::File,
     io,
     io::{BufReader, Read, Write},
@@ -75,6 +74,7 @@ use std::{
 };
 
 use csv::ByteRecord;
+use foldhash::HashSet;
 use indicatif::HumanCount;
 use polars::prelude::*;
 use serde::Deserialize;

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -50,8 +50,7 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
-use std::collections::HashMap;
-
+use foldhash::{HashMap, HashMapExt};
 use serde::Deserialize;
 
 use crate::{

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -88,9 +88,10 @@ Common options:
 
 "#;
 
-use std::{borrow::Cow, collections::HashSet, fs, sync::Arc};
+use std::{borrow::Cow, fs, sync::Arc};
 
 use crossbeam_channel;
+use foldhash::HashSet;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget};
 use regex::bytes::RegexBuilder;

--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -99,9 +99,7 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
-use std::collections::HashMap;
-
-use foldhash::fast::RandomState;
+use foldhash::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -204,7 +202,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // Verify or VerifyVerbose Mode
         let mut safenames_vec: Vec<String> = Vec::new();
         let mut unsafenames_vec: Vec<String> = Vec::new();
-        let mut checkednames_map: HashMap<String, u16, RandomState> = HashMap::default();
+        let mut checkednames_map: HashMap<String, u16> = HashMap::default();
         let mut temp_string;
 
         for header_name in &headers {

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -227,14 +227,11 @@ Common options:
                            Must be a single character. (default: ,)
 "#;
 
-use std::{
-    collections::{HashMap, HashSet},
-    io,
-    str::FromStr,
-};
+use std::{io, str::FromStr};
 
 use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc, Weekday};
 use chrono_tz::Tz;
+use foldhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use futures_util::StreamExt;
 use qsv_dateparser::parse_with_preference_and_timezone;
 use rand::{
@@ -1562,8 +1559,6 @@ fn do_weighted_sampling<T: Rng + ?Sized>(
     max_weight: f64,
     rng: &mut T,
 ) -> CliResult<()> {
-    use std::collections::HashSet;
-
     let mut selected = HashSet::with_capacity(sample_size);
     let mut attempts = 0;
     let max_attempts = sample_size * 100; // Prevent infinite loops

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -276,7 +276,6 @@ Common options:
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
     env,
     fs::File,
     io,
@@ -286,6 +285,7 @@ use std::{
     time::Instant,
 };
 
+use foldhash::{HashMap, HashMapExt};
 use polars::{
     io::avro::{AvroWriter, Compression as AvroCompression},
     polars_utils::compression::{GzipLevel, ZstdLevel},

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -311,7 +311,6 @@ if the CSV is not well-formed. See "safety:" comments in the code for more detai
 */
 
 use std::{
-    collections::HashMap,
     fmt, fs,
     io::{self, BufRead, Seek, Write},
     iter::repeat_n,
@@ -322,6 +321,7 @@ use std::{
 
 use blake3;
 use crossbeam_channel;
+use foldhash::{HashMap, HashMapExt};
 use itertools::Itertools;
 use phf::phf_map;
 use qsv_dateparser::parse_with_preference;

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -69,6 +69,7 @@ Common options:
 use std::{fs::File, str};
 
 use csv::ByteRecord;
+use foldhash::HashSet;
 use memmap2::MmapOptions;
 use serde::Deserialize;
 
@@ -151,25 +152,24 @@ impl Args {
         };
 
         // Create a set of field column indices for efficient lookup
-        let field_column_set: std::collections::HashSet<usize> =
-            field_column_indices.iter().copied().collect();
+        let field_column_set: HashSet<usize> = field_column_indices.iter().copied().collect();
 
         // Determine selected attribute columns if --select is specified
         // --select filters which columns become attribute rows (field columns are unaffected)
-        let selected_attribute_set: Option<std::collections::HashSet<usize>> =
-            if let Some(ref sel) = self.flag_select {
-                let selection = sel
-                    .selection(&headers, true)
-                    .map_err(|e| CliError::Other(format!("Column selection error: {e}")))?;
-                if selection.is_empty() {
-                    return fail_incorrectusage_clierror!(
-                        "--select resulted in no columns to transpose."
-                    );
-                }
-                Some(selection.iter().copied().collect())
-            } else {
-                None
-            };
+        let selected_attribute_set: Option<HashSet<usize>> = if let Some(ref sel) = self.flag_select
+        {
+            let selection = sel
+                .selection(&headers, true)
+                .map_err(|e| CliError::Other(format!("Column selection error: {e}")))?;
+            if selection.is_empty() {
+                return fail_incorrectusage_clierror!(
+                    "--select resulted in no columns to transpose."
+                );
+            }
+            Some(selection.iter().copied().collect())
+        } else {
+            None
+        };
 
         // Write output headers
         let mut header_record = ByteRecord::with_capacity(64, 3);

--- a/src/mcp_skills_gen.rs
+++ b/src/mcp_skills_gen.rs
@@ -8,6 +8,7 @@
 
 use std::{fs, path::Path};
 
+use foldhash::{HashMap, HashMapExt};
 use qsv_docopt::parse::{Argument as DocoptArgument, Atom, Parser};
 use serde::{Deserialize, Serialize};
 
@@ -155,7 +156,7 @@ impl UsageParser {
         let parser =
             Parser::new(&self.usage_text).map_err(|e| format!("Docopt parsing failed: {e}"))?;
 
-        let mut args_map = std::collections::HashMap::new();
+        let mut args_map = HashMap::new();
         let mut options = Vec::new();
         let mut subcommands = Vec::new();
 
@@ -492,8 +493,8 @@ impl UsageParser {
 
     /// Extract descriptions from the usage text manually
     /// Returns a map of flag/arg name to description
-    fn extract_descriptions_from_text(&self) -> std::collections::HashMap<String, String> {
-        let mut descriptions = std::collections::HashMap::new();
+    fn extract_descriptions_from_text(&self) -> HashMap<String, String> {
+        let mut descriptions = HashMap::new();
         let lines: Vec<&str> = self.usage_text.lines().collect();
 
         let mut i = 0;

--- a/src/odhtcache.rs
+++ b/src/odhtcache.rs
@@ -1,6 +1,7 @@
 // inspired by https://github.com/race604/dedup/blob/master/src/cache.rs
-use std::{collections::HashSet, path::PathBuf};
+use std::path::PathBuf;
 
+use foldhash::{HashSet, HashSetExt};
 use log::debug;
 use memmap2::MmapMut;
 use odht::{Config, FxHashFn, HashTable, bytes_needed};

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -1,6 +1,6 @@
 use std::{borrow::ToOwned, collections::hash_map::Entry, process};
 
-use foldhash::{HashMap, HashMapExt};
+use foldhash::{HashMap, HashMapExt, HashSet};
 use serde::Deserialize;
 use serde_json::Value;
 use stats::Frequencies;
@@ -3612,8 +3612,7 @@ fn frequency_stats_filter_type() {
     // Only 'name' and 'quantity' columns should remain (String and Integer)
     // 'price' should be excluded (it's Float)
     assert!(!got.is_empty());
-    let fields: std::collections::HashSet<&str> =
-        got.iter().skip(1).map(|row| row[0].as_str()).collect();
+    let fields: HashSet<&str> = got.iter().skip(1).map(|row| row[0].as_str()).collect();
     assert!(fields.contains("name"), "Expected 'name' column");
     assert!(fields.contains("quantity"), "Expected 'quantity' column");
     assert!(
@@ -3659,8 +3658,7 @@ fn frequency_stats_filter_compound_expression() {
     // 'category' has cardinality 2, should remain
     // 'count' has cardinality 3, should remain
     assert!(!got.is_empty());
-    let fields: std::collections::HashSet<&str> =
-        got.iter().skip(1).map(|row| row[0].as_str()).collect();
+    let fields: HashSet<&str> = got.iter().skip(1).map(|row| row[0].as_str()).collect();
     assert!(fields.contains("category"), "Expected 'category' column");
     assert!(fields.contains("count"), "Expected 'count' column");
     assert!(
@@ -3735,8 +3733,7 @@ fn frequency_stats_filter_cardinality() {
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     assert!(!got.is_empty());
-    let fields: std::collections::HashSet<&str> =
-        got.iter().skip(1).map(|row| row[0].as_str()).collect();
+    let fields: HashSet<&str> = got.iter().skip(1).map(|row| row[0].as_str()).collect();
     assert!(fields.contains("category"), "Expected 'category' column");
     assert!(
         fields.contains("subcategory"),


### PR DESCRIPTION
Replace usages of std::collections::HashMap and HashSet with foldhash implementations across multiple modules and tests. Added foldhash imports (HashMap, HashMapExt, HashSet, HashSetExt) and removed redundant std::collections imports, updating type annotations and local uses accordingly (cmd/*, mcp_skills_gen.rs, odhtcache.rs, tests). No intended functional changes—this standardizes collection types to foldhash throughout the project.

foldhash is much faster than std::collections::Hash*.

foldhash is a fast, non-crypto, minimally DoS-resistant hashing algorithm. In these cases, we don't need the DoS resistance of std:collections::Hash*