### PR TITLE
feat(mcp): Sniff CSV for Date/DateTime columns before Parquet conversion

### DIFF
--- a/.claude/skills/tests/mcp-tools.test.ts
+++ b/.claude/skills/tests/mcp-tools.test.ts
@@ -352,6 +352,27 @@ test('createToParquetTool returns valid tool definition', () => {
   assert.deepStrictEqual(toolDef.inputSchema.required, ['input_file']);
 });
 
+test('createToParquetTool description mentions sniff-based date detection', () => {
+  const toolDef = createToParquetTool();
+
+  assert.ok(
+    toolDef.description.includes('Sniffs the CSV'),
+    'Description should mention sniffing the CSV'
+  );
+  assert.ok(
+    toolDef.description.includes('Date/DateTime'),
+    'Description should mention Date/DateTime detection'
+  );
+  assert.ok(
+    toolDef.description.includes('--infer-dates'),
+    'Description should mention --infer-dates flag'
+  );
+  assert.ok(
+    toolDef.description.includes('--dates-whitelist'),
+    'Description should mention --dates-whitelist flag'
+  );
+});
+
 test('handleToParquetCall requires input_file parameter', async () => {
   const result = await handleToParquetCall({});
 


### PR DESCRIPTION
Use `qsv sniff --json` to detect Date/DateTime fields before generating the stats cache, then pass --infer-dates and --dates-whitelist to ensure accurate date type inference in the resulting Parquet file.

Adds runQsvWithOutput helper for capturing qsv stdout, updates tool description, and adds unit + integration tests for the new behavior.