### PR TITLE
docs(mcp): add Cowork working directory sync guidance to agents, commands, and skills

### DIFF
--- a/.claude/skills/agents/data-analyst.md
+++ b/.claude/skills/agents/data-analyst.md
@@ -38,13 +38,13 @@ Reference these domain knowledge files for best practices:
 
 ## Session Setup
 
-When running in Claude Code or Cowork, sync the qsv working directory to your session's current working directory BEFORE any file operations:
+When running in Claude Code or Cowork, sync the qsv working directory to your session's current working directory (the workspace root shown in the file tree) BEFORE any file operations:
 
 1. Call `qsv_get_working_dir` to check qsv's current working directory
-2. If it doesn't match your session's CWD, call `qsv_set_working_dir` with your CWD
+2. If it doesn't match your workspace root, call `qsv_set_working_dir` with that directory
 3. This ensures relative file paths resolve correctly
 
-Skip this if the user provides absolute file paths.
+Skip this if the user provides absolute file paths or if you're unsure of the workspace root — in that case, prefer absolute paths or ask the user which directory to use.
 
 ## Standard Workflow
 

--- a/.claude/skills/agents/data-wrangler.md
+++ b/.claude/skills/agents/data-wrangler.md
@@ -38,13 +38,13 @@ Reference these domain knowledge files for best practices:
 
 ## Session Setup
 
-When running in Claude Code or Cowork, sync the qsv working directory to your session's current working directory BEFORE any file operations:
+When running in Claude Code or Cowork, sync the qsv working directory to your session's current working directory (the workspace root shown in the file tree) BEFORE any file operations:
 
 1. Call `qsv_get_working_dir` to check qsv's current working directory
-2. If it doesn't match your session's CWD, call `qsv_set_working_dir` with your CWD
+2. If it doesn't match your workspace root, call `qsv_set_working_dir` with that directory
 3. This ensures relative file paths resolve correctly
 
-Skip this if the user provides absolute file paths.
+Skip this if the user provides absolute file paths or if you're unsure of the workspace root — in that case, prefer absolute paths or ask the user which directory to use.
 
 ## Standard Workflow
 

--- a/.claude/skills/commands/csv-query.md
+++ b/.claude/skills/commands/csv-query.md
@@ -22,7 +22,7 @@ Query tabular data files using SQL via the Polars-powered `sqlp` command.
 
 ## Cowork Setup
 
-If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's directory. If it differs from your session CWD, call `qsv_set_working_dir` to sync it.
+If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's current working directory. If it differs from your workspace root (the directory where relative paths should resolve), call `qsv_set_working_dir` to sync it.
 
 ## Decision Tree
 

--- a/.claude/skills/commands/data-clean.md
+++ b/.claude/skills/commands/data-clean.md
@@ -20,7 +20,7 @@ Clean the given tabular data file by fixing common data quality issues.
 
 ## Cowork Setup
 
-If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's directory. If it differs from your session CWD, call `qsv_set_working_dir` to sync it.
+If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's current working directory. If it differs from your workspace root (the directory where relative paths should resolve), call `qsv_set_working_dir` to sync it.
 
 ## Steps
 

--- a/.claude/skills/commands/data-convert.md
+++ b/.claude/skills/commands/data-convert.md
@@ -19,7 +19,7 @@ Convert tabular data files between formats.
 
 ## Cowork Setup
 
-If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's directory. If it differs from your session CWD, call `qsv_set_working_dir` to sync it.
+If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's current working directory. If it differs from your workspace root (the directory where relative paths should resolve), call `qsv_set_working_dir` to sync it.
 
 ## Supported Conversions
 

--- a/.claude/skills/commands/data-join.md
+++ b/.claude/skills/commands/data-join.md
@@ -21,7 +21,7 @@ Join two tabular data files on common columns.
 
 ## Cowork Setup
 
-If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's directory. If it differs from your session CWD, call `qsv_set_working_dir` to sync it.
+If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's current working directory. If it differs from your workspace root (the directory where relative paths should resolve), call `qsv_set_working_dir` to sync it.
 
 ## Strategy Selection
 

--- a/.claude/skills/commands/data-profile.md
+++ b/.claude/skills/commands/data-profile.md
@@ -21,7 +21,7 @@ Profile the given tabular data file to understand its structure, types, and dist
 
 ## Cowork Setup
 
-If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's directory. If it differs from your session CWD, call `qsv_set_working_dir` to sync it.
+If running in Claude Code or Cowork, first call `qsv_get_working_dir` to check qsv's current working directory. If it differs from your workspace root (the directory where relative paths should resolve), call `qsv_set_working_dir` to sync it.
 
 ## Steps
 

--- a/.claude/skills/skills/csv-wrangling/SKILL.md
+++ b/.claude/skills/skills/csv-wrangling/SKILL.md
@@ -4,7 +4,7 @@
 
 Always follow this sequence when processing CSV data:
 
-0. **Setup (Cowork)** - Sync qsv working directory to session CWD if needed
+0. **Setup (Cowork)** - `qsv_get_working_dir` (check current dir) -> `qsv_set_working_dir` (sync to workspace root if needed)
 1. **Discover** - `sniff` (detect format, encoding, delimiter) -> `headers` -> `count`
 2. **Index** - `index` (enables fast random access for subsequent commands)
 3. **Profile** - `stats --cardinality --stats-jsonl` (creates cache used by smart commands)


### PR DESCRIPTION
Prevents file-not-found errors when qsv's default working directory (Downloads) differs from the Cowork session's CWD. Agents get a "Session Setup" section, slash commands get allowed-tools entries and a "Cowork Setup" section, and the csv-wrangling skill gets a step 0 for directory sync.