### PR TITLE
refactor(mcp): improved SQL guidance - Recommend Parquet + DuckDB for…

### DIFF
--- a/.claude/skills/tests/mcp-tools.test.ts
+++ b/.claude/skills/tests/mcp-tools.test.ts
@@ -356,8 +356,8 @@ test('createToParquetTool description mentions sniff-based date detection', () =
   const toolDef = createToParquetTool();
 
   assert.ok(
-    toolDef.description.includes('Sniffs the CSV'),
-    'Description should mention sniffing the CSV'
+    toolDef.description.includes('Sniffs CSV'),
+    'Description should mention sniffing CSV'
   );
   assert.ok(
     toolDef.description.includes('Date/DateTime'),


### PR DESCRIPTION
… large CSVs

Clarify guidance for sqlp and qsv_to_parquet: recommend converting CSVs >10MB to Parquet (same file stem, working dir) and prefer querying Parquet with DuckDB; otherwise use sqlp with SKIP_INPUT and read_parquet(). Update WHEN_TO_USE_GUIDANCE, COMMON_PATTERNS, and ERROR_PREVENTION_HINTS to reflect this workflow. Refine qsv_to_parquet tool description and auto-optimization text, and update the post-conversion message to recommend DuckDB or the qsv_sqlp SKIP_INPUT/read_parquet pattern. Adjust test expectation to match the revised phrasing ('Sniffs CSV').