### PR TITLE
feat(schema): auto-detect Date/DateTime columns for Polars schema via sniff

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -158,6 +158,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 log::log_enabled!(log::Level::Debug),
                 input_path,
                 &schema_file,
+                args.flag_prefer_dmy,
             )? {
                 return Ok(());
             }

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -774,6 +774,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         debuglog_flag,
                         table,
                         &schema_file,
+                        false,
                     )?;
                 }
 
@@ -822,6 +823,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         debuglog_flag,
                         table,
                         &schema_file,
+                        false,
                     )?;
 
                     if valid_schema_exists {

--- a/tests/test_sqlp.rs
+++ b/tests/test_sqlp.rs
@@ -1076,9 +1076,24 @@ select ward,count(*) as cnt from temp_table2 group by ward order by cnt desc, wa
         r#"{
   "fields": {
     "case_enquiry_id": "UInt64",
-    "open_dt": "String",
-    "target_dt": "String",
-    "closed_dt": "String",
+    "open_dt": {
+      "Datetime": [
+        "Milliseconds",
+        null
+      ]
+    },
+    "target_dt": {
+      "Datetime": [
+        "Milliseconds",
+        null
+      ]
+    },
+    "closed_dt": {
+      "Datetime": [
+        "Milliseconds",
+        null
+      ]
+    },
     "ontime": "String",
     "case_status": "String",
     "closure_reason": "String",


### PR DESCRIPTION
`schema --polars` now runs `qsv sniff --json` to identify Date/DateTime columns before generating stats, passing them as --dates-whitelist so the stats command infers date types correctly. Previously, the PolarsSchema stats mode omitted --infer-dates, causing all date columns to be typed as String in the .pschema.json output.