### PR TITLE
refactor(mcp): comprehensive deduplication and cleanup (-625 lines)

### DIFF
--- a/.claude/skills/src/index.ts
+++ b/.claude/skills/src/index.ts
@@ -38,7 +38,6 @@ export {
 export {
   createPipelineToolDefinition,
   executePipeline,
-  pipelineToShellScript,
 } from "./mcp-pipeline.js";
 
 // Re-export for convenience

--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -20,7 +20,6 @@ import {
 import { SkillLoader } from "./loader.js";
 import { SkillExecutor } from "./executor.js";
 import { FilesystemResourceProvider } from "./mcp-filesystem.js";
-import type { McpToolResult } from "./types.js";
 import { config } from "./config.js";
 import {
   COMMON_COMMANDS,

--- a/.claude/skills/src/pipeline.ts
+++ b/.claude/skills/src/pipeline.ts
@@ -33,7 +33,7 @@ export class QsvPipeline {
   /**
    * Select columns
    */
-  select(selection: string, options?: Record<string, any>): this {
+  select(selection: string, options?: Record<string, unknown>): this {
     return this.add("qsv-select", {
       args: { selection },
       options,
@@ -43,7 +43,7 @@ export class QsvPipeline {
   /**
    * Remove duplicate rows
    */
-  dedup(options?: Record<string, any>): this {
+  dedup(options?: Record<string, unknown>): this {
     return this.add("qsv-dedup", {
       args: {},
       options,
@@ -53,7 +53,7 @@ export class QsvPipeline {
   /**
    * Compute statistics
    */
-  stats(options?: Record<string, any>): this {
+  stats(options?: Record<string, unknown>): this {
     return this.add("qsv-stats", {
       args: {},
       options,
@@ -63,7 +63,7 @@ export class QsvPipeline {
   /**
    * Compute extended statistics
    */
-  moarstats(options?: Record<string, any>): this {
+  moarstats(options?: Record<string, unknown>): this {
     return this.add("qsv-moarstats", {
       args: {},
       options,
@@ -73,7 +73,7 @@ export class QsvPipeline {
   /**
    * Sort by column
    */
-  sortBy(column: string, options?: Record<string, any>): this {
+  sortBy(column: string, options?: Record<string, unknown>): this {
     return this.add("qsv-sort", {
       args: {},
       options: { ...options, select: column },
@@ -86,7 +86,7 @@ export class QsvPipeline {
   search(
     pattern: string,
     column?: string,
-    options?: Record<string, any>,
+    options?: Record<string, unknown>,
   ): this {
     return this.add("qsv-search", {
       args: { regex: pattern },
@@ -100,7 +100,7 @@ export class QsvPipeline {
   filter(
     pattern: string,
     column?: string,
-    options?: Record<string, any>,
+    options?: Record<string, unknown>,
   ): this {
     return this.search(pattern, column, options);
   }
@@ -108,7 +108,7 @@ export class QsvPipeline {
   /**
    * Frequency distribution
    */
-  frequency(options?: Record<string, any>): this {
+  frequency(options?: Record<string, unknown>): this {
     return this.add("qsv-frequency", {
       args: {},
       options,
@@ -118,7 +118,7 @@ export class QsvPipeline {
   /**
    * Join with another CSV
    */
-  join(columns: string, file: string, options?: Record<string, any>): this {
+  join(columns: string, file: string, options?: Record<string, unknown>): this {
     return this.add("qsv-join", {
       args: { columns1: columns, input1: file },
       options,
@@ -131,7 +131,7 @@ export class QsvPipeline {
   rename(
     columns: string,
     newNames: string,
-    options?: Record<string, any>,
+    options?: Record<string, unknown>,
   ): this {
     return this.add("qsv-rename", {
       args: {},
@@ -145,7 +145,7 @@ export class QsvPipeline {
   apply(
     operations: string,
     column: string,
-    options?: Record<string, any>,
+    options?: Record<string, unknown>,
   ): this {
     return this.add("qsv-apply", {
       args: { operations, column },
@@ -156,7 +156,7 @@ export class QsvPipeline {
   /**
    * Slice rows
    */
-  slice(start?: number, end?: number, options?: Record<string, any>): this {
+  slice(start?: number, end?: number, options?: Record<string, unknown>): this {
     const sliceOptions = { ...options };
     if (start !== undefined) sliceOptions.start = start;
     if (end !== undefined) sliceOptions.end = end;
@@ -177,7 +177,7 @@ export class QsvPipeline {
   /**
    * Transpose the CSV
    */
-  transpose(options?: Record<string, any>): this {
+  transpose(options?: Record<string, unknown>): this {
     return this.add("qsv-transpose", {
       args: {},
       options,

--- a/.claude/skills/src/types.ts
+++ b/.claude/skills/src/types.ts
@@ -48,8 +48,8 @@ export interface BehavioralHints {
 }
 
 export interface SkillParams {
-  args?: Record<string, any>;
-  options?: Record<string, any>;
+  args?: Record<string, unknown>;
+  options?: Record<string, unknown>;
   stdin?: string | Buffer;
   inputFile?: string;
   timeoutMs?: number;

--- a/.claude/skills/src/utils.ts
+++ b/.claude/skills/src/utils.ts
@@ -3,6 +3,34 @@
  */
 
 /**
+ * Compare two semantic version strings
+ * Strips pre-release (-alpha.1) and build metadata (+build.123) before comparing.
+ * Returns: -1 if v1 < v2, 0 if equal, 1 if v1 > v2
+ */
+export function compareVersions(v1: string, v2: string): number {
+  // Strip pre-release and build metadata (e.g., "1.2.3-alpha.1+build" -> "1.2.3")
+  const strip = (v: string) => v.replace(/[-+].*$/, "");
+  const parts1 = strip(v1).split(".").map(Number);
+  const parts2 = strip(v2).split(".").map(Number);
+
+  // Validate that all parts are valid numbers
+  if (parts1.some(isNaN) || parts2.some(isNaN)) {
+    console.warn(
+      `[Utils] Invalid version format: "${v1}" or "${v2}" - comparison may be incorrect`,
+    );
+    return 0;
+  }
+
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const part1 = parts1[i] || 0;
+    const part2 = parts2[i] || 0;
+    if (part1 < part2) return -1;
+    if (part1 > part2) return 1;
+  }
+  return 0;
+}
+
+/**
  * Format bytes to human-readable string
  */
 export function formatBytes(bytes: number): string {

--- a/.claude/skills/tests/converted-file-manager.test.ts
+++ b/.claude/skills/tests/converted-file-manager.test.ts
@@ -6,17 +6,10 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { mkdtemp, writeFile, rm, stat, readFile } from 'fs/promises';
+import { writeFile, rm, stat, readFile } from 'fs/promises';
 import { join } from 'path';
-import { tmpdir } from 'os';
 import { ConvertedFileManager } from '../src/converted-file-manager.js';
-
-/**
- * Create a temporary test directory
- */
-async function createTestDir(): Promise<string> {
-  return await mkdtemp(join(tmpdir(), 'qsv-cfm-test-'));
-}
+import { createTestDir, cleanupTestDir } from './test-helpers.js';
 
 /**
  * Create a test file with specified size
@@ -26,17 +19,6 @@ async function createTestFile(dir: string, filename: string, sizeBytes: number):
   const content = 'x'.repeat(sizeBytes);
   await writeFile(filepath, content, 'utf8');
   return filepath;
-}
-
-/**
- * Clean up test directory
- */
-async function cleanupTestDir(dir: string): Promise<void> {
-  try {
-    await rm(dir, { recursive: true, force: true });
-  } catch {
-    // Ignore cleanup errors
-  }
 }
 
 test('ConvertedFileManager initializes with default settings', async () => {

--- a/.claude/skills/tests/executor-timeout.test.ts
+++ b/.claude/skills/tests/executor-timeout.test.ts
@@ -9,9 +9,7 @@ import { spawn } from 'node:child_process';
 import { SkillExecutor } from '../src/executor.js';
 import type { QsvSkill } from '../src/types.js';
 import { config } from '../src/config.js';
-
-// Skip integration tests if qsv is not available
-const QSV_AVAILABLE = config.qsvValidation.valid;
+import { QSV_AVAILABLE } from './test-helpers.js';
 
 /**
  * A skill definition that can be used for timeout testing.

--- a/.claude/skills/tests/mcp-filesystem.test.ts
+++ b/.claude/skills/tests/mcp-filesystem.test.ts
@@ -119,9 +119,9 @@ test('listFiles excludes converted files with UUID pattern', async () => {
     // Create a normal CSV file
     await writeFile(join(tempDir, 'normal.csv'), 'col1,col2\nval1,val2\n');
 
-    // Create a converted file (UUID pattern from ConvertedFileManager)
+    // Create a converted file (16-char hex pattern from ConvertedFileManager)
     await writeFile(
-      join(tempDir, 'data.xlsx.converted.06488439-4c06-4abc-999e-9e6af19b1234.csv'),
+      join(tempDir, 'data.xlsx.converted.06488439a4c0b123.csv'),
       'col1,col2\nval1,val2\n'
     );
 

--- a/.claude/skills/tests/pipeline-integration.test.ts
+++ b/.claude/skills/tests/pipeline-integration.test.ts
@@ -7,46 +7,12 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { writeFile, mkdtemp, rm, readFile, realpath } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { tmpdir } from 'os';
 import { executePipeline } from '../src/mcp-pipeline.js';
 import { SkillLoader } from '../src/loader.js';
 import { FilesystemResourceProvider } from '../src/mcp-filesystem.js';
-import { config } from '../src/config.js';
-
-// Skip tests if qsv is not available
-const QSV_AVAILABLE = config.qsvValidation.valid;
-
-/**
- * Create a temporary test directory
- */
-async function createTestDir(): Promise<string> {
-  // mkdtemp guarantees unique names; realpath canonicalizes Windows short paths
-  // (e.g., RUNNER~1 → runneradmin) to match FilesystemResourceProvider.realpathSync()
-  const dir = await mkdtemp(join(tmpdir(), 'qsv-pipeline-test-'));
-  return realpath(dir);
-}
-
-/**
- * Create a test CSV file
- */
-async function createTestCSV(dir: string, filename: string, content: string): Promise<string> {
-  const filepath = join(dir, filename);
-  await writeFile(filepath, content, 'utf8');
-  return filepath;
-}
-
-/**
- * Clean up test directory
- */
-async function cleanupTestDir(dir: string): Promise<void> {
-  try {
-    await rm(dir, { recursive: true, force: true });
-  } catch {
-    // Ignore cleanup errors
-  }
-}
+import { QSV_AVAILABLE, createTestDir, createTestCSV, cleanupTestDir } from './test-helpers.js';
 
 // ============================================================================
 // Multi-step Pipeline Execution Tests

--- a/.claude/skills/tests/qsv-integration.test.ts
+++ b/.claude/skills/tests/qsv-integration.test.ts
@@ -5,46 +5,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { writeFile, readFile, unlink, mkdir, rm, stat, access } from 'fs/promises';
+import { readFile, stat, access } from 'fs/promises';
 import { join } from 'path';
-import { tmpdir } from 'os';
 import { handleToolCall, handleToParquetCall } from '../src/mcp-tools.js';
+import { config } from '../src/config.js';
 import { SkillLoader } from '../src/loader.js';
 import { SkillExecutor } from '../src/executor.js';
 import { FilesystemResourceProvider } from '../src/mcp-filesystem.js';
-import { config } from '../src/config.js';
-
-// Skip tests if qsv is not available
-const QSV_AVAILABLE = config.qsvValidation.valid;
-
-/**
- * Create a temporary test directory
- */
-async function createTestDir(): Promise<string> {
-  const testDir = join(tmpdir(), `qsv-integration-test-${Date.now()}`);
-  await mkdir(testDir, { recursive: true });
-  return testDir;
-}
-
-/**
- * Create a test CSV file
- */
-async function createTestCSV(dir: string, filename: string, content: string): Promise<string> {
-  const filepath = join(dir, filename);
-  await writeFile(filepath, content, 'utf8');
-  return filepath;
-}
-
-/**
- * Clean up test directory
- */
-async function cleanupTestDir(dir: string): Promise<void> {
-  try {
-    await rm(dir, { recursive: true, force: true });
-  } catch (error) {
-    // Ignore cleanup errors
-  }
-}
+import { QSV_AVAILABLE, createTestDir, createTestCSV, cleanupTestDir } from './test-helpers.js';
 
 test('qsv_count returns row count', { skip: !QSV_AVAILABLE }, async () => {
   const testDir = await createTestDir();

--- a/.claude/skills/tests/test-helpers.ts
+++ b/.claude/skills/tests/test-helpers.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared test helpers for qsv MCP Server tests
+ *
+ * Consolidates common patterns found across test files:
+ * - Test directory creation/cleanup
+ * - CSV file creation
+ * - qsv availability check
+ */
+
+import { writeFile, mkdtemp, rm, realpath } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { config } from "../src/config.js";
+
+/**
+ * Whether a valid qsv binary is available for integration tests.
+ * Tests that require qsv should skip when this is false.
+ *
+ * Usage: test("name", { skip: !QSV_AVAILABLE }, async () => { ... })
+ */
+export const QSV_AVAILABLE: boolean = config.qsvValidation.valid;
+
+/**
+ * Create a temporary test directory with a unique name.
+ * Uses mkdtemp for guaranteed uniqueness and realpath for
+ * Windows 8.3 short path compatibility.
+ */
+export async function createTestDir(prefix = "qsv-test"): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), `${prefix}-`));
+  return realpath(dir);
+}
+
+/**
+ * Clean up a test directory, ignoring errors.
+ */
+export async function cleanupTestDir(dir: string): Promise<void> {
+  try {
+    await rm(dir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+/**
+ * Create a test CSV file with the given content.
+ * Returns the absolute path to the created file.
+ */
+export async function createTestCSV(
+  dir: string,
+  filename: string,
+  content: string,
+): Promise<string> {
+  const filepath = join(dir, filename);
+  await writeFile(filepath, content, "utf8");
+  return filepath;
+}

--- a/.claude/skills/tests/update-checker.test.ts
+++ b/.claude/skills/tests/update-checker.test.ts
@@ -6,32 +6,11 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { mkdtemp, rm, writeFile, readFile } from 'fs/promises';
+import { writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
-import { tmpdir } from 'os';
 import { UpdateChecker, getUpdateConfigFromEnv } from '../src/update-checker.js';
 import { config } from '../src/config.js';
-
-/**
- * Create a temporary test directory
- */
-async function createTestDir(): Promise<string> {
-  return await mkdtemp(join(tmpdir(), 'qsv-update-test-'));
-}
-
-/**
- * Clean up test directory
- */
-async function cleanupTestDir(dir: string): Promise<void> {
-  try {
-    await rm(dir, { recursive: true, force: true });
-  } catch {
-    // Ignore cleanup errors
-  }
-}
-
-// Skip tests if qsv is not available
-const QSV_AVAILABLE = config.qsvValidation.valid;
+import { QSV_AVAILABLE, createTestDir, cleanupTestDir } from './test-helpers.js';
 
 test('UpdateChecker initializes with default config', () => {
   const checker = new UpdateChecker();


### PR DESCRIPTION
Fix isTemporaryFile regex to match 16-char hex (not 36-char UUID), extract errorResult/successResult helpers, decompose handleToolCall into 4 focused functions, consolidate 3 runQsv implementations into shared runQsvSimple, merge 7 guidance tables into single COMMAND_GUIDANCE map, extract shared test helpers, remove dead code (getFileContent, pipelineToShellScript), replace Record<string, any> with unknown, optimize SkillLoader with parallel reads and single-pass getStats.

All 211 tests pass, no behavioral changes.