### PR TITLE
fix(help): fix section detection, acronym casing & option word-wrap i…

### DIFF
--- a/docs/help/apply.md
+++ b/docs/help/apply.md
@@ -352,11 +352,11 @@ qsv apply --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c, --new-column` | string | Put the transformed values in a new column instead. |  |
-| `-r, --rename` | string | New name for the transformed column. |  |
-| `-C, --comparand=<string>` | string | The string to compare against for replace & similarity operations. Also used with numtocurrency operation to specify currency symbol. |  |
-| `-R, --replacement=<string>` | string | The string to use for the replace & emptyreplace operations. Also used with numtocurrency operation to conversion rate. |  |
-| `-f, --formatstr=<string>` | string | This option is used by several subcommands: |  |
+| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. |  |
+| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
+| `-C,`<br>`--comparand=<string>` | string | The string to compare against for replace & similarity operations. Also used with numtocurrency operation to specify currency symbol. |  |
+| `-R,`<br>`--replacement=<string>` | string | The string to use for the replace & emptyreplace operations. Also used with numtocurrency operation to conversion rate. |  |
+| `-f,`<br>`--formatstr=<string>` | string | This option is used by several subcommands: |  |
 
 <a name="operations-options"></a>
 
@@ -364,8 +364,8 @@ qsv apply --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="common-options"></a>
 
@@ -373,11 +373,11 @@ qsv apply --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/apply.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/apply.rs)

--- a/docs/help/applydp.md
+++ b/docs/help/applydp.md
@@ -214,11 +214,11 @@ qsv applydp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c, --new-column` | string | Put the transformed values in a new column instead. |  |
-| `-r, --rename` | string | New name for the transformed column. |  |
-| `-C, --comparand=<string>` | string | The string to compare against for replace & similarity operations. |  |
-| `-R, --replacement=<string>` | string | The string to use for the replace & emptyreplace operations. |  |
-| `-f, --formatstr=<string>` | string | This option is used by several subcommands: |  |
+| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. |  |
+| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
+| `-C,`<br>`--comparand=<string>` | string | The string to compare against for replace & similarity operations. |  |
+| `-R,`<br>`--replacement=<string>` | string | The string to use for the replace & emptyreplace operations. |  |
+| `-f,`<br>`--formatstr=<string>` | string | This option is used by several subcommands: |  |
 
 <a name="operations-options"></a>
 
@@ -226,8 +226,8 @@ qsv applydp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 
 <a name="common-options"></a>
 
@@ -235,10 +235,10 @@ qsv applydp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/applydp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/applydp.rs)

--- a/docs/help/behead.md
+++ b/docs/help/behead.md
@@ -29,9 +29,9 @@ qsv behead --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-f, --flexible` | flag | Do not validate if the CSV has different number of fields per record, increasing performance. |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-f,`<br>`--flexible` | flag | Do not validate if the CSV has different number of fields per record, increasing performance. |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
 
 ---
 **Source:** [`src/cmd/behead.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/behead.rs)

--- a/docs/help/cat.md
+++ b/docs/help/cat.md
@@ -97,7 +97,7 @@ qsv cat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-p, --pad` | flag | When concatenating columns, this flag will cause all records to appear. It will pad each row if other CSV data isn't long enough. |  |
+| `-p,`<br>`--pad` | flag | When concatenating columns, this flag will cause all records to appear. It will pad each row if other CSV data isn't long enough. |  |
 
 <a name="rows-option"></a>
 
@@ -113,8 +113,8 @@ qsv cat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g, --group` | string | When concatenating with rowskey, you can specify a grouping value which will be used as the first column in the output. This is useful when you want to know which file a row came from. Valid values are 'fullpath', 'parentdirfname', 'parentdirfstem', 'fname', 'fstem' and 'none'. A new column will be added to the beginning of each row using --group-name. If 'none' is specified, no grouping column will be added. | `none` |
-| `-N, --group-name` | string | When concatenating with rowskey, this flag provides the name for the new grouping column. | `file` |
+| `-g,`<br>`--group` | string | When concatenating with rowskey, you can specify a grouping value which will be used as the first column in the output. This is useful when you want to know which file a row came from. Valid values are 'fullpath', 'parentdirfname', 'parentdirfstem', 'fname', 'fstem' and 'none'. A new column will be added to the beginning of each row using --group-name. If 'none' is specified, no grouping column will be added. | `none` |
+| `-N,`<br>`--group-name` | string | When concatenating with rowskey, this flag provides the name for the new grouping column. | `file` |
 
 <a name="common-options"></a>
 
@@ -122,10 +122,10 @@ qsv cat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will NOT be interpreted as column names. Note that this has no effect when concatenating columns. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. Note that this has no effect when concatenating columns. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/cat.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/cat.rs)

--- a/docs/help/clipboard.md
+++ b/docs/help/clipboard.md
@@ -48,7 +48,7 @@ qsv clipboard --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --save` | flag | Save output to clipboard. |  |
+| `-s,`<br>`--save` | flag | Save output to clipboard. |  |
 
 <a name="common-options"></a>
 
@@ -56,7 +56,7 @@ qsv clipboard --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/clipboard.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/clipboard.rs)

--- a/docs/help/color.md
+++ b/docs/help/color.md
@@ -44,9 +44,9 @@ qsv color --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-C, --color` | flag | Force color on, even in situations where colors would normally be disabled. |  |
-| `-n, --row-numbers` | flag | Show row numbers. |  |
-| `-t, --title` | string | Add a title row above the headers. |  |
+| `-C,`<br>`--color` | flag | Force color on, even in situations where colors would normally be disabled. |  |
+| `-n,`<br>`--row-numbers` | flag | Show row numbers. |  |
+| `-t,`<br>`--title` | string | Add a title row above the headers. |  |
 
 <a name="common-options"></a>
 
@@ -54,9 +54,9 @@ qsv color --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---

--- a/docs/help/count.md
+++ b/docs/help/count.md
@@ -88,7 +88,7 @@ qsv count --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-H, --human-readable` | flag | Comma separate counts. |  |
+| `-H,`<br>`--human-readable` | flag | Comma separate counts. |  |
 
 <a name="width-options"></a>
 
@@ -115,10 +115,10 @@ qsv count --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-f, --flexible` | flag | Do not validate if the CSV has different number of fields per record, increasing performance when counting without an index. |  |
-| `-n, --no-headers` | flag | When set, the first row will be included in the count. |  |
-| `-d, --delimiter` | string | The delimiter to use when reading CSV data. Must be a single character. | `,` |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-f,`<br>`--flexible` | flag | Do not validate if the CSV has different number of fields per record, increasing performance when counting without an index. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will be included in the count. |  |
+| `-d,`<br>`--delimiter` | string | The delimiter to use when reading CSV data. Must be a single character. | `,` |
 
 ---
 **Source:** [`src/cmd/count.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/count.rs)

--- a/docs/help/datefmt.md
+++ b/docs/help/datefmt.md
@@ -96,8 +96,8 @@ qsv datefmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c, --new-column` | string | Put the transformed values in a new column instead. |  |
-| `-r, --rename` | string | New name for the transformed column. |  |
+| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. |  |
+| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
 | `--prefer-dmy` | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. |  |
 | `--keep-zero-time` | flag | If a formatted date ends with "T00:00:00+00:00", keep the time instead of removing it. |  |
 | `--input-tz=<string>` | string | The timezone to use for the input date if the date does not have timezone specified. The timezone must be a valid IANA timezone name or the string "local" for the local timezone. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> for a list of valid timezone names. | `UTC` |
@@ -105,9 +105,9 @@ qsv datefmt --help
 | `--default-tz=<string>` | string | The timezone to use for BOTH input and output dates when they do have timezone. Shortcut for --input-tz and --output-tz set to the same timezone. The timezone must be a valid IANA timezone name or the string "local". |  |
 | `--utc` | flag | Shortcut for --input-tz and --output-tz set to UTC. |  |
 | `--zulu` | flag | Shortcut for --output-tz set to UTC and --formatstr set to "%Y-%m-%dT%H:%M:%SZ". |  |
-| `-R, --ts-resolution` | string | The resolution to use when parsing Unix timestamps. Valid values are "sec", "milli", "micro", "nano". | `sec` |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| `-R,`<br>`--ts-resolution` | string | The resolution to use when parsing Unix timestamps. Valid values are "sec", "milli", "micro", "nano". | `sec` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="common-options"></a>
 
@@ -115,11 +115,11 @@ qsv datefmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/datefmt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/datefmt.rs)

--- a/docs/help/dedup.md
+++ b/docs/help/dedup.md
@@ -83,13 +83,13 @@ qsv dedup --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --select` | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. See 'qsv select --help' for the format details. |  |
-| `-N, --numeric` | flag | Compare according to string numerical value |  |
-| `-i, --ignore-case` | flag | Compare strings disregarding case. |  |
+| `-s,`<br>`--select` | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. See 'qsv select --help' for the format details. |  |
+| `-N,`<br>`--numeric` | flag | Compare according to string numerical value |  |
+| `-i,`<br>`--ignore-case` | flag | Compare strings disregarding case. |  |
 | `--sorted` | flag | The input is already sorted. Do not load the CSV into memory to sort it first. Meant to be used in tandem and after an extsort. |  |
-| `-D, --dupes-output` | string | Write duplicates to <file>. |  |
-| `-H, --human-readable` | flag | Comma separate duplicate count. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel when sorting an unsorted CSV, before deduping. When not set, the number of jobs is set to the number of CPUs detected. Does not work with --sorted option as its not multithreaded. |  |
+| `-D,`<br>`--dupes-output` | string | Write duplicates to <file>. |  |
+| `-H,`<br>`--human-readable` | flag | Comma separate duplicate count. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when sorting an unsorted CSV, before deduping. When not set, the number of jobs is set to the number of CPUs detected. Does not work with --sorted option as its not multithreaded. |  |
 
 <a name="common-options"></a>
 
@@ -97,11 +97,11 @@ qsv dedup --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-q, --quiet` | flag | Do not print duplicate count to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-q,`<br>`--quiet` | flag | Do not print duplicate count to stderr. |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---

--- a/docs/help/describegpt.md
+++ b/docs/help/describegpt.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/describegpt.rs](https://github.com/dathere/qsv/blob/master/src/cmd/describegpt.rs)** | 🌐🤖🪄🗃️📚⛩️ ![CKAN](../images/ckan.png)
 
 <a name="nav"></a>
-[Description](#description) | [Examples](#examples) | [Usage](#usage) | [Describegpt Options](#describegpt-options) | [Dictionary Options](#dictionary-options) | [Tag Options](#tag-options) | [Custom Prompt Options](#custom-prompt-options) | [Llm Api Options](#llm-api-options) | [Caching Options](#caching-options) | [Common Options](#common-options)
+[Description](#description) | [Examples](#examples) | [Usage](#usage) | [Data Analysis/Inferencing Options](#data-analysis/inferencing-options) | [Dictionary Options](#dictionary-options) | [Tag Options](#tag-options) | [Stats/Frequency Options](#stats/frequency-options) | [Custom Prompt Options](#custom-prompt-options) | [LLM API Options](#llm-api-options) | [Caching Options](#caching-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -200,16 +200,16 @@ qsv describegpt (--redis-cache) (--flush-cache)
 qsv describegpt --help
 ```
 
-<a name="describegpt-options"></a>
+<a name="data-analysis/inferencing-options"></a>
 
-## Describegpt Options [↩](#nav)
+## Data Analysis/Inferencing Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--dictionary` | flag | Create a Data Dictionary using a hybrid "neuro-procedural" pipeline - i.e. the Dictionary is populated deterministically using Summary Statistics and Frequency Distribution data, and only the human-friendly Label and Description are populated by the LLM using the same statistical context. |  |
 | `--description` | flag | Infer a general Description of the dataset based on detailed statistical context. An Attribution signature is embedded in the Description. |  |
 | `--tags` | flag | Infer Tags that categorize the dataset based on detailed statistical context. Useful for grouping datasets and filtering. |  |
-| `-A, --all` | flag | Shortcut for --dictionary --description --tags. |  |
+| `-A,`<br>`--all` | flag | Shortcut for --dictionary --description --tags. |  |
 
 <a name="dictionary-options"></a>
 
@@ -233,6 +233,13 @@ qsv describegpt --help
 | `--cache-dir` | string | The directory to use for caching downloaded tag vocabulary resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
 | `--ckan-api` | string | The URL of the CKAN API to use for downloading tag vocabulary resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
 | `--ckan-token` | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. |  |
+
+<a name="stats/frequency-options"></a>
+
+## Stats/Frequency Options [↩](#nav)
+
+| Option | Type | Description | Default |
+|--------|------|-------------|--------|
 | `--stats-options` | string | Options for the stats command used to generate summary statistics. If it starts with "file:" prefix, the statistics are read from the specified CSV file instead of running the stats command. e.g. "file:my_custom_stats.csv" | `--infer-dates --infer-boolean --mad --quartiles --percentiles --force --stats-jsonl` |
 | `--freq-options` | string | Options for the frequency command used to generate frequency distributions. You can use this to exclude certain variable types from frequency analysis (e.g., --select '!id,!uuid'), limit results differently per use case, or control output format. If --limit is specified here, it takes precedence over --enum-threshold. If it starts with "file:" prefix, the frequency data is read from the specified CSV file instead of running the frequency command. e.g. "file:my_custom_frequency.csv" | `--rank-strategy dense` |
 | `--enum-threshold` | string | The threshold for compiling Enumerations with the frequency command before bucketing other unique values into the "Other" category. This is a convenience shortcut for --freq-options --limit <n>. If --freq-options contains --limit, this flag is ignored. | `10` |
@@ -243,7 +250,7 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-p, --prompt` | string | Custom prompt to answer questions about the dataset. The prompt will be answered based on the dataset's Summary Statistics, Frequency data & Data Dictionary. If the prompt CANNOT be answered by looking at these metadata, a SQL query will be generated to answer the question. If the "polars" or the "QSV_DESCRIBEGPT_DB_ENGINE" environment variable is set & the `--sql-results` option is used, the SQL query will be automatically executed and its results returned. Otherwise, the SQL query will be returned along with the reasoning behind it. If it starts with "file:" prefix, the prompt is read from the file specified. e.g. "file:my_long_prompt.txt" |  |
+| `-p,`<br>`--prompt` | string | Custom prompt to answer questions about the dataset. The prompt will be answered based on the dataset's Summary Statistics, Frequency data & Data Dictionary. If the prompt CANNOT be answered by looking at these metadata, a SQL query will be generated to answer the question. If the "polars" or the "QSV_DESCRIBEGPT_DB_ENGINE" environment variable is set & the `--sql-results` option is used, the SQL query will be automatically executed and its results returned. Otherwise, the SQL query will be returned along with the reasoning behind it. If it starts with "file:" prefix, the prompt is read from the file specified. e.g. "file:my_long_prompt.txt" |  |
 | `--sql-results` | string | The file to save the SQL query results to. Only valid if the --prompt option is used & the "polars" or the "QSV_DESCRIBEGPT_DB_ENGINE" environment variable is set. If the SQL query executes successfully, the results will be saved with a ".csv" extension. Otherwise, it will be saved with a ".sql" extension so the user can inspect why it failed and modify it. |  |
 | `--prompt-file` | string | The configurable TOML file containing prompts to use for inferencing. If no file is provided, default prompts will be used. The prompt file uses the Mini Jinja template engine (<https://docs.rs/minijinja>) See <https://github.com/dathere/qsv/blob/master/resources/describegpt_defaults.toml> |  |
 | `--sample-size` | string | The number of rows to randomly sample from the input file for the sample data. Uses the INDEXED sampling method with the qsv sample command. | `100` |
@@ -253,16 +260,16 @@ qsv describegpt --help
 
 <a name="llm-api-options"></a>
 
-## Llm Api Options [↩](#nav)
+## LLM API Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-u, --base-url` | string | The LLM API URL. Supports APIs & local LLMs compatible with the OpenAI API specification. Some common base URLs: OpenAI: <https://api.openai.com/v1> Gemini: <https://generativelanguage.googleapis.com/v1beta/openai> TogetherAI: <https://api.together.ai/v1> | `http://localhost:1234/v1` |
-| `-m, --model` | string | The model to use for inferencing. If set, takes precedence over the QSV_LLM_MODEL environment variable. | `openai/gpt-oss-20b` |
+| `-u,`<br>`--base-url` | string | The LLM API URL. Supports APIs & local LLMs compatible with the OpenAI API specification. Some common base URLs: OpenAI: <https://api.openai.com/v1> Gemini: <https://generativelanguage.googleapis.com/v1beta/openai> TogetherAI: <https://api.together.ai/v1> | `http://localhost:1234/v1` |
+| `-m,`<br>`--model` | string | The model to use for inferencing. If set, takes precedence over the QSV_LLM_MODEL environment variable. | `openai/gpt-oss-20b` |
 | `--language` | string | The output language/dialect to use for the response. (e.g., "Spanish", "French", "Hindi", "Mandarin", "Italian", "Castilian", "Franglais", "Taglish", "Pig Latin", "Valley Girl", "Pirate", "Shakespearean English", "Chavacano", "Gen Z", "Yoda", etc.) |  |
 | `--addl-props` | string | Additional model properties to pass to the LLM chat/completion API. Various models support different properties beyond the standard ones. For instance, gpt-oss-20b supports the "reasoning_effort" property. e.g. to set the "reasoning_effort" property to "high" & "temperature" to 0.5, use '{"reasoning_effort": "high", "temperature": 0.5}' |  |
-| `-k, --api-key` | string | The API key to use. If set, takes precedence over the QSV_LLM_APIKEY envvar. Required when the base URL is not localhost. Set to NONE to suppress sending the API key. |  |
-| `-t, --max-tokens` | string | Limits the number of generated tokens in the output. Set to 0 to disable token limits. If the --base-url is localhost, indicating a local LLM, the default is automatically set to 0. | `10000` |
+| `-k,`<br>`--api-key` | string | The API key to use. If set, takes precedence over the QSV_LLM_APIKEY envvar. Required when the base URL is not localhost. Set to NONE to suppress sending the API key. |  |
+| `-t,`<br>`--max-tokens` | string | Limits the number of generated tokens in the output. Set to 0 to disable token limits. If the --base-url is localhost, indicating a local LLM, the default is automatically set to 0. | `10000` |
 | `--timeout` | string | Timeout for completions in seconds. If 0, no timeout is used. | `300` |
 | `--user-agent` | string | Specify custom user agent. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
 | `--export-prompt` | string | Export the default prompts to the specified file that can be used with the --prompt-file option. The file will be saved with a .toml extension. If the file already exists, it will be overwritten. It will exit after exporting the prompts. |  |
@@ -286,10 +293,10 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
 | `--format` | string | Output format: Markdown, TSV, JSON, or TOON. TOON is a compact, human-readable encoding of the JSON data model for LLM prompts. See <https://toonformat.dev/> for more info. | `Markdown` |
-| `-o, --output` | string | Write output to <file> instead of stdout. If --format is set to TSV, separate files will be created for each prompt type with the pattern {filestem}.{kind}.tsv (e.g., output.dictionary.tsv, output.tags.tsv). |  |
-| `-q, --quiet` | flag | Do not print status messages to stderr. |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. If --format is set to TSV, separate files will be created for each prompt type with the pattern {filestem}.{kind}.tsv (e.g., output.dictionary.tsv, output.tags.tsv). |  |
+| `-q,`<br>`--quiet` | flag | Do not print status messages to stderr. |  |
 
 ---
 **Source:** [`src/cmd/describegpt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/describegpt.rs)

--- a/docs/help/diff.md
+++ b/docs/help/diff.md
@@ -121,10 +121,10 @@ qsv diff --help
 | `--delimiter-left` | string | The field delimiter for reading CSV data on the left. Must be a single character. (default: ,) |  |
 | `--delimiter-right` | string | The field delimiter for reading CSV data on the right. Must be a single character. (default: ,) |  |
 | `--delimiter-output` | string | The field delimiter for writing the CSV diff result. Must be a single character. (default: ,) |  |
-| `-k, --key` | string | The column indices that uniquely identify a record as a comma separated list of 0-based indices, e.g. 0,1,2 or column names, e.g. name,age. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. (default: 0) |  |
+| `-k,`<br>`--key` | string | The column indices that uniquely identify a record as a comma separated list of 0-based indices, e.g. 0,1,2 or column names, e.g. name,age. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. (default: 0) |  |
 | `--sort-columns` | string | The column indices by which the diff result should be sorted as a comma separated list of indices, e.g. 0,1,2 or column names, e.g. name,age. Records in the diff result that are marked as "modified" ("delete" and "add" records that have the same key, but have different content) will always be kept together in the sorted diff result and so won't be sorted independently from each other. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. |  |
 | `--drop-equal-fields` | flag | Drop values of equal fields in modified rows of the CSV diff result (and replace them with the empty string). Key field values will not be dropped. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -132,9 +132,9 @@ qsv diff --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | Set ALL delimiters to this character. Overrides --delimiter-right, --delimiter-left and --delimiter-output. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | Set ALL delimiters to this character. Overrides --delimiter-right, --delimiter-left and --delimiter-output. |  |
 
 ---
 **Source:** [`src/cmd/diff.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/diff.rs)

--- a/docs/help/edit.md
+++ b/docs/help/edit.md
@@ -52,7 +52,7 @@ qsv edit --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --in-place` | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. |  |
+| `-i,`<br>`--in-place` | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. |  |
 
 <a name="common-options"></a>
 
@@ -60,9 +60,9 @@ qsv edit --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | Start row indices from the header row as 0 (allows editing the header row). |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | Start row indices from the header row as 0 (allows editing the header row). |  |
 
 ---
 **Source:** [`src/cmd/edit.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/edit.rs)

--- a/docs/help/enum.md
+++ b/docs/help/enum.md
@@ -174,7 +174,7 @@ qsv enum --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c, --new-column` | string | Name of the column to create. Will default to "index". |  |
+| `-c,`<br>`--new-column` | string | Name of the column to create. Will default to "index". |  |
 | `--start` | string | The value to start the enumeration from. Only applies in Increment mode. (default: 0) |  |
 | `--increment` | string | The value to increment the enumeration by. Only applies in Increment mode. (default: 1) |  |
 | `--constant` | string | Fill a new column with the given value. Changes the default column name to "constant" unless overridden by --new-column. To specify a null value, pass the literal "<NULL>". |  |
@@ -189,10 +189,10 @@ qsv enum --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/enumerate.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/enumerate.rs)

--- a/docs/help/excel.md
+++ b/docs/help/excel.md
@@ -171,7 +171,7 @@ qsv excel --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --sheet` | string | Name (case-insensitive) or zero-based index of sheet to export. Negative indices start from the end (-1 = last sheet). If the sheet cannot be found, qsv will read the first sheet. | `0` |
+| `-s,`<br>`--sheet` | string | Name (case-insensitive) or zero-based index of sheet to export. Negative indices start from the end (-1 = last sheet). If the sheet cannot be found, qsv will read the first sheet. | `0` |
 | `--header-row` | string | The header row. Set if other than the first non-empty row of the sheet. |  |
 | `--metadata` | string | Outputs workbook metadata in CSV or JSON format: index, sheet_name, headers, type, visible, column_count, row_count, safe_headers, safe_headers_count, unsafe_headers, unsafe_headers_count and duplicate_headers_count, names, name_count, tables, table_count. headers is a list of the first row which is presumed to be the header row. type is the sheet type (WorkSheet, DialogSheet, MacroSheet, ChartSheet, Vba). visible is the sheet visibility (Visible, Hidden, VeryHidden). row_count includes all rows, including the first row. safe_headers is a list of headers with "safe"(PostgreSQL-ready) names. unsafe_headers is a list of headers with "unsafe" names. duplicate_headers_count is a count of duplicate header names. names is a list of defined names in the workbook, with the associated formula. name_count is the number of defined names in the workbook. tables is a list of tables in the workbook, along with the sheet where the table is found, the columns and the column_count.  (XLSX only) table_count is the number of tables in the workbook.  (XLSX only) | `none` |
 | `--table` | string | An Excel table (case-insensitive) to extract to a CSV. Only valid for XLSX files. The --sheet option is ignored as a table could be in any sheet. Overrides --range option. |  |
@@ -182,7 +182,7 @@ qsv excel --help
 | `--trim` | flag | Trim all fields so that leading & trailing whitespaces are removed. Also removes embedded linebreaks. |  |
 | `--date-format` | string | Optional date format to use when formatting dates. See <https://docs.rs/chrono/latest/chrono/format/strftime/index.html> for the full list of supported format specifiers. Note that if a date format is invalid, qsv will fall back and return the date as if no date-format was specified. |  |
 | `--keep-zero-time` | flag | Keep the time part of a date-time field if it is 00:00:00. By default, qsv will remove the time part if it is 00:00:00. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -190,10 +190,10 @@ qsv excel --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
-| `-q, --quiet` | flag | Do not display export summary message. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
+| `-q,`<br>`--quiet` | flag | Do not display export summary message. |  |
 
 ---
 **Source:** [`src/cmd/excel.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/excel.rs)

--- a/docs/help/exclude.md
+++ b/docs/help/exclude.md
@@ -119,8 +119,8 @@ qsv exclude --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --ignore-case` | flag | When set, matching is done case insensitively. |  |
-| `-v, --invert` | flag | When set, matching rows will be the only ones included, forming set intersection, instead of the ones discarded. |  |
+| `-i,`<br>`--ignore-case` | flag | When set, matching is done case insensitively. |  |
+| `-v,`<br>`--invert` | flag | When set, matching rows will be the only ones included, forming set intersection, instead of the ones discarded. |  |
 
 <a name="common-options"></a>
 
@@ -128,10 +128,10 @@ qsv exclude --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/exclude.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/exclude.rs)

--- a/docs/help/explode.md
+++ b/docs/help/explode.md
@@ -43,7 +43,7 @@ qsv explode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-r, --rename` | string | New name for the exploded column. |  |
+| `-r,`<br>`--rename` | string | New name for the exploded column. |  |
 
 <a name="common-options"></a>
 
@@ -51,10 +51,10 @@ qsv explode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/explode.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/explode.rs)

--- a/docs/help/extdedup.md
+++ b/docs/help/extdedup.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/extdedup.rs](https://github.com/dathere/qsv/blob/master/src/cmd/extdedup.rs)** | 👆
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [Extdedup Options](#extdedup-options) | [Csv Mode Only Options](#csv-mode-only-options)
+[Description](#description) | [Usage](#usage) | [Extdedup Options](#extdedup-options) | [CSV Mode Only Options](#csv-mode-only-options)
 
 <a name="description"></a>
 
@@ -46,23 +46,23 @@ qsv extdedup --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --select` | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extdedup will work in LINE MODE, deduping the input as a text file on a line-by-line basis. |  |
+| `-s,`<br>`--select` | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extdedup will work in LINE MODE, deduping the input as a text file on a line-by-line basis. |  |
 | `--no-output` | flag | Do not write deduplicated output to <output>. Use this if you only want to know the duplicate count. |  |
-| `-D, --dupes-output` | string | Write duplicates to <file>. Note that the file will NOT be a valid CSV. It is a list of duplicate lines, with the row number of the duplicate separated by a tab from the duplicate line itself. |  |
-| `-H, --human-readable` | flag | Comma separate duplicate count. |  |
+| `-D,`<br>`--dupes-output` | string | Write duplicates to <file>. Note that the file will NOT be a valid CSV. It is a list of duplicate lines, with the row number of the duplicate separated by a tab from the duplicate line itself. |  |
+| `-H,`<br>`--human-readable` | flag | Comma separate duplicate count. |  |
 | `--memory-limit` | string | The maximum amount of memory to buffer the on-disk hash table. If less than 50, this is a percentage of total memory. If more than 50, this is the memory in MB to allocate, capped at 90 percent of total memory. | `10` |
 | `--temp-dir` | string | Directory to store temporary hash table file. If not specified, defaults to operating system temp directory. |  |
 
 <a name="csv-mode-only-options"></a>
 
-## Csv Mode Only Options [↩](#nav)
+## CSV Mode Only Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be deduped with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-h, --help` | flag | Display this message |  |
-| `-q, --quiet` | flag | Do not print duplicate count to stderr. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be deduped with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-q,`<br>`--quiet` | flag | Do not print duplicate count to stderr. |  |
 
 ---
 **Source:** [`src/cmd/extdedup.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/extdedup.rs)

--- a/docs/help/extsort.md
+++ b/docs/help/extsort.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/extsort.rs](https://github.com/dathere/qsv/blob/master/src/cmd/extsort.rs)** | 🚀📇👆
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [External Sort Option](#external-sort-option) | [Csv Mode Only Options](#csv-mode-only-options)
+[Description](#description) | [Usage](#usage) | [External Sort Option](#external-sort-option) | [CSV Mode Only Options](#csv-mode-only-options)
 
 <a name="description"></a>
 
@@ -39,21 +39,21 @@ qsv extsort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --select` | string | Select a subset of columns to sort (CSV MODE). Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extsort will work in LINE MODE, sorting the input as a text file on a line-by-line basis. |  |
-| `-R, --reverse` | flag | Reverse order |  |
+| `-s,`<br>`--select` | string | Select a subset of columns to sort (CSV MODE). Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extsort will work in LINE MODE, sorting the input as a text file on a line-by-line basis. |  |
+| `-R,`<br>`--reverse` | flag | Reverse order |  |
 | `--memory-limit` | string | The maximum amount of memory to buffer the external merge sort. If less than 50, this is a percentage of total memory. If more than 50, this is the memory in MB to allocate, capped at 90 percent of total memory. | `20` |
 | `--tmp-dir` | string | The directory to use for externally sorting file segments. | `./` |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="csv-mode-only-options"></a>
 
-## Csv Mode Only Options [↩](#nav)
+## CSV Mode Only Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers and will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers and will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
 
 ---
 **Source:** [`src/cmd/extsort.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/extsort.rs)

--- a/docs/help/fetch.md
+++ b/docs/help/fetch.md
@@ -78,7 +78,7 @@ construct URLs for each CSV record with the --url-template option (see Examples 
 EXAMPLES USING THE URL-COLUMN ARGUMENT:
 
 data.csv
-### Url
+### URL
 
 <https://api.zippopotam.us/us/90210>
 <https://api.zippopotam.us/us/94105>
@@ -184,13 +184,13 @@ qsv fetch --help
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--url-template` | string | URL template to use. Use column names enclosed with curly braces to insert the CSV data for a record. Mutually exclusive with url-column. |  |
-| `-c, --new-column` | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
+| `-c,`<br>`--new-column` | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
 | `--jaq` | string | Apply jaq selector to API returned JSON value. Mutually exclusive with --jaqfile, |  |
 | `--jaqfile` | string | Load jaq selector from file instead. Mutually exclusive with --jaq. |  |
 | `--pretty` | flag | Prettify JSON responses. Otherwise, they're minified. If the response is not in JSON format, it's passed through. Note that --pretty requires the --new-column option. |  |
 | `--rate-limit` | string | Rate Limit in Queries Per Second (max: 1000). Note that fetch dynamically throttles as well based on rate-limit and retry-after response headers. Set to 0 to go as fast as possible, automatically throttling as required. CAUTION: Only use zero for APIs that use RateLimit and/or Retry-After headers, otherwise your fetch job may look like a Denial Of Service attack. Even though zero is the default, this is mitigated by --max-errors having a default of 10. | `0` |
 | `--timeout` | string | Timeout for each URL request. | `30` |
-| `-H, --http-header` | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
+| `-H,`<br>`--http-header` | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
 | `--max-retries` | string | Maximum number of retries per record before an error is raised. | `5` |
 | `--max-errors` | string | Maximum number of errors before aborting. Set to zero (0) to continue despite errors. | `10` |
 | `--store-error` | flag | On error, store error code/message instead of blank value. |  |
@@ -218,11 +218,11 @@ qsv fetch --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/fetch.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fetch.rs)

--- a/docs/help/fetchpost.md
+++ b/docs/help/fetchpost.md
@@ -179,16 +179,16 @@ qsv fetchpost --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-t, --payload-tpl` | string | Instead of <column-list>, use a MiniJinja template file to render a JSON payload in the HTTP Post body. You can also use --payload-tpl to render a non-JSON payload, but --content-type will have to be set manually. If a rendered JSON is invalid, `fetchpost` will abort and return an error. |  |
+| `-t,`<br>`--payload-tpl` | string | Instead of <column-list>, use a MiniJinja template file to render a JSON payload in the HTTP Post body. You can also use --payload-tpl to render a non-JSON payload, but --content-type will have to be set manually. If a rendered JSON is invalid, `fetchpost` will abort and return an error. |  |
 | `--content-type` | string | Overrides automatic content types for `<column-list>` (`application/x-www-form-urlencoded`) and `--payload-tpl` (`application/json`). Typical alternative values are `multipart/form-data` and `text/plain`. It is the responsibility of the user to format the payload accordingly when using --payload-tpl. |  |
-| `-j, --globals-json` | string | A JSON file containing global variables. When posting as an HTML Form, this file is added to the Form data. When constructing a payload using a MiniJinja template, the JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.api_key}}, {{qsv_g.base_url}}). |  |
-| `-c, --new-column` | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
+| `-j,`<br>`--globals-json` | string | A JSON file containing global variables. When posting as an HTML Form, this file is added to the Form data. When constructing a payload using a MiniJinja template, the JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.api_key}}, {{qsv_g.base_url}}). |  |
+| `-c,`<br>`--new-column` | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
 | `--jaq` | string | Apply jaq selector to API returned JSON response. Mutually exclusive with --jaqfile. |  |
 | `--jaqfile` | string | Load jaq selector from file instead. Mutually exclusive with --jaq. |  |
 | `--pretty` | flag | Prettify JSON responses. Otherwise, they're minified. If the response is not in JSON format, it's passed through unchanged. Note that --pretty requires the --new-column option. |  |
 | `--rate-limit` | string | Rate Limit in Queries Per Second (max: 1000). Note that fetch dynamically throttles as well based on rate-limit and retry-after response headers. Set to 0 to go as fast as possible, automatically throttling as required. CAUTION: Only use zero for APIs that use RateLimit and/or Retry-After headers, otherwise your fetchpost job may look like a Denial Of Service attack. Even though zero is the default, this is mitigated by --max-errors having a default of 10. | `0` |
 | `--timeout` | string | Timeout for each URL request. | `30` |
-| `-H, --http-header` | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
+| `-H,`<br>`--http-header` | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
 | `--compress` | flag | Compress the HTTP request body using gzip. Note that most servers do not support compressed request bodies unless they are specifically configured to do so. This should only be enabled for trusted scenarios where "zip bombs" are not a concern. see <https://github.com/postmanlabs/httpbin/issues/577#issuecomment-875814469> for more info. |  |
 | `--max-retries` | string | Maximum number of retries per record before an error is raised. | `5` |
 | `--max-errors` | string | Maximum number of errors before aborting. Set to zero (0) to continue despite errors. | `10` |
@@ -217,11 +217,11 @@ qsv fetchpost --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/fetchpost.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fetchpost.rs)

--- a/docs/help/fill.md
+++ b/docs/help/fill.md
@@ -59,10 +59,10 @@ qsv fill --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g, --groupby` | string | Group by specified columns. |  |
-| `-f, --first` | flag | Fill using the first valid value of a column, instead of the latest. |  |
-| `-b, --backfill` | flag | Fill initial empty values with the first valid value. |  |
-| `-v, --default` | string | Fill using this default value. |  |
+| `-g,`<br>`--groupby` | string | Group by specified columns. |  |
+| `-f,`<br>`--first` | flag | Fill using the first valid value of a column, instead of the latest. |  |
+| `-b,`<br>`--backfill` | flag | Fill initial empty values with the first valid value. |  |
+| `-v,`<br>`--default` | string | Fill using this default value. |  |
 
 <a name="common-options"></a>
 
@@ -70,10 +70,10 @@ qsv fill --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/fill.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fill.rs)

--- a/docs/help/fixlengths.md
+++ b/docs/help/fixlengths.md
@@ -38,9 +38,9 @@ qsv fixlengths --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-l, --length` | string | Forcefully set the length of each record. If a record is not the size given, then it is truncated or expanded as appropriate. |  |
-| `-r, --remove-empty` | flag | Remove empty columns. |  |
-| `-i, --insert` | string | If empty fields need to be inserted, insert them at <pos>. If <pos> is zero, then it is inserted at the end of each record. If <pos> is negative, it is inserted from the END of each record going backwards. If <pos> is positive, it is inserted from the BEGINNING of each record going forward. | `0` |
+| `-l,`<br>`--length` | string | Forcefully set the length of each record. If a record is not the size given, then it is truncated or expanded as appropriate. |  |
+| `-r,`<br>`--remove-empty` | flag | Remove empty columns. |  |
+| `-i,`<br>`--insert` | string | If empty fields need to be inserted, insert them at <pos>. If <pos> is zero, then it is inserted at the end of each record. If <pos> is negative, it is inserted from the END of each record going backwards. If <pos> is positive, it is inserted from the BEGINNING of each record going forward. | `0` |
 | `--quote` | string | The quote character to use. | `"` |
 | `--escape` | string | The escape character to use. When not specified, quotes are escaped by doubling them. |  |
 
@@ -50,10 +50,10 @@ qsv fixlengths --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-q, --quiet` | flag | Don't print removed column information. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-q,`<br>`--quiet` | flag | Don't print removed column information. |  |
 
 ---
 **Source:** [`src/cmd/fixlengths.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fixlengths.rs)

--- a/docs/help/flatten.md
+++ b/docs/help/flatten.md
@@ -37,9 +37,9 @@ qsv flatten --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c, --condense` | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
-| `-f, --field-separator` | string | A string of character to write between a column name and its value. |  |
-| `-s, --separator` | string | A string of characters to write after each record. When non-empty, a new line is automatically appended to the separator. | `#` |
+| `-c,`<br>`--condense` | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
+| `-f,`<br>`--field-separator` | string | A string of character to write between a column name and its value. |  |
+| `-s,`<br>`--separator` | string | A string of characters to write after each record. When non-empty, a new line is automatically appended to the separator. | `#` |
 
 <a name="common-options"></a>
 
@@ -47,9 +47,9 @@ qsv flatten --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. When set, the name of each field will be its index. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. When set, the name of each field will be its index. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/flatten.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/flatten.rs)

--- a/docs/help/fmt.md
+++ b/docs/help/fmt.md
@@ -37,7 +37,7 @@ qsv fmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-t, --out-delimiter` | string | The field delimiter for writing CSV data. Must be a single character. If set to "T", uses tab as the delimiter. | `,` |
+| `-t,`<br>`--out-delimiter` | string | The field delimiter for writing CSV data. Must be a single character. If set to "T", uses tab as the delimiter. | `,` |
 | `--crlf` | flag | Use '\r\n' line endings in the output. |  |
 | `--ascii` | flag | Use ASCII field and record separators. Use Substitute (U+00A1) as the quote character. |  |
 | `--quote` | string | The quote character to use. | `"` |
@@ -52,9 +52,9 @@ qsv fmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/fmt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fmt.rs)

--- a/docs/help/foreach.md
+++ b/docs/help/foreach.md
@@ -66,8 +66,8 @@ qsv foreach --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-u, --unify` | flag | If the output of the executed command is a CSV, unify the result by skipping headers on each subsequent command. Does not work when --dry-run is true. |  |
-| `-c, --new-column` | string | If unifying, add a new column with given name and copying the value of the current input file line. |  |
+| `-u,`<br>`--unify` | flag | If the output of the executed command is a CSV, unify the result by skipping headers on each subsequent command. Does not work when --dry-run is true. |  |
+| `-c,`<br>`--new-column` | string | If unifying, add a new column with given name and copying the value of the current input file line. |  |
 | `--dry-run` | string | If set to true (the default for safety reasons), the commands are sent to stdout instead of executing them. If set to a file, the commands will be written to the specified text file instead of executing them. Only if set to false will the commands be actually executed. | `true` |
 
 <a name="common-options"></a>
@@ -76,10 +76,10 @@ qsv foreach --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the file will be considered to have no headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the file will be considered to have no headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/foreach.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/foreach.rs)

--- a/docs/help/frequency.md
+++ b/docs/help/frequency.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/frequency.rs](https://github.com/dathere/qsv/blob/master/src/cmd/frequency.rs)** | 📇😣🏎️👆🪄![Luau](../images/luau.png)
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [Frequency Options](#frequency-options) | [Json Output Options](#json-output-options) | [Common Options](#common-options)
+[Description](#description) | [Usage](#usage) | [Frequency Options](#frequency-options) | [JSON Output Options](#json-output-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -97,31 +97,31 @@ qsv frequency --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --select` | string | Select a subset of columns to compute frequencies for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv frequency' will disable the use of indexing. |  |
-| `-l, --limit` | string | Limit the frequency table to the N most common items. Set to '0' to disable a limit. If negative, only return values with an occurrence count >= absolute value of the negative limit. e.g. --limit -2 will only return values with an occurrence count >= 2. | `10` |
-| `-u, --unq-limit` | string | If a column has all unique values, limit the frequency table to a sample of N unique items. Set to '0' to disable a unique_limit. | `10` |
+| `-s,`<br>`--select` | string | Select a subset of columns to compute frequencies for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv frequency' will disable the use of indexing. |  |
+| `-l,`<br>`--limit` | string | Limit the frequency table to the N most common items. Set to '0' to disable a limit. If negative, only return values with an occurrence count >= absolute value of the negative limit. e.g. --limit -2 will only return values with an occurrence count >= 2. | `10` |
+| `-u,`<br>`--unq-limit` | string | If a column has all unique values, limit the frequency table to a sample of N unique items. Set to '0' to disable a unique_limit. | `10` |
 | `--lmt-threshold` | string | The threshold for which --limit and --unq-limit will be applied. If the number of unique items in a column >= threshold, the limits will be applied. Set to '0' to disable the threshold and always apply limits. | `0` |
-| `-r, --rank-strategy` | string | The strategy to use when there are count-tied values in the frequency table. See <https://en.wikipedia.org/wiki/Ranking> for more info. | `dense` |
+| `-r,`<br>`--rank-strategy` | string | The strategy to use when there are count-tied values in the frequency table. See <https://en.wikipedia.org/wiki/Ranking> for more info. | `dense` |
 | `--pct-dec-places` | string | The number of decimal places to round the percentage to. If negative, the number of decimal places will be set automatically to the minimum number of decimal places needed to represent the percentage accurately, up to the absolute value of the negative number. | `-5` |
 | `--other-sorted` | flag | By default, the "Other" category is placed at the end of the frequency table for a field. If this is enabled, the "Other" category will be sorted with the rest of the values by count. |  |
 | `--other-text` | string | The text to use for the "Other" category. If set to "<NONE>", the "Other" category will not be included in the frequency table. | `Other` |
 | `--no-other` | flag | Don't include the "Other" category in the frequency table. This is equivalent to --other-text "<NONE>". |  |
 | `--null-sorted` | flag | By default, the NULL category (controlled by --null-text) is placed at the end of the frequency table for a field, after "Other" if present. If this is enabled, the NULL category will be sorted with the rest of the values by count. |  |
-| `-a, --asc` | flag | Sort the frequency tables in ascending order by count. The default is descending order. Note that this option will also reverse ranking - i.e. the LEAST frequent values will have a rank of 1. |  |
+| `-a,`<br>`--asc` | flag | Sort the frequency tables in ascending order by count. The default is descending order. Note that this option will also reverse ranking - i.e. the LEAST frequent values will have a rank of 1. |  |
 | `--no-trim` | flag | Don't trim whitespace from values when computing frequencies. The default is to trim leading and trailing whitespaces. |  |
 | `--null-text` | string | The text to use for NULL values. If set to "<NONE>", NULLs will not be included in the frequency table (equivalent to --no-nulls). | `(NULL)` |
 | `--no-nulls` | flag | Don't include NULLs in the frequency table. This is equivalent to --null-text "<NONE>". |  |
 | `--pct-nulls` | flag | Include NULL values in percentage and rank calculations. When disabled (default), percentages are "valid percentages" calculated with NULLs excluded from the denominator, and NULL entries display empty percentage and rank values. When enabled, NULLs are included in the denominator (original behavior). Has no effect when --no-nulls is set. |  |
-| `-i, --ignore-case` | flag | Ignore case when computing frequencies. |  |
+| `-i,`<br>`--ignore-case` | flag | Ignore case when computing frequencies. |  |
 | `--no-float` | string | Exclude Float columns from frequency analysis. Floats typically contain continuous values where frequency tables are not meaningful. To exclude ALL Float columns, use --no-float "*" To exclude Floats except specific columns, specify a comma-separated list of Float columns to INCLUDE. e.g. "--no-float *" excludes all Floats "--no-float price,rate" excludes Floats except 'price' and 'rate' Requires stats cache for type detection. |  |
 | `--stats-filter` | string | Filter columns based on their statistics using a Luau expression. Columns where the expression evaluates to `true` are EXCLUDED. Available fields: field, type, is_ascii, cardinality, nullcount, sum, min, max, range, sort_order, min_length, max_length, mean, stddev, variance, cv, sparsity, q1, q2_median, q3, iqr, mad, skewness, mode, antimode, n_negative, n_zero, n_positive, etc. e.g. "nullcount > 1000" - exclude columns with many nulls "type == 'Float'" - exclude Float columns "cardinality > 500 and nullcount > 0" - compound expression Requires stats cache and the "luau" feature. |  |
 | `--all-unique-text` | string | The text to use for the "<ALL_UNIQUE>" category. | `<ALL_UNIQUE>` |
 | `--vis-whitespace` | flag | Visualize whitespace characters in the output. See <https://github.com/dathere/qsv/wiki/Supplemental#whitespace-markers> for the list of whitespace markers. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
 <a name="json-output-options"></a>
 
-## Json Output Options [↩](#nav)
+## JSON Output Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
@@ -137,10 +137,10 @@ qsv frequency --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will NOT be included in the frequency table. Additionally, the 'field' column will be 1-based indices instead of header names. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be included in the frequency table. Additionally, the 'field' column will be 1-based indices instead of header names. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---

--- a/docs/help/geocode.md
+++ b/docs/help/geocode.md
@@ -363,8 +363,8 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c, --new-column` | string | Put the transformed values in a new column instead. Not valid when using the '%dyncols:' --formatstr option. |  |
-| `-r, --rename` | string | New name for the transformed column. |  |
+| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. Not valid when using the '%dyncols:' --formatstr option. |  |
+| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
 | `--country` | string | The comma-delimited, case-insensitive list of countries to filter for. Country is specified as a ISO 3166-1 alpha-2 (two-letter) country code. <https://en.wikipedia.org/wiki/ISO_3166-2> |  |
 
 <a name="suggest-only-options"></a>
@@ -382,7 +382,7 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-k, --k_weight` | string | Use population-weighted distance for reverse subcommand. (i.e. nearest.distance - k * city.population) Larger values will favor more populated cities. If not set (default), the population is not used and the nearest city is returned. |  |
+| `-k,`<br>`--k_weight` | string | Use population-weighted distance for reverse subcommand. (i.e. nearest.distance - k * city.population) Larger values will favor more populated cities. If not set (default), the population is not used and the nearest city is returned. |  |
 
 <a name="dynamic-formatting-options"></a>
 
@@ -390,10 +390,10 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-l, --language` | string | The language to use when geocoding. The language is specified as a ISO 639-1 code. Note that the Geonames index must have been built with the specified language using the `index-update` subcommand with the --languages option. If the language is not available, the first language in the index is used. | `en` |
+| `-l,`<br>`--language` | string | The language to use when geocoding. The language is specified as a ISO 639-1 code. Note that the Geonames index must have been built with the specified language using the `index-update` subcommand with the --languages option. If the language is not available, the first language in the index is used. | `en` |
 | `--invalid-result` | string | The string to return when the geocode result is empty/invalid. If not set, the original value is used. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 | `--timeout` | string | Timeout for downloading Geonames cities index. | `120` |
 | `--cache-dir` | string | The directory to use for caching the Geonames cities index. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
 
@@ -413,10 +413,10 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/geocode.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/geocode.rs)

--- a/docs/help/geoconvert.md
+++ b/docs/help/geoconvert.md
@@ -67,10 +67,10 @@ qsv geoconvert --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g, --geometry` | string | The name of the column that has WKT geometry. Alternative to --latitude and --longitude. |  |
-| `-y, --latitude` | string | The name of the column with northing values. |  |
-| `-x, --longitude` | string | The name of the column with easting values. |  |
-| `-l, --max-length` | string | The maximum column length when the output format is CSV. Oftentimes, the geometry column is too long to fit in a CSV file, causing other tools like Python & PostgreSQL to fail. If a column is too long, it will be truncated to the specified length and an ellipsis ("...") will be appended. |  |
+| `-g,`<br>`--geometry` | string | The name of the column that has WKT geometry. Alternative to --latitude and --longitude. |  |
+| `-y,`<br>`--latitude` | string | The name of the column with northing values. |  |
+| `-x,`<br>`--longitude` | string | The name of the column with easting values. |  |
+| `-l,`<br>`--max-length` | string | The maximum column length when the output format is CSV. Oftentimes, the geometry column is too long to fit in a CSV file, causing other tools like Python & PostgreSQL to fail. If a column is too long, it will be truncated to the specified length and an ellipsis ("...") will be appended. |  |
 
 <a name="common-options"></a>
 
@@ -78,8 +78,8 @@ qsv geoconvert --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
 
 ---
 **Source:** [`src/cmd/geoconvert.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/geoconvert.rs)

--- a/docs/help/headers.md
+++ b/docs/help/headers.md
@@ -45,8 +45,8 @@ qsv headers --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-j, --just-names` | flag | Only show the header names (hide column index). This is automatically enabled if more than one input is given. |  |
-| `-J, --just-count` | flag | Only show the number of headers. |  |
+| `-j,`<br>`--just-names` | flag | Only show the header names (hide column index). This is automatically enabled if more than one input is given. |  |
+| `-J,`<br>`--just-count` | flag | Only show the number of headers. |  |
 | `--intersect` | flag | Shows the intersection of all headers in all of the inputs given. |  |
 | `--trim` | flag | Trim space & quote characters from header name. |  |
 
@@ -56,8 +56,8 @@ qsv headers --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/headers.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/headers.rs)

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -40,7 +40,7 @@ qsv index --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-o, --output` | string | Write index to <file> instead of <input>.idx. Generally, this is not currently useful because the only way to use an index is if it is specially named <input>.idx. |  |
+| `-o,`<br>`--output` | string | Write index to <file> instead of <input>.idx. Generally, this is not currently useful because the only way to use an index is if it is specially named <input>.idx. |  |
 
 <a name="common-options"></a>
 
@@ -48,7 +48,7 @@ qsv index --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/index.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/index.rs)

--- a/docs/help/input.md
+++ b/docs/help/input.md
@@ -71,9 +71,9 @@ qsv input --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/input.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/input.rs)

--- a/docs/help/join.md
+++ b/docs/help/join.md
@@ -65,8 +65,8 @@ qsv join --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --ignore-case` | flag | When set, joins are done case insensitively. |  |
-| `-z, --ignore-leading-zeros` | flag | When set, leading zeros are ignored in join keys. |  |
+| `-i,`<br>`--ignore-case` | flag | When set, joins are done case insensitively. |  |
+| `-z,`<br>`--ignore-leading-zeros` | flag | When set, leading zeros are ignored in join keys. |  |
 
 <a name="common-options"></a>
 
@@ -74,10 +74,10 @@ qsv join --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/join.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/join.rs)

--- a/docs/help/joinp.md
+++ b/docs/help/joinp.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/joinp.rs](https://github.com/dathere/qsv/blob/master/src/cmd/joinp.rs)** | 🚀🐻‍❄️🪄
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [Joinp Options](#joinp-options) | [Join Options](#join-options) | [Polars Csv Parsing Options](#polars-csv-parsing-options) | [Asof Join Options](#asof-join-options) | [Output Format Options](#output-format-options) | [Join Key Transformation Options](#join-key-transformation-options) | [Common Options](#common-options)
+[Description](#description) | [Usage](#usage) | [Joinp Options](#joinp-options) | [Join Options](#join-options) | [Polars CSV Parsing Options](#polars-csv-parsing-options) | [Asof Join Options](#asof-join-options) | [Output Format Options](#output-format-options) | [Join Key Transformation Options](#join-key-transformation-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -68,7 +68,7 @@ qsv joinp --help
 
 <a name="polars-csv-parsing-options"></a>
 
-## Polars Csv Parsing Options [↩](#nav)
+## Polars CSV Parsing Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
@@ -92,7 +92,7 @@ qsv joinp --help
 | `--right_by` | string | Do an 'asof_by' join. This specifies the column/s for the right CSV. |  |
 | `--strategy` | string | The strategy to use for the asof join: backward - For each row in the first CSV data set, we find the last row in the second data set whose key is less than or equal to the key in the first data set. forward -  For each row in the first CSV data set, we find the first row in the second data set whose key is greater than or equal to the key in the first data set. nearest -  selects the last row in the second data set whose value is nearest to the value in the first data set. | `backward` |
 | `--tolerance` | string | The tolerance for the nearest asof join. This is only used when the nearest strategy is used. The tolerance is a positive integer that specifies the maximum number of rows to search for a match. |  |
-| `-X, --allow-exact-matches` | flag | When set, the asof join will allow exact matches. (i.e. less-than-or-equal-to or greater-than-or-equal-to) Otherwise, the asof join will only allow nearest matches (strictly less-than or greater-than) by default. |  |
+| `-X,`<br>`--allow-exact-matches` | flag | When set, the asof join will allow exact matches. (i.e. less-than-or-equal-to or greater-than-or-equal-to) Otherwise, the asof join will only allow nearest matches (strictly less-than or greater-than) by default. |  |
 
 <a name="output-format-options"></a>
 
@@ -113,9 +113,9 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --ignore-case` | flag | When set, joins are done case insensitively. |  |
-| `-z, --ignore-leading-zeros` | flag | When set, joins are done ignoring leading zeros. Note that this is only applied to the join keys for both numeric and string columns. Also note that Polars will automatically remove leading zeros from numeric columns when it infers the schema. To force the schema to be all String types, set --cache-schema to -1 or -2. |  |
-| `-N, --norm-unicode` | string | When set, join keys are Unicode normalized. | `none` |
+| `-i,`<br>`--ignore-case` | flag | When set, joins are done case insensitively. |  |
+| `-z,`<br>`--ignore-leading-zeros` | flag | When set, joins are done ignoring leading zeros. Note that this is only applied to the join keys for both numeric and string columns. Also note that Polars will automatically remove leading zeros from numeric columns when it infers the schema. To force the schema to be all String types, set --cache-schema to -1 or -2. |  |
+| `-N,`<br>`--norm-unicode` | string | When set, join keys are Unicode normalized. | `none` |
 
 <a name="common-options"></a>
 
@@ -123,10 +123,10 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
-| `-q, --quiet` | flag | Do not return join shape to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| `-q,`<br>`--quiet` | flag | Do not return join shape to stderr. |  |
 
 ---
 **Source:** [`src/cmd/joinp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/joinp.rs)

--- a/docs/help/json.md
+++ b/docs/help/json.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/json.rs](https://github.com/dathere/qsv/blob/master/src/cmd/json.rs)** | 👆
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [Json Options](#json-options) | [Common Options](#common-options)
+[Description](#description) | [Usage](#usage) | [JSON Options](#json-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -158,12 +158,12 @@ qsv json --help
 
 <a name="json-options"></a>
 
-## Json Options [↩](#nav)
+## JSON Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--jaq` | string | Filter JSON data using jaq syntax (<https://github.com/01mf02/jaq>), which is identical to the popular JSON command-line tool - jq. <https://jqlang.github.io/jq/> Note that the filter is applied BEFORE converting JSON to CSV |  |
-| `-s, --select` | string | Select, reorder or drop columns for output. Otherwise, all the columns will be output in the same order as the first object's keys in the JSON data. See 'qsv select --help' for the full syntax. Note however that <cols> NEED to be a comma-delimited list of column NAMES and NOT column INDICES. | `1-` |
+| `-s,`<br>`--select` | string | Select, reorder or drop columns for output. Otherwise, all the columns will be output in the same order as the first object's keys in the JSON data. See 'qsv select --help' for the full syntax. Note however that <cols> NEED to be a comma-delimited list of column NAMES and NOT column INDICES. | `1-` |
 
 <a name="common-options"></a>
 
@@ -171,8 +171,8 @@ qsv json --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
 
 ---
 **Source:** [`src/cmd/json.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/json.rs)

--- a/docs/help/jsonl.md
+++ b/docs/help/jsonl.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/jsonl.rs](https://github.com/dathere/qsv/blob/master/src/cmd/jsonl.rs)** | 🚀🔣
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [Jsonl Options](#jsonl-options) | [Common Options](#common-options)
+[Description](#description) | [Usage](#usage) | [JSONL Options](#jsonl-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -34,13 +34,13 @@ qsv jsonl --help
 
 <a name="jsonl-options"></a>
 
-## Jsonl Options [↩](#nav)
+## JSONL Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--ignore-errors` | flag | Skip malformed input lines. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 
 <a name="common-options"></a>
 
@@ -48,9 +48,9 @@ qsv jsonl --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
 
 ---
 **Source:** [`src/cmd/jsonl.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/jsonl.rs)

--- a/docs/help/lens.md
+++ b/docs/help/lens.md
@@ -137,19 +137,19 @@ qsv lens --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-d, --delimiter` | string | Delimiter character (comma by default) "auto" to auto-detect the delimiter |  |
-| `-t, --tab-separated` | flag | Use tab separation. Shortcut for -d '\t' |  |
+| `-d,`<br>`--delimiter` | string | Delimiter character (comma by default) "auto" to auto-detect the delimiter |  |
+| `-t,`<br>`--tab-separated` | flag | Use tab separation. Shortcut for -d '\t' |  |
 | `--no-headers` | flag | Do not interpret the first row as headers |  |
 | `--columns` | string | Use this regex to select columns to display by default. Example: "col1\|col2\|col3" to select columns "col1", "col2" and "col3" and also columns like "col1_1", "col22" and "col3-more". |  |
 | `--filter` | string | Use this regex to filter rows to display by default. The regex is matched against each cell in every column. Example: "val1\|val2" filters rows with any cells containing "val1", "val2" or text like "my_val1" or "val234". |  |
 | `--find` | string | Use this regex to find and highlight matches by default. Automatically sets --monochrome to true so the matches are easier to see. The regex is matched against each cell in every column. Example: "val1\|val2" highlights text containing "val1", "val2" or longer text like "val1_ok" or "val2_error". |  |
-| `-i, --ignore-case` | flag | Searches ignore case. Ignored if any uppercase letters are present in the search string |  |
-| `-f, --freeze-columns` | string | Freeze the first N columns | `1` |
-| `-m, --monochrome` | flag | Disable color output |  |
-| `-W, --wrap-mode` | string | Set the wrap mode for the output. | `disabled` |
-| `-A, --auto-reload` | flag | Automatically reload the data when the file changes. |  |
-| `-S, --streaming-stdin` | flag | Enable streaming stdin (load input as it's being piped in) NOTE: This option only applies to stdin input. |  |
-| `-P, --prompt` | string | Set a custom prompt in the status bar. Normally paired w/ --echo-column: qsv lens --prompt 'Select City:' --echo-column 'City' Supports ANSI escape codes for colored or styled text. When using escape codes, ensure it's properly escaped. For example, in bash/zsh, the $'...' syntax is used to do so: qsv lens --prompt $'\033[1;5;31mBlinking red, bold text\033[0m' see <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors> or <https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797> for more info on ANSI escape codes. Typing a complicated prompt on the command line can be tricky. If the prompt starts with "file:", it's interpreted as a filepath from which to load the prompt, e.g. qsv lens --prompt "file:prompt.txt" |  |
+| `-i,`<br>`--ignore-case` | flag | Searches ignore case. Ignored if any uppercase letters are present in the search string |  |
+| `-f,`<br>`--freeze-columns` | string | Freeze the first N columns | `1` |
+| `-m,`<br>`--monochrome` | flag | Disable color output |  |
+| `-W,`<br>`--wrap-mode` | string | Set the wrap mode for the output. | `disabled` |
+| `-A,`<br>`--auto-reload` | flag | Automatically reload the data when the file changes. |  |
+| `-S,`<br>`--streaming-stdin` | flag | Enable streaming stdin (load input as it's being piped in) NOTE: This option only applies to stdin input. |  |
+| `-P,`<br>`--prompt` | string | Set a custom prompt in the status bar. Normally paired w/ --echo-column: qsv lens --prompt 'Select City:' --echo-column 'City' Supports ANSI escape codes for colored or styled text. When using escape codes, ensure it's properly escaped. For example, in bash/zsh, the $'...' syntax is used to do so: qsv lens --prompt $'\033[1;5;31mBlinking red, bold text\033[0m' see <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors> or <https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797> for more info on ANSI escape codes. Typing a complicated prompt on the command line can be tricky. If the prompt starts with "file:", it's interpreted as a filepath from which to load the prompt, e.g. qsv lens --prompt "file:prompt.txt" |  |
 | `--echo-column` | string | Print the value of this column to stdout for the selected row |  |
 | `--debug` | flag | Show stats for debugging |  |
 
@@ -159,7 +159,7 @@ qsv lens --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/lens.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/lens.rs)

--- a/docs/help/luau.md
+++ b/docs/help/luau.md
@@ -258,11 +258,11 @@ qsv luau --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g, --no-globals` | flag | Don't create Luau global variables for each column, only `col`. Useful when some column names mask standard Luau globals and to increase PERFORMANCE. Note: access to Luau globals thru _G remains even with -g. |  |
+| `-g,`<br>`--no-globals` | flag | Don't create Luau global variables for each column, only `col`. Useful when some column names mask standard Luau globals and to increase PERFORMANCE. Note: access to Luau globals thru _G remains even with -g. |  |
 | `--colindex` | flag | Create a 1-based column index. Useful when some column names mask standard Luau globals. Automatically enabled with --no-headers. |  |
-| `-r, --remap` | flag | Only the listed new columns are written to the output CSV. Only applies to "map" subcommand. |  |
-| `-B, --begin` | string | Luau script/file to execute in the BEGINning, before processing the CSV with the main-script. Typically used to initialize global variables. Takes precedence over an embedded BEGIN script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
-| `-E, --end` | string | Luau script/file to execute at the END, after processing the CSV with the main-script. Typically used for aggregations. The output of the END script is sent to stderr. Takes precedence over an embedded END script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
+| `-r,`<br>`--remap` | flag | Only the listed new columns are written to the output CSV. Only applies to "map" subcommand. |  |
+| `-B,`<br>`--begin` | string | Luau script/file to execute in the BEGINning, before processing the CSV with the main-script. Typically used to initialize global variables. Takes precedence over an embedded BEGIN script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
+| `-E,`<br>`--end` | string | Luau script/file to execute at the END, after processing the CSV with the main-script. Typically used for aggregations. The output of the END script is sent to stderr. Takes precedence over an embedded END script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
 | `--max-errors` | string | The maximum number of errors to tolerate before aborting. Set to zero to disable error limit. | `10` |
 | `--timeout` | string | Timeout for downloading lookup_tables using the qsv_register_lookup() helper function. | `60` |
 | `--ckan-api` | string | The URL of the CKAN API to use for downloading lookup_table resources using the qsv_register_lookup() helper function with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
@@ -275,11 +275,11 @@ qsv luau --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Automatically enables --colindex option. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. Ignored in qsvdp. In SEQUENTIAL MODE, the progress bar will show the number of rows processed. In RANDOM ACCESS MODE, the progress bar will show the position of the current row being processed. Enabling this option will also suppress stderr output from the END script. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Automatically enables --colindex option. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. Ignored in qsvdp. In SEQUENTIAL MODE, the progress bar will show the number of rows processed. In RANDOM ACCESS MODE, the progress bar will show the position of the current row being processed. Enabling this option will also suppress stderr output from the END script. |  |
 
 ---
 **Source:** [`src/cmd/luau.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/luau.rs)

--- a/docs/help/moarstats.md
+++ b/docs/help/moarstats.md
@@ -261,7 +261,7 @@ qsv moarstats --help
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--advanced` | flag | Compute Kurtosis, Shannon Entropy, Bimodality Coefficient, Gini Coefficient and Atkinson Index. These advanced statistics computations require reading the original CSV file to collect all values for computation and are computationally expensive. Further, Entropy computation requires the frequency command to be run with --limit 0 to collect all frequencies. An index will be auto-created for the original CSV file if it doesn't already exist to enable parallel processing. |  |
-| `-e, --epsilon` | string | The Atkinson Index Inequality Aversion parameter. Epsilon controls the sensitivity of the Atkinson Index to inequality. The higher the epsilon, the more sensitive the index is to inequality. Typical values are 0.5 (standard in economic research), 1.0 (natural boundary), or 2.0 (useful for poverty analysis). | `1.0` |
+| `-e,`<br>`--epsilon` | string | The Atkinson Index Inequality Aversion parameter. Epsilon controls the sensitivity of the Atkinson Index to inequality. The higher the epsilon, the more sensitive the index is to inequality. Typical values are 0.5 (standard in economic research), 1.0 (natural boundary), or 2.0 (useful for poverty analysis). | `1.0` |
 | `--stats-options` | string | Options to pass to the stats command if baseline stats need to be generated. The options are passed as a single string that will be split by whitespace. | `--infer-dates --infer-boolean --mad --quartiles --percentiles --force --stats-jsonl` |
 | `--round` | string | Round statistics to <n> decimal places. Rounding follows Midpoint Nearest Even (Bankers Rounding) rule. | `4` |
 | `--use-percentiles` | flag | Use percentiles instead of Q1/Q3 for winsorization/trimming. Requires percentiles to be computed in the stats CSV. |  |
@@ -274,13 +274,13 @@ qsv moarstats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-B, --bivariate` | flag | Enable bivariate statistics computation. Requires indexed CSV file (index will be auto-created if missing). Computes pairwise correlations, covariances, mutual information, and normalized mutual information between columns. The bivariate statistics |  |
-| `-S, --bivariate-stats` | string | Comma-separated list of bivariate statistics to compute. Options: pearson, spearman, kendall, covariance, mi (mutual information), nmi (normalized mutual information) Use "all" to compute all statistics or "fast" to compute only pearson & covariance, which is much faster as it doesn't require storing all values and uses streaming algorithms. | `fast` |
-| `-C, --cardinality-threshold` | string | Skip mutual information computation for field pairs where either field has cardinality exceeding this threshold. Helps avoid expensive computations for high-cardinality fields. | `1000000` |
-| `-J, --join-inputs` | string | Additional datasets to join. Comma-separated list of CSV files to join with the primary input. e.g.: --join-inputs customers.csv,products.csv |  |
-| `-K, --join-keys` | string | Join keys for each dataset. Comma-separated list of join key column names, one per dataset. Must specify same number of keys as datasets (primary + addl). e.g.: --join-keys customer_id,customer_id,product_id |  |
-| `-T, --join-type` | string | Join type when using --join-inputs. Valid values: inner, left, right, full | `inner` |
-| `-p, --progressbar` | flag | Show progress bars when computing bivariate statistics. |  |
+| `-B,`<br>`--bivariate` | flag | Enable bivariate statistics computation. Requires indexed CSV file (index will be auto-created if missing). Computes pairwise correlations, covariances, mutual information, and normalized mutual information between columns. The bivariate statistics |  |
+| `-S,`<br>`--bivariate-stats` | string | Comma-separated list of bivariate statistics to compute. Options: pearson, spearman, kendall, covariance, mi (mutual information), nmi (normalized mutual information) Use "all" to compute all statistics or "fast" to compute only pearson & covariance, which is much faster as it doesn't require storing all values and uses streaming algorithms. | `fast` |
+| `-C,`<br>`--cardinality-threshold` | string | Skip mutual information computation for field pairs where either field has cardinality exceeding this threshold. Helps avoid expensive computations for high-cardinality fields. | `1000000` |
+| `-J,`<br>`--join-inputs` | string | Additional datasets to join. Comma-separated list of CSV files to join with the primary input. e.g.: --join-inputs customers.csv,products.csv |  |
+| `-K,`<br>`--join-keys` | string | Join keys for each dataset. Comma-separated list of join key column names, one per dataset. Must specify same number of keys as datasets (primary + addl). e.g.: --join-keys customer_id,customer_id,product_id |  |
+| `-T,`<br>`--join-type` | string | Join type when using --join-inputs. Valid values: inner, left, right, full | `inner` |
+| `-p,`<br>`--progressbar` | flag | Show progress bars when computing bivariate statistics. |  |
 
 <a name="common-options"></a>
 
@@ -289,9 +289,9 @@ qsv moarstats --help
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--force` | flag | Force recomputing stats even if valid precomputed stats cache exists. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of overwriting the stats CSV file. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of overwriting the stats CSV file. |  |
 
 ---
 **Source:** [`src/cmd/moarstats.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/moarstats.rs)

--- a/docs/help/partition.md
+++ b/docs/help/partition.md
@@ -68,7 +68,7 @@ qsv partition --help
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--filename` | string | A filename template to use when constructing the names of the output files.  The string '{}' will be replaced by a value based on the partition column, but sanitized for shell safety. | `{}.csv` |
-| `-p, --prefix-length` | string | Truncate the partition column after the specified number of bytes when creating the output file. |  |
+| `-p,`<br>`--prefix-length` | string | Truncate the partition column after the specified number of bytes when creating the output file. |  |
 | `--drop` | flag | Drop the partition column from results. |  |
 | `--limit` | string | Limit the number of simultaneously open files. Useful for partitioning large datasets with many unique values to avoid "too many open files" errors. Data is processed in batches until all unique values are processed. If not set, it will be automatically set to the system limit with a 10% safety margin. If set to 0, it will process all data at once, regardless of the system's open files limit. |  |
 
@@ -78,9 +78,9 @@ qsv partition --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/partition.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/partition.rs)

--- a/docs/help/pivotp.md
+++ b/docs/help/pivotp.md
@@ -46,9 +46,9 @@ qsv pivotp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --index` | string | The column(s) to use as the index (row labels). Specify multiple columns by separating them with a comma. The output will have one row for each unique combination of the index's values. If None, all remaining columns not specified on --on and --values will be used. At least one of --index and --values must be specified. |  |
-| `-v, --values` | string | The column(s) containing values to aggregate. If an aggregation is specified, these are the values on which the aggregation will be computed. If None, all remaining columns not specified on --on and --index will be used. At least one of --index and --values must be specified. |  |
-| `-a, --agg` | string | The aggregation function to use: first - First value encountered last - Last value encountered sum - Sum of values min - Minimum value max - Maximum value mean - Average value median - Median value len - Count of values item - Get single value from group. Raises error if there are multiple values. smart - use value column data type & statistics to pick an aggregation. Will only work if there is one value column, otherwise it falls back to `first` | `smart` |
+| `-i,`<br>`--index` | string | The column(s) to use as the index (row labels). Specify multiple columns by separating them with a comma. The output will have one row for each unique combination of the index's values. If None, all remaining columns not specified on --on and --values will be used. At least one of --index and --values must be specified. |  |
+| `-v,`<br>`--values` | string | The column(s) containing values to aggregate. If an aggregation is specified, these are the values on which the aggregation will be computed. If None, all remaining columns not specified on --on and --index will be used. At least one of --index and --values must be specified. |  |
+| `-a,`<br>`--agg` | string | The aggregation function to use: first - First value encountered last - Last value encountered sum - Sum of values min - Minimum value max - Maximum value mean - Average value median - Median value len - Count of values item - Get single value from group. Raises error if there are multiple values. smart - use value column data type & statistics to pick an aggregation. Will only work if there is one value column, otherwise it falls back to `first` | `smart` |
 | `--sort-columns` | flag | Sort the transposed columns by name. |  |
 | `--maintain-order` | flag | Maintain the order of the input columns. |  |
 | `--col-separator` | string | The separator in generated column names in case of multiple --values columns. | `_` |
@@ -64,10 +64,10 @@ qsv pivotp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
-| `-q, --quiet` | flag | Do not return smart aggregation chosen nor pivot result shape to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| `-q,`<br>`--quiet` | flag | Do not return smart aggregation chosen nor pivot result shape to stderr. |  |
 
 ---
 **Source:** [`src/cmd/pivotp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pivotp.rs)

--- a/docs/help/pragmastat.md
+++ b/docs/help/pragmastat.md
@@ -104,9 +104,9 @@ qsv pragmastat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-t, --twosample` | flag | Compute two-sample estimators for all column pairs. |  |
-| `-s, --select` | string | Select columns for analysis. Uses qsv's column selection syntax. Non-numeric columns appear with n=0. In two-sample mode, all pairs of selected columns are computed. |  |
-| `-m, --misrate` | string | Probability that bounds fail to contain the true parameter. Lower values produce wider bounds. Must be achievable for the given sample size. | `0.001` |
+| `-t,`<br>`--twosample` | flag | Compute two-sample estimators for all column pairs. |  |
+| `-s,`<br>`--select` | string | Select columns for analysis. Uses qsv's column selection syntax. Non-numeric columns appear with n=0. In two-sample mode, all pairs of selected columns are computed. |  |
+| `-m,`<br>`--misrate` | string | Probability that bounds fail to contain the true parameter. Lower values produce wider bounds. Must be achievable for the given sample size. | `0.001` |
 
 <a name="common-options"></a>
 
@@ -114,10 +114,10 @@ qsv pragmastat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
-| `-n, --no-headers` | flag | When set, the first row will not be treated as headers. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be treated as headers. |  |
 
 ---
 **Source:** [`src/cmd/pragmastat.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pragmastat.rs)

--- a/docs/help/pro.md
+++ b/docs/help/pro.md
@@ -45,7 +45,7 @@ qsv pro --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/pro.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pro.rs)

--- a/docs/help/prompt.md
+++ b/docs/help/prompt.md
@@ -52,10 +52,10 @@ qsv prompt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-m, --msg` | string | The prompt message to display in the file dialog title. When not using --fd-output, the default is "Select a File". When using --fd-output, the default is "Save File As". |  |
-| `-F, --filters` | string | The filter to use for the INPUT file dialog. Set to "None" to disable filters. Filters are comma-delimited file extensions. Defaults to csv,tsv,tab,ssv,xls,xlsx,xlsm,xlsb,ods. If the polars feature is enabled, it adds avro,arrow,ipc,parquet, json,jsonl,ndjson & gz,zst,zlib compressed files to the filter. |  |
-| `-d, --workdir` | string | The directory to start the file dialog in. | `.` |
-| `-f, --fd-output` | flag | Write output to a file by using a save file dialog. Used when piping into qsv prompt. Mutually exclusive with --output. |  |
+| `-m,`<br>`--msg` | string | The prompt message to display in the file dialog title. When not using --fd-output, the default is "Select a File". When using --fd-output, the default is "Save File As". |  |
+| `-F,`<br>`--filters` | string | The filter to use for the INPUT file dialog. Set to "None" to disable filters. Filters are comma-delimited file extensions. Defaults to csv,tsv,tab,ssv,xls,xlsx,xlsm,xlsb,ods. If the polars feature is enabled, it adds avro,arrow,ipc,parquet, json,jsonl,ndjson & gz,zst,zlib compressed files to the filter. |  |
+| `-d,`<br>`--workdir` | string | The directory to start the file dialog in. | `.` |
+| `-f,`<br>`--fd-output` | flag | Write output to a file by using a save file dialog. Used when piping into qsv prompt. Mutually exclusive with --output. |  |
 | `--save-fname` | string | The filename to save the output as when using --fd-output. | `output.csv` |
 | `--base-delay-ms` | string | The base delay in milliseconds to use when opening INPUT dialog. This is to ensure that the INPUT dialog is shown before/over the OUTPUT dialog when using the prompt command is used in both INPUT and OUTPUT modes in a single pipeline. | `200` |
 
@@ -65,9 +65,9 @@ qsv prompt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> without showing a save dialog. Mutually exclusive with --fd-output. |  |
-| `-q, --quiet` | flag | Do not print --fd-output message to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> without showing a save dialog. Mutually exclusive with --fd-output. |  |
+| `-q,`<br>`--quiet` | flag | Do not print --fd-output message to stderr. |  |
 
 ---
 **Source:** [`src/cmd/prompt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/prompt.rs)

--- a/docs/help/pseudo.md
+++ b/docs/help/pseudo.md
@@ -78,13 +78,13 @@ qsv pseudo --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
 | `--start` | string | The starting number for the incremental identifier. | `0` |
 | `--increment` | string | The increment for the incremental identifier. | `1` |
 | `--formatstr` | string | The format string for the incremental identifier. The format string must contain a single "{}" which will be replaced with the incremental identifier. | `{}` |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/pseudo.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pseudo.rs)

--- a/docs/help/py.md
+++ b/docs/help/py.md
@@ -150,8 +150,8 @@ qsv py --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-f, --helper` | string | File containing Python code that's loaded into the qsv_uh Python module. Functions with a return statement in the file can be called with the prefix "qsv_uh". The returned value is used in the map or filter operation. |  |
-| `-b, --batch` | string | The number of rows per batch to process before releasing memory and acquiring a new GILpool. Set to 0 to process the entire file in one batch. | `50000` |
+| `-f,`<br>`--helper` | string | File containing Python code that's loaded into the qsv_uh Python module. Functions with a return statement in the file can be called with the prefix "qsv_uh". The returned value is used in the map or filter operation. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to process before releasing memory and acquiring a new GILpool. Set to 0 to process the entire file in one batch. | `50000` |
 
 <a name="common-options"></a>
 
@@ -159,11 +159,11 @@ qsv py --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/python.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/python.rs)

--- a/docs/help/rename.md
+++ b/docs/help/rename.md
@@ -78,10 +78,10 @@ qsv rename --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the header will be inserted on top. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the header will be inserted on top. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/rename.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/rename.rs)

--- a/docs/help/replace.md
+++ b/docs/help/replace.md
@@ -89,15 +89,15 @@ qsv replace --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
+| `-i,`<br>`--ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
 | `--literal` | flag | Treat the regex pattern as a literal string. This allows you to search for matches that contain regex special characters. |  |
 | `--exact` | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
-| `-s, --select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
-| `-u, --unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
+| `-s,`<br>`--select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
+| `-u,`<br>`--unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
 | `--size-limit` | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. | `50` |
 | `--dfa-size-limit` | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. | `10` |
 | `--not-one` | flag | Use exit code 0 instead of 1 for no replacement found. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -105,12 +105,12 @@ qsv replace --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
-| `-q, --quiet` | flag | Do not print number of replacements to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-q,`<br>`--quiet` | flag | Do not print number of replacements to stderr. |  |
 
 ---
 **Source:** [`src/cmd/replace.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/replace.rs)

--- a/docs/help/reverse.md
+++ b/docs/help/reverse.md
@@ -35,10 +35,10 @@ qsv reverse --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be reversed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be reversed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---

--- a/docs/help/safenames.md
+++ b/docs/help/safenames.md
@@ -108,9 +108,9 @@ qsv safenames --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. Note that no output is generated for Verify and Verbose modes. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. Note that no output is generated for Verify and Verbose modes. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/safenames.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/safenames.rs)

--- a/docs/help/sample.md
+++ b/docs/help/sample.md
@@ -244,10 +244,10 @@ qsv sample --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will be considered as part of the population to sample from. (When not set, the first row is the header row and will always appear in the output.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will be considered as part of the population to sample from. (When not set, the first row is the header row and will always appear in the output.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/sample.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sample.rs)

--- a/docs/help/schema.md
+++ b/docs/help/schema.md
@@ -13,7 +13,7 @@
 
 Generate JSON Schema or Polars Schema (with the `--polars` option) from CSV data.
 
-### Json Schema Validation:
+### JSON Schema Validation:
 
 This command derives a JSON Schema Validation (Draft 2020-12) file from CSV data,
 including validation rules based on data type and input data domain/range.
@@ -81,7 +81,7 @@ qsv schema --help
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--enum-threshold` | string | Cardinality threshold for adding enum constraints. Enum constraints are compiled for String & Integer types. | `50` |
-| `-i, --ignore-case` | flag | Ignore case when compiling unique values for enum constraints. Do note however that the `validate` command is case-sensitive when validating against enum constraints. |  |
+| `-i,`<br>`--ignore-case` | flag | Ignore case when compiling unique values for enum constraints. Do note however that the `validate` command is case-sensitive when validating against enum constraints. |  |
 | `--strict-dates` | flag | Enforce Internet Datetime format (RFC-3339) for detected date/datetime columns. Otherwise, even if columns are inferred as date/datetime, they are set to type "string" in the schema instead of "date" or "date-time". |  |
 | `--strict-formats` | flag | Enforce JSON Schema format constraints for detected email, hostname, and IP address columns. When enabled, String fields are checked against email, hostname, IPv4, and IPv6 formats. Format constraints are only added if ALL unique values in the field match the detected format. |  |
 | `--pattern-columns` | string | Select columns to derive regex pattern constraints. That is, this will create a regular expression that matches all values for each specified column. Columns are selected using `select` syntax (see `qsv select --help` for details). |  |
@@ -89,8 +89,8 @@ qsv schema --help
 | `--prefer-dmy` | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. |  |
 | `--force` | flag | Force recomputing cardinality and unique values even if stats cache file exists and is current. |  |
 | `--stdout` | flag | Send generated JSON schema file to stdout instead. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-o, --output` | string | Write output to <file> instead of using the default filename. For JSON Schema, the default is <input>.schema.json. For Polars schema, the default is <input>.pschema.json. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of using the default filename. For JSON Schema, the default is <input>.schema.json. For Polars schema, the default is <input>.pschema.json. |  |
 | `--polars` | flag | Infer a Polars schema instead of a JSON Schema. This option is only available if the `polars` feature is enabled. The generated Polars schema will be written to a file with the `.pschema.json` suffix appended to the input filename. |  |
 
 <a name="common-options"></a>
@@ -99,9 +99,9 @@ qsv schema --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be processed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be processed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---

--- a/docs/help/search.md
+++ b/docs/help/search.md
@@ -107,21 +107,21 @@ qsv search --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
+| `-i,`<br>`--ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
 | `--literal` | flag | Treat the regex as a literal string. This allows you to search for matches that contain regex special characters. |  |
 | `--exact` | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
-| `-s, --select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
-| `-v, --invert-match` | flag | Select only rows that did not match |  |
-| `-u, --unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
-| `-f, --flag` | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>, with the row numbers of the matched rows and 0 for the non-matched rows. If column is named M, only the M column will be written to the output, and only matched rows are returned. |  |
-| `-Q, --quick` | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. |  |
+| `-s,`<br>`--select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
+| `-v,`<br>`--invert-match` | flag | Select only rows that did not match |  |
+| `-u,`<br>`--unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
+| `-f,`<br>`--flag` | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>, with the row numbers of the matched rows and 0 for the non-matched rows. If column is named M, only the M column will be written to the output, and only matched rows are returned. |  |
+| `-Q,`<br>`--quick` | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. |  |
 | `--preview-match` | string | Preview the first N matches or all the matches found in N milliseconds, whichever occurs first. Returns the preview to stderr. Output is still written to stdout or --output as usual. Only applicable when CSV is NOT indexed, as it's read sequentially. Forces a sequential search, even if the CSV is indexed. |  |
-| `-c, --count` | flag | Return number of matches to stderr. |  |
+| `-c,`<br>`--count` | flag | Return number of matches to stderr. |  |
 | `--size-limit` | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
 | `--dfa-size-limit` | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
 | `--json` | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). Automatically sets --quiet. |  |
 | `--not-one` | flag | Use exit code 0 instead of 1 for no match found. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -129,12 +129,12 @@ qsv search --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. Only applicable when CSV is NOT indexed. |  |
-| `-q, --quiet` | flag | Do not return number of matches to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. Only applicable when CSV is NOT indexed. |  |
+| `-q,`<br>`--quiet` | flag | Do not return number of matches to stderr. |  |
 
 ---
 **Source:** [`src/cmd/search.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/search.rs)

--- a/docs/help/searchset.md
+++ b/docs/help/searchset.md
@@ -60,18 +60,18 @@ qsv searchset --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i, --ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
+| `-i,`<br>`--ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
 | `--literal` | flag | Treat the regex as a literal string. This allows you to search for matches that contain regex special characters. |  |
 | `--exact` | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
-| `-s, --select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
-| `-v, --invert-match` | flag | Select only rows that did not match |  |
-| `-u, --unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
-| `-f, --flag` | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>. For each found row, <column> is set to the row number of the row, followed by a semicolon, then a list of the matching regexes. |  |
+| `-s,`<br>`--select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
+| `-v,`<br>`--invert-match` | flag | Select only rows that did not match |  |
+| `-u,`<br>`--unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
+| `-f,`<br>`--flag` | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>. For each found row, <column> is set to the row number of the row, followed by a semicolon, then a list of the matching regexes. |  |
 | `--flag-matches-only` | flag | When --flag is enabled, only rows that match are sent to output. Rows that do not match are filtered. |  |
 | `--unmatched-output` | string | When --flag-matches-only is enabled, output the rows that did not match to <file>. |  |
-| `-Q, --quick` | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. Ignored if --json is enabled. |  |
-| `-c, --count` | flag | Return number of matches to stderr. Ignored if --json is enabled. |  |
-| `-j, --json` | flag | Return number of matches, number of rows with matches, and number of rows to stderr in JSON format. |  |
+| `-Q,`<br>`--quick` | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. Ignored if --json is enabled. |  |
+| `-c,`<br>`--count` | flag | Return number of matches to stderr. Ignored if --json is enabled. |  |
+| `-j,`<br>`--json` | flag | Return number of matches, number of rows with matches, and number of rows to stderr in JSON format. |  |
 | `--size-limit` | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
 | `--dfa-size-limit` | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
 | `--not-one` | flag | Use exit code 0 instead of 1 for no match found. |  |
@@ -83,12 +83,12 @@ qsv searchset --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
-| `-q, --quiet` | flag | Do not return number of matches to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-q,`<br>`--quiet` | flag | Do not return number of matches to stderr. |  |
 
 ---
 **Source:** [`src/cmd/searchset.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/searchset.rs)

--- a/docs/help/select.md
+++ b/docs/help/select.md
@@ -158,9 +158,9 @@ qsv select --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-R, --random` | flag | Randomly shuffle the columns in the selection. |  |
+| `-R,`<br>`--random` | flag | Randomly shuffle the columns in the selection. |  |
 | `--seed` | string | Seed for the random number generator. |  |
-| `-S, --sort` | flag | Sort the selected columns lexicographically, i.e. by their byte values. |  |
+| `-S,`<br>`--sort` | flag | Sort the selected columns lexicographically, i.e. by their byte values. |  |
 
 <a name="common-options"></a>
 
@@ -168,10 +168,10 @@ qsv select --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/select.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/select.rs)

--- a/docs/help/slice.md
+++ b/docs/help/slice.md
@@ -114,10 +114,10 @@ qsv slice --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --start` | string | The index of the record to slice from. If negative, starts from the last record. |  |
-| `-e, --end` | string | The index of the record to slice to. |  |
-| `-l, --len` | string | The length of the slice (can be used instead of --end). |  |
-| `-i, --index` | string | Slice a single record (shortcut for -s N -l 1). If negative, starts from the last record. |  |
+| `-s,`<br>`--start` | string | The index of the record to slice from. If negative, starts from the last record. |  |
+| `-e,`<br>`--end` | string | The index of the record to slice to. |  |
+| `-l,`<br>`--len` | string | The length of the slice (can be used instead of --end). |  |
+| `-i,`<br>`--index` | string | Slice a single record (shortcut for -s N -l 1). If negative, starts from the last record. |  |
 | `--json` | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). |  |
 | `--invert` | flag | slice all records EXCEPT those in the specified range. |  |
 
@@ -127,10 +127,10 @@ qsv slice --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Otherwise, the first row will always appear in the output as the header row. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Otherwise, the first row will always appear in the output as the header row. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/slice.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/slice.rs)

--- a/docs/help/snappy.md
+++ b/docs/help/snappy.md
@@ -71,11 +71,11 @@ qsv snappy --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <output> instead of stdout. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel when compressing. When not set, its set to the number of CPUs - 1 |  |
-| `-q, --quiet` | flag | Suppress status messages to stderr. |  |
-| `-p, --progressbar` | flag | Show download progress bars. Only valid for URL input. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <output> instead of stdout. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when compressing. When not set, its set to the number of CPUs - 1 |  |
+| `-q,`<br>`--quiet` | flag | Suppress status messages to stderr. |  |
+| `-p,`<br>`--progressbar` | flag | Show download progress bars. Only valid for URL input. |  |
 
 ---
 **Source:** [`src/cmd/snappy.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/snappy.rs)

--- a/docs/help/sniff.md
+++ b/docs/help/sniff.md
@@ -98,7 +98,7 @@ qsv sniff --help
 |--------|------|-------------|--------|
 | `--sample` | string | First n rows to sample to sniff out the metadata. When sample size is between 0 and 1 exclusive, it is treated as a percentage of the CSV to sample (e.g. 0.20 is 20 percent). When it is zero, the entire file will be sampled. When the input is a URL, the sample size dictates how many lines to sample without having to download the entire file. Ignored when --no-infer is enabled. | `1000` |
 | `--prefer-dmy` | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. Ignored when --no-infer is enabled. |  |
-| `-d, --delimiter` | string | The delimiter for reading CSV data. Specify this when the delimiter is known beforehand, as the delimiter inferencing algorithm can sometimes fail. Must be a single ascii character. |  |
+| `-d,`<br>`--delimiter` | string | The delimiter for reading CSV data. Specify this when the delimiter is known beforehand, as the delimiter inferencing algorithm can sometimes fail. Must be a single ascii character. |  |
 | `--quote` | string | The quote character for reading CSV data. Specify this when the quote character is known beforehand, as the quote char inferencing algorithm can sometimes fail. Must be a single ascii character - typically, double quote ("), single quote ('), or backtick (`). |  |
 | `--json` | flag | Return results in JSON format. |  |
 | `--pretty-json` | flag | Return results in pretty JSON format. |  |
@@ -108,7 +108,7 @@ qsv sniff --help
 | `--stats-types` | flag | Use the same data type names as `stats`. (Unsigned, Signed => Integer, Text => String, everything else the same) |  |
 | `--no-infer` | flag | Do not infer the schema. Only return the file's mime type, size and last modified date. Use this to use sniff as a general mime type detector. Note that CSV and TSV files will only be detected as mime type plain/text in this mode. |  |
 | `--just-mime` | flag | Only return the file's mime type. Use this to use sniff as a general mime type detector. Synonym for --no-infer. |  |
-| `-Q, --quick` | flag | When sniffing a non-CSV remote file, only download the first chunk of the file before attempting to detect the mime type. This is faster but less accurate as some mime types cannot be detected with just the first downloaded chunk. |  |
+| `-Q,`<br>`--quick` | flag | When sniffing a non-CSV remote file, only download the first chunk of the file before attempting to detect the mime type. This is faster but less accurate as some mime types cannot be detected with just the first downloaded chunk. |  |
 | `--harvest-mode` | flag | This is a convenience flag when using sniff in CKAN harvesters. It is equivalent to --quick --timeout 10 --stats-types --json and --user-agent "CKAN-harvest/$QSV_VERSION ($QSV_TARGET; $QSV_BIN_NAME)" |  |
 
 <a name="common-options"></a>
@@ -117,8 +117,8 @@ qsv sniff --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-p, --progressbar` | flag | Show progress bars. Only valid for URL input. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Only valid for URL input. |  |
 
 ---
 **Source:** [`src/cmd/sniff.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sniff.rs)

--- a/docs/help/sort.md
+++ b/docs/help/sort.md
@@ -35,12 +35,12 @@ qsv sort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --select` | string | Select a subset of columns to sort. See 'qsv select --help' for the format details. |  |
-| `-N, --numeric` | flag | Compare according to string numerical value |  |
+| `-s,`<br>`--select` | string | Select a subset of columns to sort. See 'qsv select --help' for the format details. |  |
+| `-N,`<br>`--numeric` | flag | Compare according to string numerical value |  |
 | `--natural` | flag | Compare strings using natural sort order (treats numbers within strings as actual numbers, e.g. "data1.txt", "data2.txt", "data10.txt", as opposed to "data1.txt", "data10.txt", "data2.txt" when sorting lexicographically) <https://en.wikipedia.org/wiki/Natural_sort_order> |  |
-| `-R, --reverse` | flag | Reverse order |  |
-| `-i, --ignore-case` | flag | Compare strings disregarding case |  |
-| `-u, --unique` | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. |  |
+| `-R,`<br>`--reverse` | flag | Reverse order |  |
+| `-i,`<br>`--ignore-case` | flag | Compare strings disregarding case |  |
+| `-u,`<br>`--unique` | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. |  |
 
 <a name="random-sorting-options"></a>
 
@@ -51,7 +51,7 @@ qsv sort --help
 | `--random` | flag | Randomize (scramble) the data by row |  |
 | `--seed` | string | Random Number Generator (RNG) seed to use if --random is set |  |
 | `--rng` | string | The RNG algorithm to use if --random is set. | `standard` |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 | `--faster` | flag | When set, the sort will be faster. This is done by using a faster sorting algorithm that is not "stable" (i.e. the order of identical values is not guaranteed to be preserved). It has the added side benefit that the sort will also be in-place (i.e. does not allocate), which is useful for sorting large files that will otherwise NOT fit in memory using the default allocating stable sort. |  |
 
 <a name="common-options"></a>
@@ -60,10 +60,10 @@ qsv sort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. Ignored if --random or --faster is set. |  |
 
 ---

--- a/docs/help/sortcheck.md
+++ b/docs/help/sortcheck.md
@@ -50,8 +50,8 @@ qsv sortcheck --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --select` | string | Select a subset of columns to check for sort. See 'qsv select --help' for the format details. |  |
-| `-i, --ignore-case` | flag | Compare strings disregarding case |  |
+| `-s,`<br>`--select` | string | Select a subset of columns to check for sort. See 'qsv select --help' for the format details. |  |
+| `-i,`<br>`--ignore-case` | flag | Compare strings disregarding case |  |
 | `--all` | flag | Check all records. Do not stop/short-circuit the check on the first unsorted record. |  |
 | `--json` | flag | Return results in JSON format, scanning --all records. The JSON result has the following properties - sorted (boolean), record_count (number), unsorted_breaks (number) & dupe_count (number). Unsorted breaks count the number of times two consecutive rows are unsorted (i.e. n row > n+1 row). Dupe count is the number of times two consecutive rows are equal. Note that dupe count does not apply if the file is not sorted and is set to -1. |  |
 | `--pretty-json` | flag | Same as --json but in pretty JSON format. |  |
@@ -62,10 +62,10 @@ qsv sortcheck --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/sortcheck.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sortcheck.rs)

--- a/docs/help/split.md
+++ b/docs/help/split.md
@@ -137,10 +137,10 @@ qsv split --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --size` | string | The number of records to write into each chunk. | `500` |
-| `-c, --chunks` | string | The number of chunks to split the data into. This option is mutually exclusive with --size. The number of rows in each chunk is determined by the number of records in the CSV data and the number of desired chunks. If the number of records is not evenly divisible by the number of chunks, the last chunk will have fewer records. |  |
-| `-k, --kb-size` | string | The size of each chunk in kilobytes. The number of rows in each chunk may vary, but the size of each chunk will not exceed the desired size. This option is mutually exclusive with --size and --chunks. |  |
-| `-j, --jobs` | string | The number of splitting jobs to run in parallel. This only works when the given CSV data has an index already created. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-s,`<br>`--size` | string | The number of records to write into each chunk. | `500` |
+| `-c,`<br>`--chunks` | string | The number of chunks to split the data into. This option is mutually exclusive with --size. The number of rows in each chunk is determined by the number of records in the CSV data and the number of desired chunks. If the number of records is not evenly divisible by the number of chunks, the last chunk will have fewer records. |  |
+| `-k,`<br>`--kb-size` | string | The size of each chunk in kilobytes. The number of rows in each chunk may vary, but the size of each chunk will not exceed the desired size. This option is mutually exclusive with --size and --chunks. |  |
+| `-j,`<br>`--jobs` | string | The number of splitting jobs to run in parallel. This only works when the given CSV data has an index already created. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
 | `--filename` | string | A filename template to use when constructing the names of the output files.  The string '{}' will be replaced by the zero-based row number of the first row in the chunk. | `{}.csv` |
 | `--pad` | string | The zero padding width that is used in the generated filename. | `0` |
 
@@ -160,10 +160,10 @@ qsv split --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-q, --quiet` | flag | Do not display an output summary to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-q,`<br>`--quiet` | flag | Do not display an output summary to stderr. |  |
 
 ---
 **Source:** [`src/cmd/split.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/split.rs)

--- a/docs/help/sqlp.md
+++ b/docs/help/sqlp.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/sqlp.rs](https://github.com/dathere/qsv/blob/master/src/cmd/sqlp.rs)** | 📇🚀🐻‍❄️🗄️🪄
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [Sqlp Options](#sqlp-options) | [Polars Csv Input Parsing Options](#polars-csv-input-parsing-options) | [Csv Output Format Only Options](#csv-output-format-only-options) | [Parquet Output Format Only Options](#parquet-output-format-only-options) | [Common Options](#common-options)
+[Description](#description) | [Usage](#usage) | [Sqlp Options](#sqlp-options) | [Polars CSV Input Parsing Options](#polars-csv-input-parsing-options) | [CSV Output Format Only Options](#csv-output-format-only-options) | [Arrow/Avro/Parquet Output Formats Only Options](#arrow/avro/parquet-output-formats-only-options) | [Parquet Output Format Only Options](#parquet-output-format-only-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -304,7 +304,7 @@ qsv sqlp --help
 
 <a name="polars-csv-input-parsing-options"></a>
 
-## Polars Csv Input Parsing Options [↩](#nav)
+## Polars CSV Input Parsing Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
@@ -321,7 +321,7 @@ qsv sqlp --help
 
 <a name="csv-output-format-only-options"></a>
 
-## Csv Output Format Only Options [↩](#nav)
+## CSV Output Format Only Options [↩](#nav)
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
@@ -330,6 +330,13 @@ qsv sqlp --help
 | `--time-format` | string | The time format to use writing times. |  |
 | `--float-precision` | string | The number of digits of precision to use when writing floats. |  |
 | `--wnull-value` | string | The string to use when WRITING null values. | `<empty string>` |
+
+<a name="arrow/avro/parquet-output-formats-only-options"></a>
+
+## Arrow/Avro/Parquet Output Formats Only Options [↩](#nav)
+
+| Option | Type | Description | Default |
+|--------|------|-------------|--------|
 | `--compression` | string | The compression codec to use when writing arrow or parquet files. For Arrow, valid values are: zstd, lz4, uncompressed For Avro, valid values are: deflate, snappy, uncompressed (default) For Parquet, valid values are: zstd, lz4raw, gzip, snappy, uncompressed | `zstd` |
 
 <a name="parquet-output-format-only-options"></a>
@@ -347,10 +354,10 @@ qsv sqlp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading and writing CSV data. Must be a single character. | `,` |
-| `-q, --quiet` | flag | Do not return result shape to stderr. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading and writing CSV data. Must be a single character. | `,` |
+| `-q,`<br>`--quiet` | flag | Do not return result shape to stderr. |  |
 
 ---
 **Source:** [`src/cmd/sqlp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sqlp.rs)

--- a/docs/help/stats.md
+++ b/docs/help/stats.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/stats.rs](https://github.com/dathere/qsv/blob/master/src/cmd/stats.rs)** | 📇🤯🏎️👆🪄
 
 <a name="nav"></a>
-[Description](#description) | [Examples](#examples) | [Usage](#usage) | [Stats Options](#stats-options) | [Boolean Inferencing Options](#boolean-inferencing-options) | [Date Inferencing Options](#date-inferencing-options) | [Common Options](#common-options)
+[Description](#description) | [Examples](#examples) | [Usage](#usage) | [Stats Options](#stats-options) | [Boolean Inferencing Options](#boolean-inferencing-options) | [Numeric & Date/Datetime Stats That Require In-memory Sorting Options](#numeric-&-date/datetime-stats-that-require-in-memory-sorting-options) | [Date Inferencing Options](#date-inferencing-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -228,8 +228,8 @@ qsv stats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s, --select` | string | Select a subset of columns to compute stats for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv stats' will prevent the use of indexing. |  |
-| `-E, --everything` | flag | Compute all statistics available. |  |
+| `-s,`<br>`--select` | string | Select a subset of columns to compute stats for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv stats' will prevent the use of indexing. |  |
+| `-E,`<br>`--everything` | flag | Compute all statistics available. |  |
 | `--typesonly` | flag | Infer data types only and do not compute statistics. Note that if you want to infer dates and boolean types, you'll still need to use the --infer-dates & --infer-boolean options. |  |
 
 <a name="boolean-inferencing-options"></a>
@@ -242,6 +242,13 @@ qsv stats --help
 | `--boolean-patterns` | string | Comma-separated list of boolean pattern pairs in the format "true_pattern:false_pattern". Each pattern can be a string of any length. The patterns are case-insensitive. If a pattern ends with a "*", it is treated as a prefix. For example, "t*:f*,y*:n*" will match "true", "truthy", "Truth" as boolean true values so long as the corresponding false pattern (e.g. False, f, etc.) is also matched & cardinality is 2. Ignored if --infer-boolean is false. | `1:0,t*:f*,y*:n*` |
 | `--mode` | flag | Compute the mode/s & antimode/s. Multimodal-aware. If there are multiple modes/antimodes, they are separated by the QSV_STATS_SEPARATOR environment variable. If not set, the default separator is "\|". Uses memory proportional to the cardinality of each column. |  |
 | `--cardinality` | flag | Compute the cardinality and the uniqueness ratio. This is automatically enabled if --infer-boolean is enabled. <https://en.wikipedia.org/wiki/Cardinality_(SQL_statements)> Uses memory proportional to the number of unique values in each column. |  |
+
+<a name="numeric-&-date/datetime-stats-that-require-in-memory-sorting-options"></a>
+
+## Numeric & Date/Datetime Stats That Require In-memory Sorting Options [↩](#nav)
+
+| Option | Type | Description | Default |
+|--------|------|-------------|--------|
 | `--median` | flag | Compute the median. Loads & sorts all the selected columns' data in memory. <https://en.wikipedia.org/wiki/Median> |  |
 | `--mad` | flag | Compute the median absolute deviation (MAD). <https://en.wikipedia.org/wiki/Median_absolute_deviation> |  |
 | `--quartiles` | flag | Compute the quartiles (using method 3), the IQR, the lower/upper, inner/outer fences and skewness. <https://en.wikipedia.org/wiki/Quartile#Method_3> |  |
@@ -261,9 +268,9 @@ qsv stats --help
 | `--dates-whitelist` | string | The comma-separated, case-insensitive patterns to look for when shortlisting fields for date inferencing. i.e. if the field's name has any of these patterns, it is shortlisted for date inferencing. | `sniff` |
 | `--prefer-dmy` | flag | Parse dates in dmy format. Otherwise, use mdy format. Ignored if --infer-dates is false. |  |
 | `--force` | flag | Force recomputing stats even if valid precomputed stats cache exists. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
 | `--stats-jsonl` | flag | Also write the stats in JSONL format. If set, the stats will be written to <FILESTEM>.stats.csv.data.jsonl. Note that this option used internally by other qsv "smart" commands (see <https://github.com/dathere/qsv/blob/master/docs/PERFORMANCE.md#stats-cache>) to load cached stats to make them work smarter & faster. You can preemptively create the stats-jsonl file by using this option BEFORE running "smart" commands and they will automatically use it. |  |
-| `-c, --cache-threshold` | string | Controls the creation of stats cache files. * when greater than 1, the threshold in milliseconds before caching stats results. If a stats run takes longer than this threshold, the stats results will be cached. * 0 to suppress caching. * 1 to force caching. * a negative number to automatically create an index when the input file size is greater than abs(arg) in bytes. If the negative number ends with 5, it will delete the index file and the stats cache file after the stats run. Otherwise, the index file and the cache files are kept. | `5000` |
+| `-c,`<br>`--cache-threshold` | string | Controls the creation of stats cache files. * when greater than 1, the threshold in milliseconds before caching stats results. If a stats run takes longer than this threshold, the stats results will be cached. * 0 to suppress caching. * 1 to force caching. * a negative number to automatically create an index when the input file size is greater than abs(arg) in bytes. If the negative number ends with 5, it will delete the index file and the stats cache file after the stats run. Otherwise, the index file and the cache files are kept. | `5000` |
 | `--vis-whitespace` | flag | Visualize whitespace characters in the output. See <https://github.com/dathere/qsv/wiki/Supplemental#whitespace-markers> for the list of whitespace markers. |  |
 
 <a name="common-options"></a>
@@ -272,10 +279,10 @@ qsv stats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-n, --no-headers` | flag | When set, the first row will NOT be interpreted as column names. i.e., They will be included in statistics. |  |
-| `-d, --delimiter` | string | The field delimiter for READING CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. i.e., They will be included in statistics. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for READING CSV data. Must be a single character. (default: ,) |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. This option is ignored when computing default, streaming statistics, as it is not needed. |  |
 
 ---

--- a/docs/help/table.md
+++ b/docs/help/table.md
@@ -43,10 +43,10 @@ qsv table --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-w, --width` | string | The minimum width of each column. | `2` |
-| `-p, --pad` | string | The minimum number of spaces between each column. | `2` |
-| `-a, --align` | string | How entries should be aligned in a column. Options: "left", "right", "center". "leftendtab" & "leftfwf" "leftendtab" is a special alignment that similar to "left" but with whitespace padding ending with a tab character. The resulting output still validates as a valid TSV file, while also being more human-readable (aka "aligned" TSV). "leftfwf" is similar to "left" with Fixed Width Format allgnment. The first line is a comment (prefixed with "#") that enumerates the position (1-based, comma-separated) of each column. | `left` |
-| `-c, --condense` | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
+| `-w,`<br>`--width` | string | The minimum width of each column. | `2` |
+| `-p,`<br>`--pad` | string | The minimum number of spaces between each column. | `2` |
+| `-a,`<br>`--align` | string | How entries should be aligned in a column. Options: "left", "right", "center". "leftendtab" & "leftfwf" "leftendtab" is a special alignment that similar to "left" but with whitespace padding ending with a tab character. The resulting output still validates as a valid TSV file, while also being more human-readable (aka "aligned" TSV). "leftfwf" is similar to "left" with Fixed Width Format allgnment. The first line is a comment (prefixed with "#") that enumerates the position (1-based, comma-separated) of each column. | `left` |
+| `-c,`<br>`--condense` | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
 
 <a name="common-options"></a>
 
@@ -54,9 +54,9 @@ qsv table --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---

--- a/docs/help/template.md
+++ b/docs/help/template.md
@@ -95,13 +95,13 @@ qsv template --help
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
 | `--template` | string | MiniJinja template string to use (alternative to --template-file) |  |
-| `-t, --template-file` | string | MiniJinja template file to use |  |
-| `-j, --globals-json` | string | A JSON file containing global variables to make available in templates. The JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.school_name}}, {{qsv_g.year}}). This allows sharing common values across all template renders. |  |
+| `-t,`<br>`--template-file` | string | MiniJinja template file to use |  |
+| `-j,`<br>`--globals-json` | string | A JSON file containing global variables to make available in templates. The JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.school_name}}, {{qsv_g.year}}). This allows sharing common values across all template renders. |  |
 | `--outfilename` | string | MiniJinja template string to use to create the filename of the output files to write to <outdir>. If set to just QSV_ROWNO, the filestem is set to the current rowno of the record, padded with leading zeroes, with the ".txt" extension (e.g. 001.txt, 002.txt, etc.) Note that all the fields, including QSV_ROWNO, are available when defining the filename template. | `QSV_ROWNO` |
 | `--outsubdir-size` | string | The number of files per subdirectory in <outdir>. | `1000` |
 | `--customfilter-error` | string | The value to return when a custom filter returns an error. Use "<empty string>" to return an empty string. | `<FILTER_ERROR>` |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 | `--timeout` | string | Timeout for downloading lookups on URLs. | `30` |
 | `--cache-dir` | string | The directory to use for caching downloaded lookup resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
 | `--ckan-api` | string | The URL of the CKAN API to use for downloading lookup resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
@@ -113,11 +113,11 @@ qsv template --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. Templates must use numeric 1-based indices with the "_c" prefix.(e.g. col1: {{_c1}} col2: {{_c2}}) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Templates must use numeric 1-based indices with the "_c" prefix.(e.g. col1: {{_c1}} col2: {{_c2}}) |  |
 | `--delimiter` | string | Field separator for reading CSV | `,` |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/template.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/template.rs)

--- a/docs/help/to.md
+++ b/docs/help/to.md
@@ -114,7 +114,7 @@ Print dump to stdout.
 qsv to sqlite --dump - file1.csv file2.csv
 ```
 
-### Excel Xlsx
+### Excel XLSX
 
 Convert to new xlsx file.
 Example:
@@ -135,7 +135,7 @@ Load files listed in the 'ourdata.infile-list' into xlsx file.
 qsv to xlsx output.xlsx ourdata.infile-list
 ```
 
-### Ods
+### ODS
 
 Convert to new ODS (Open Document Spreadsheet) file.
 Example:
@@ -206,18 +206,18 @@ qsv to --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-k, --print-package` | flag | Print statistics as datapackage, by default will print field summary. |  |
-| `-u, --dump` | flag | Create database dump file for use with `psql` or `sqlite3` command line tools (postgres/sqlite only). |  |
-| `-a, --stats` | flag | Produce extra statistics about the data beyond just type guessing. |  |
-| `-c, --stats-csv` | string | Output stats as CSV to specified file. |  |
-| `-q, --quiet` | flag | Do not print out field summary. |  |
-| `-s, --schema` | string | The schema to load the data into. (postgres only). |  |
-| `-d, --drop` | flag | Drop tables before loading new data into them (postgres/sqlite only). |  |
-| `-e, --evolve` | flag | If loading into existing db, alter existing tables so that new data will load. (postgres/sqlite only). |  |
-| `-i, --pipe` | flag | Adjust output format for piped data (omits row counts and field format columns). |  |
-| `-p, --separator` | string | For xlsx, use this character to help truncate xlsx sheet names. Defaults to space. |  |
-| `-A, --all-strings` | flag | Convert all fields to strings. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-k,`<br>`--print-package` | flag | Print statistics as datapackage, by default will print field summary. |  |
+| `-u,`<br>`--dump` | flag | Create database dump file for use with `psql` or `sqlite3` command line tools (postgres/sqlite only). |  |
+| `-a,`<br>`--stats` | flag | Produce extra statistics about the data beyond just type guessing. |  |
+| `-c,`<br>`--stats-csv` | string | Output stats as CSV to specified file. |  |
+| `-q,`<br>`--quiet` | flag | Do not print out field summary. |  |
+| `-s,`<br>`--schema` | string | The schema to load the data into. (postgres only). |  |
+| `-d,`<br>`--drop` | flag | Drop tables before loading new data into them (postgres/sqlite only). |  |
+| `-e,`<br>`--evolve` | flag | If loading into existing db, alter existing tables so that new data will load. (postgres/sqlite only). |  |
+| `-i,`<br>`--pipe` | flag | Adjust output format for piped data (omits row counts and field format columns). |  |
+| `-p,`<br>`--separator` | string | For xlsx, use this character to help truncate xlsx sheet names. Defaults to space. |  |
+| `-A,`<br>`--all-strings` | flag | Convert all fields to strings. |  |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -225,8 +225,8 @@ qsv to --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/to.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/to.rs)

--- a/docs/help/tojsonl.md
+++ b/docs/help/tojsonl.md
@@ -44,8 +44,8 @@ qsv tojsonl --help
 |--------|------|-------------|--------|
 | `--trim` | flag | Trim leading and trailing whitespace from fields before converting to JSON. |  |
 | `--no-boolean` | flag | Do not infer boolean fields. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="common-options"></a>
 
@@ -53,11 +53,11 @@ qsv tojsonl --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
-| `-q, --quiet` | flag | Do not display enum/const list inferencing messages. |  |
+| `-q,`<br>`--quiet` | flag | Do not display enum/const list inferencing messages. |  |
 
 ---
 **Source:** [`src/cmd/tojsonl.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/tojsonl.rs)

--- a/docs/help/transpose.md
+++ b/docs/help/transpose.md
@@ -77,8 +77,8 @@ qsv transpose --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-m, --multipass` | flag | Process the transpose by making multiple passes over the dataset. Consumes memory relative to the number of rows. Note that in general it is faster to process the transpose in memory. Useful for really big datasets as the default is to read the entire dataset into memory. |  |
-| `-s, --select` | string | Select a subset of columns to transpose. When used with --long, this filters which columns become attribute rows (the field columns are unaffected). See 'qsv select --help' for the full selection syntax. |  |
+| `-m,`<br>`--multipass` | flag | Process the transpose by making multiple passes over the dataset. Consumes memory relative to the number of rows. Note that in general it is faster to process the transpose in memory. Useful for really big datasets as the default is to read the entire dataset into memory. |  |
+| `-s,`<br>`--select` | string | Select a subset of columns to transpose. When used with --long, this filters which columns become attribute rows (the field columns are unaffected). See 'qsv select --help' for the full selection syntax. |  |
 | `--long` | string | Convert wide-format CSV to "long" format. |  |
 
 <a name="common-options"></a>
@@ -87,9 +87,9 @@ qsv transpose --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-o, --output` | string | Write output to <file> instead of stdout. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. Ignored when --multipass or --long option is enabled. |  |
 
 ---

--- a/docs/help/validate.md
+++ b/docs/help/validate.md
@@ -13,7 +13,7 @@
 
 Validates CSV data using two main modes:
 
-### Json Schema Validation Mode:
+### JSON Schema Validation Mode:
 
 This mode is invoked if a JSON Schema file (draft 2020-12) is provided.
 
@@ -245,8 +245,8 @@ qsv validate --help
 | `--json` | flag | When validating without a JSON Schema, return the RFC 4180 check as a JSON file instead of a message. |  |
 | `--pretty-json` | flag | Same as --json, but pretty printed. |  |
 | `--valid-output` | string | Change validation mode behavior so if ALL rows are valid, to pass it to output, return exit code 1, and set stderr to the number of valid rows. Setting this will override the default behavior of creating a valid file only when there are invalid records. To send valid records to stdout, use `-` as the filename. |  |
-| `-j, --jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b, --batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="fancy-regex-options"></a>
 
@@ -287,11 +287,11 @@ qsv validate --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h, --help` | flag | Display this message |  |
-| `-n, --no-headers` | flag | When set, the first row will not be interpreted as headers. It will be validated with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. Note that this option is only valid when running in RFC 4180 validation mode as JSON Schema validation requires headers. |  |
-| `-d, --delimiter` | string | The field delimiter for reading CSV data. Must be a single character. |  |
-| `-p, --progressbar` | flag | Show progress bars. Not valid for stdin. |  |
-| `-q, --quiet` | flag | Do not display validation summary message. |  |
+| `-h,`<br>`--help` | flag | Display this message |  |
+| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. It will be validated with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. Note that this option is only valid when running in RFC 4180 validation mode as JSON Schema validation requires headers. |  |
+| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. |  |
+| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| `-q,`<br>`--quiet` | flag | Do not display validation summary message. |  |
 
 ---
 **Source:** [`src/cmd/validate.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/validate.rs)


### PR DESCRIPTION
…n markdown gen

- Add `/` and `&` to ALL-CAPS header detection so headings like "DATA ANALYSIS/INFERENCING OPTIONS:" are recognized as section breaks
- Preserve known acronyms (LLM, API, CSV, SQL, etc.) in titlecase_heading() and handle `/`-separated parts (e.g. "Analysis/Inferencing")
- Split short+long option flags into separate code spans with <br> to prevent mid-option word-wrap in rendered markdown tables