### PR TITLE
docs(help): add nbsp padding to Argument and Option table columns

### DIFF
--- a/docs/help/apply.md
+++ b/docs/help/apply.md
@@ -340,11 +340,11 @@ qsv apply --help
 
 | Argument | Description |
 |----------|-------------|
-| `<column>` | The column/s to apply the transformation to. Note that the <column> argument supports multiple columns for the operations & emptyreplace subcommands. See 'qsv select --help' for the format details. |
-| `<operations>` | The operation/s to apply. |
-| `<column>` | The column/s to apply the operations to. |
-| `<column>` | The column/s to check for emptiness. |
-| `<input>` | The input file to read from. If not specified, reads from stdin. |
+| &nbsp;`<column>`&nbsp; | The column/s to apply the transformation to. Note that the <column> argument supports multiple columns for the operations & emptyreplace subcommands. See 'qsv select --help' for the format details. |
+| &nbsp;`<operations>`&nbsp; | The operation/s to apply. |
+| &nbsp;`<column>`&nbsp; | The column/s to apply the operations to. |
+| &nbsp;`<column>`&nbsp; | The column/s to check for emptiness. |
+| &nbsp;`<input>`&nbsp; | The input file to read from. If not specified, reads from stdin. |
 
 <a name="apply-options"></a>
 
@@ -352,11 +352,11 @@ qsv apply --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. |  |
-| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
-| `-C,`<br>`--comparand=<string>` | string | The string to compare against for replace & similarity operations. Also used with numtocurrency operation to specify currency symbol. |  |
-| `-R,`<br>`--replacement=<string>` | string | The string to use for the replace & emptyreplace operations. Also used with numtocurrency operation to conversion rate. |  |
-| `-f,`<br>`--formatstr=<string>` | string | This option is used by several subcommands: |  |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | Put the transformed values in a new column instead. |  |
+| &nbsp;`-r,`<br>`--rename`&nbsp; | string | New name for the transformed column. |  |
+| &nbsp;`-C,`<br>`--comparand=<string>`&nbsp; | string | The string to compare against for replace & similarity operations. Also used with numtocurrency operation to specify currency symbol. |  |
+| &nbsp;`-R,`<br>`--replacement=<string>`&nbsp; | string | The string to use for the replace & emptyreplace operations. Also used with numtocurrency operation to conversion rate. |  |
+| &nbsp;`-f,`<br>`--formatstr=<string>`&nbsp; | string | This option is used by several subcommands: |  |
 
 <a name="operations-options"></a>
 
@@ -364,8 +364,8 @@ qsv apply --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="common-options"></a>
 
@@ -373,11 +373,11 @@ qsv apply --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/apply.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/apply.rs)

--- a/docs/help/applydp.md
+++ b/docs/help/applydp.md
@@ -202,11 +202,11 @@ qsv applydp --help
 
 | Argument | Description |
 |----------|-------------|
-| `<column>` | The column/s to apply the transformation to. Note that the <column> argument supports multiple columns for the operations & emptyreplace subcommands. See 'qsv select --help' for the format details. |
-| `<operations>` | The operation/s to apply. |
-| `<column>` | The column/s to apply the operations to. |
-| `<column>` | The column/s to check for emptiness. |
-| `<input>` | The input file to read from. If not specified, reads from stdin. |
+| &nbsp;`<column>`&nbsp; | The column/s to apply the transformation to. Note that the <column> argument supports multiple columns for the operations & emptyreplace subcommands. See 'qsv select --help' for the format details. |
+| &nbsp;`<operations>`&nbsp; | The operation/s to apply. |
+| &nbsp;`<column>`&nbsp; | The column/s to apply the operations to. |
+| &nbsp;`<column>`&nbsp; | The column/s to check for emptiness. |
+| &nbsp;`<input>`&nbsp; | The input file to read from. If not specified, reads from stdin. |
 
 <a name="applydp-options"></a>
 
@@ -214,11 +214,11 @@ qsv applydp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. |  |
-| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
-| `-C,`<br>`--comparand=<string>` | string | The string to compare against for replace & similarity operations. |  |
-| `-R,`<br>`--replacement=<string>` | string | The string to use for the replace & emptyreplace operations. |  |
-| `-f,`<br>`--formatstr=<string>` | string | This option is used by several subcommands: |  |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | Put the transformed values in a new column instead. |  |
+| &nbsp;`-r,`<br>`--rename`&nbsp; | string | New name for the transformed column. |  |
+| &nbsp;`-C,`<br>`--comparand=<string>`&nbsp; | string | The string to compare against for replace & similarity operations. |  |
+| &nbsp;`-R,`<br>`--replacement=<string>`&nbsp; | string | The string to use for the replace & emptyreplace operations. |  |
+| &nbsp;`-f,`<br>`--formatstr=<string>`&nbsp; | string | This option is used by several subcommands: |  |
 
 <a name="operations-options"></a>
 
@@ -226,8 +226,8 @@ qsv applydp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 
 <a name="common-options"></a>
 
@@ -235,10 +235,10 @@ qsv applydp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/applydp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/applydp.rs)

--- a/docs/help/behead.md
+++ b/docs/help/behead.md
@@ -29,9 +29,9 @@ qsv behead --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-f,`<br>`--flexible` | flag | Do not validate if the CSV has different number of fields per record, increasing performance. |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-f,`<br>`--flexible`&nbsp; | flag | Do not validate if the CSV has different number of fields per record, increasing performance. |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
 
 ---
 **Source:** [`src/cmd/behead.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/behead.rs)

--- a/docs/help/cat.md
+++ b/docs/help/cat.md
@@ -89,7 +89,7 @@ qsv cat --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | ...              The CSV file(s) to read. Use '-' for standard input. If input is a directory, all files in the directory will be read as input. If the input is a file with a '.infile-list' extension, the file will be read as a list of input files. If the input are snappy-compressed files(s), it will be decompressed automatically. |
+| &nbsp;`<input>`&nbsp; | ...              The CSV file(s) to read. Use '-' for standard input. If input is a directory, all files in the directory will be read as input. If the input is a file with a '.infile-list' extension, the file will be read as a list of input files. If the input are snappy-compressed files(s), it will be decompressed automatically. |
 
 <a name="columns-option"></a>
 
@@ -97,7 +97,7 @@ qsv cat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-p,`<br>`--pad` | flag | When concatenating columns, this flag will cause all records to appear. It will pad each row if other CSV data isn't long enough. |  |
+| &nbsp;`-p,`<br>`--pad`&nbsp; | flag | When concatenating columns, this flag will cause all records to appear. It will pad each row if other CSV data isn't long enough. |  |
 
 <a name="rows-option"></a>
 
@@ -105,7 +105,7 @@ qsv cat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--flexible` | flag | When concatenating rows, this flag turns off validation that the input and output CSVs have the same number of columns. This is faster, but may result in invalid CSV data. |  |
+| &nbsp;`--flexible`&nbsp; | flag | When concatenating rows, this flag turns off validation that the input and output CSVs have the same number of columns. This is faster, but may result in invalid CSV data. |  |
 
 <a name="rowskey-options"></a>
 
@@ -113,8 +113,8 @@ qsv cat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g,`<br>`--group` | string | When concatenating with rowskey, you can specify a grouping value which will be used as the first column in the output. This is useful when you want to know which file a row came from. Valid values are 'fullpath', 'parentdirfname', 'parentdirfstem', 'fname', 'fstem' and 'none'. A new column will be added to the beginning of each row using --group-name. If 'none' is specified, no grouping column will be added. | `none` |
-| `-N,`<br>`--group-name` | string | When concatenating with rowskey, this flag provides the name for the new grouping column. | `file` |
+| &nbsp;`-g,`<br>`--group`&nbsp; | string | When concatenating with rowskey, you can specify a grouping value which will be used as the first column in the output. This is useful when you want to know which file a row came from. Valid values are 'fullpath', 'parentdirfname', 'parentdirfstem', 'fname', 'fstem' and 'none'. A new column will be added to the beginning of each row using --group-name. If 'none' is specified, no grouping column will be added. | `none` |
+| &nbsp;`-N,`<br>`--group-name`&nbsp; | string | When concatenating with rowskey, this flag provides the name for the new grouping column. | `file` |
 
 <a name="common-options"></a>
 
@@ -122,10 +122,10 @@ qsv cat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. Note that this has no effect when concatenating columns. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will NOT be interpreted as column names. Note that this has no effect when concatenating columns. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/cat.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/cat.rs)

--- a/docs/help/clipboard.md
+++ b/docs/help/clipboard.md
@@ -48,7 +48,7 @@ qsv clipboard --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--save` | flag | Save output to clipboard. |  |
+| &nbsp;`-s,`<br>`--save`&nbsp; | flag | Save output to clipboard. |  |
 
 <a name="common-options"></a>
 
@@ -56,7 +56,7 @@ qsv clipboard --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/clipboard.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/clipboard.rs)

--- a/docs/help/color.md
+++ b/docs/help/color.md
@@ -44,9 +44,9 @@ qsv color --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-C,`<br>`--color` | flag | Force color on, even in situations where colors would normally be disabled. |  |
-| `-n,`<br>`--row-numbers` | flag | Show row numbers. |  |
-| `-t,`<br>`--title` | string | Add a title row above the headers. |  |
+| &nbsp;`-C,`<br>`--color`&nbsp; | flag | Force color on, even in situations where colors would normally be disabled. |  |
+| &nbsp;`-n,`<br>`--row-numbers`&nbsp; | flag | Show row numbers. |  |
+| &nbsp;`-t,`<br>`--title`&nbsp; | string | Add a title row above the headers. |  |
 
 <a name="common-options"></a>
 
@@ -54,10 +54,10 @@ qsv color --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---
 **Source:** [`src/cmd/color.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/color.rs)

--- a/docs/help/count.md
+++ b/docs/help/count.md
@@ -88,7 +88,7 @@ qsv count --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-H,`<br>`--human-readable` | flag | Comma separate counts. |  |
+| &nbsp;`-H,`<br>`--human-readable`&nbsp; | flag | Comma separate counts. |  |
 
 <a name="width-options"></a>
 
@@ -96,9 +96,9 @@ qsv count --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--width` | flag | Also return the estimated widths of each record. Its an estimate as it doesn't count quotes, and will be an undercount if the record has quoted fields. The count and width are separated by a semicolon. It will return the max, avg, median, min, variance, stddev & MAD widths, separated by hyphens. If --human-readable is set, the widths will be labeled as "max", "avg", "median", "min", "stddev" & "mad" respectively, separated by spaces. Note that this option will require scanning the entire file using the "regular", single-threaded, streaming CSV reader, using the index if available for the count. If the file is very large, it may not be able to compile some stats - particularly avg, variance, stddev & MAD. In this case, it will return 0.0 for those stats. |  |
-| `--width-no-delims` | flag | Same as --width but does not count the delimiters in the width. |  |
-| `--json` | flag | Output the width stats in JSON format. |  |
+| &nbsp;`--width`&nbsp; | flag | Also return the estimated widths of each record. Its an estimate as it doesn't count quotes, and will be an undercount if the record has quoted fields. The count and width are separated by a semicolon. It will return the max, avg, median, min, variance, stddev & MAD widths, separated by hyphens. If --human-readable is set, the widths will be labeled as "max", "avg", "median", "min", "stddev" & "mad" respectively, separated by spaces. Note that this option will require scanning the entire file using the "regular", single-threaded, streaming CSV reader, using the index if available for the count. If the file is very large, it may not be able to compile some stats - particularly avg, variance, stddev & MAD. In this case, it will return 0.0 for those stats. |  |
+| &nbsp;`--width-no-delims`&nbsp; | flag | Same as --width but does not count the delimiters in the width. |  |
+| &nbsp;`--json`&nbsp; | flag | Output the width stats in JSON format. |  |
 
 <a name="when-the-polars-feature-is-enabled-options"></a>
 
@@ -106,8 +106,8 @@ qsv count --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--no-polars` | flag | Use the "regular", single-threaded, streaming CSV reader instead of the much faster multithreaded, mem-mapped Polars CSV reader. Use this when you encounter memory issues when counting with the Polars CSV reader. The streaming reader is slower but can read any valid CSV file of any size. |  |
-| `--low-memory` | flag | Use the Polars CSV Reader's low-memory mode. This mode is slower but uses less memory. If counting still fails, use --no-polars instead to use the streaming CSV reader. |  |
+| &nbsp;`--no-polars`&nbsp; | flag | Use the "regular", single-threaded, streaming CSV reader instead of the much faster multithreaded, mem-mapped Polars CSV reader. Use this when you encounter memory issues when counting with the Polars CSV reader. The streaming reader is slower but can read any valid CSV file of any size. |  |
+| &nbsp;`--low-memory`&nbsp; | flag | Use the Polars CSV Reader's low-memory mode. This mode is slower but uses less memory. If counting still fails, use --no-polars instead to use the streaming CSV reader. |  |
 
 <a name="common-options"></a>
 
@@ -115,10 +115,10 @@ qsv count --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-f,`<br>`--flexible` | flag | Do not validate if the CSV has different number of fields per record, increasing performance when counting without an index. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will be included in the count. |  |
-| `-d,`<br>`--delimiter` | string | The delimiter to use when reading CSV data. Must be a single character. | `,` |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-f,`<br>`--flexible`&nbsp; | flag | Do not validate if the CSV has different number of fields per record, increasing performance when counting without an index. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will be included in the count. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The delimiter to use when reading CSV data. Must be a single character. | `,` |
 
 ---
 **Source:** [`src/cmd/count.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/count.rs)

--- a/docs/help/datefmt.md
+++ b/docs/help/datefmt.md
@@ -87,8 +87,8 @@ qsv datefmt --help
 
 | Argument | Description |
 |----------|-------------|
-| `<column>` | The column/s to apply the date formats to. Note that the <column> argument supports multiple columns. See 'qsv select --help' for the format details. |
-| `<input>` | The input file to read from. If not specified, reads from stdin. |
+| &nbsp;`<column>`&nbsp; | The column/s to apply the date formats to. Note that the <column> argument supports multiple columns. See 'qsv select --help' for the format details. |
+| &nbsp;`<input>`&nbsp; | The input file to read from. If not specified, reads from stdin. |
 
 <a name="datefmt-options"></a>
 
@@ -96,18 +96,18 @@ qsv datefmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. |  |
-| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
-| `--prefer-dmy` | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. |  |
-| `--keep-zero-time` | flag | If a formatted date ends with "T00:00:00+00:00", keep the time instead of removing it. |  |
-| `--input-tz=<string>` | string | The timezone to use for the input date if the date does not have timezone specified. The timezone must be a valid IANA timezone name or the string "local" for the local timezone. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> for a list of valid timezone names. | `UTC` |
-| `--output-tz=<string>` | string | The timezone to use for the output date. The timezone must be a valid IANA timezone name or the string "local". | `UTC` |
-| `--default-tz=<string>` | string | The timezone to use for BOTH input and output dates when they do have timezone. Shortcut for --input-tz and --output-tz set to the same timezone. The timezone must be a valid IANA timezone name or the string "local". |  |
-| `--utc` | flag | Shortcut for --input-tz and --output-tz set to UTC. |  |
-| `--zulu` | flag | Shortcut for --output-tz set to UTC and --formatstr set to "%Y-%m-%dT%H:%M:%SZ". |  |
-| `-R,`<br>`--ts-resolution` | string | The resolution to use when parsing Unix timestamps. Valid values are "sec", "milli", "micro", "nano". | `sec` |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | Put the transformed values in a new column instead. |  |
+| &nbsp;`-r,`<br>`--rename`&nbsp; | string | New name for the transformed column. |  |
+| &nbsp;`--prefer-dmy`&nbsp; | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. |  |
+| &nbsp;`--keep-zero-time`&nbsp; | flag | If a formatted date ends with "T00:00:00+00:00", keep the time instead of removing it. |  |
+| &nbsp;`--input-tz=<string>`&nbsp; | string | The timezone to use for the input date if the date does not have timezone specified. The timezone must be a valid IANA timezone name or the string "local" for the local timezone. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> for a list of valid timezone names. | `UTC` |
+| &nbsp;`--output-tz=<string>`&nbsp; | string | The timezone to use for the output date. The timezone must be a valid IANA timezone name or the string "local". | `UTC` |
+| &nbsp;`--default-tz=<string>`&nbsp; | string | The timezone to use for BOTH input and output dates when they do have timezone. Shortcut for --input-tz and --output-tz set to the same timezone. The timezone must be a valid IANA timezone name or the string "local". |  |
+| &nbsp;`--utc`&nbsp; | flag | Shortcut for --input-tz and --output-tz set to UTC. |  |
+| &nbsp;`--zulu`&nbsp; | flag | Shortcut for --output-tz set to UTC and --formatstr set to "%Y-%m-%dT%H:%M:%SZ". |  |
+| &nbsp;`-R,`<br>`--ts-resolution`&nbsp; | string | The resolution to use when parsing Unix timestamps. Valid values are "sec", "milli", "micro", "nano". | `sec` |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="common-options"></a>
 
@@ -115,11 +115,11 @@ qsv datefmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/datefmt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/datefmt.rs)

--- a/docs/help/dedup.md
+++ b/docs/help/dedup.md
@@ -83,13 +83,13 @@ qsv dedup --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--select` | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. See 'qsv select --help' for the format details. |  |
-| `-N,`<br>`--numeric` | flag | Compare according to string numerical value |  |
-| `-i,`<br>`--ignore-case` | flag | Compare strings disregarding case. |  |
-| `--sorted` | flag | The input is already sorted. Do not load the CSV into memory to sort it first. Meant to be used in tandem and after an extsort. |  |
-| `-D,`<br>`--dupes-output` | string | Write duplicates to <file>. |  |
-| `-H,`<br>`--human-readable` | flag | Comma separate duplicate count. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when sorting an unsorted CSV, before deduping. When not set, the number of jobs is set to the number of CPUs detected. Does not work with --sorted option as its not multithreaded. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. See 'qsv select --help' for the format details. |  |
+| &nbsp;`-N,`<br>`--numeric`&nbsp; | flag | Compare according to string numerical value |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Compare strings disregarding case. |  |
+| &nbsp;`--sorted`&nbsp; | flag | The input is already sorted. Do not load the CSV into memory to sort it first. Meant to be used in tandem and after an extsort. |  |
+| &nbsp;`-D,`<br>`--dupes-output`&nbsp; | string | Write duplicates to <file>. |  |
+| &nbsp;`-H,`<br>`--human-readable`&nbsp; | flag | Comma separate duplicate count. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel when sorting an unsorted CSV, before deduping. When not set, the number of jobs is set to the number of CPUs detected. Does not work with --sorted option as its not multithreaded. |  |
 
 <a name="common-options"></a>
 
@@ -97,12 +97,12 @@ qsv dedup --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-q,`<br>`--quiet` | flag | Do not print duplicate count to stderr. |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not print duplicate count to stderr. |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---
 **Source:** [`src/cmd/dedup.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/dedup.rs)

--- a/docs/help/describegpt.md
+++ b/docs/help/describegpt.md
@@ -206,10 +206,10 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--dictionary` | flag | Create a Data Dictionary using a hybrid "neuro-procedural" pipeline - i.e. the Dictionary is populated deterministically using Summary Statistics and Frequency Distribution data, and only the human-friendly Label and Description are populated by the LLM using the same statistical context. |  |
-| `--description` | flag | Infer a general Description of the dataset based on detailed statistical context. An Attribution signature is embedded in the Description. |  |
-| `--tags` | flag | Infer Tags that categorize the dataset based on detailed statistical context. Useful for grouping datasets and filtering. |  |
-| `-A,`<br>`--all` | flag | Shortcut for --dictionary --description --tags. |  |
+| &nbsp;`--dictionary`&nbsp; | flag | Create a Data Dictionary using a hybrid "neuro-procedural" pipeline - i.e. the Dictionary is populated deterministically using Summary Statistics and Frequency Distribution data, and only the human-friendly Label and Description are populated by the LLM using the same statistical context. |  |
+| &nbsp;`--description`&nbsp; | flag | Infer a general Description of the dataset based on detailed statistical context. An Attribution signature is embedded in the Description. |  |
+| &nbsp;`--tags`&nbsp; | flag | Infer Tags that categorize the dataset based on detailed statistical context. Useful for grouping datasets and filtering. |  |
+| &nbsp;`-A,`<br>`--all`&nbsp; | flag | Shortcut for --dictionary --description --tags. |  |
 
 <a name="dictionary-options"></a>
 
@@ -217,10 +217,10 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--num-examples` | string | The number of Example values to include in the dictionary. | `5` |
-| `--truncate-str` | string | The maximum length of an Example value in the dictionary. An ellipsis is appended to the truncated value. If zero, no truncation is performed. | `25` |
-| `--addl-cols` | flag | Add additional columns to the dictionary from the Summary Statistics. |  |
-| `--addl-cols-list` | string | A comma-separated list of additional stats columns to add to the dictionary. The columns must be present in the Summary Statistics. If the columns are not present in the Summary Statistics or already in the dictionary, they will be ignored. | `sort_order, sortiness, mean, median, mad, stddev, variance, cv` |
+| &nbsp;`--num-examples`&nbsp; | string | The number of Example values to include in the dictionary. | `5` |
+| &nbsp;`--truncate-str`&nbsp; | string | The maximum length of an Example value in the dictionary. An ellipsis is appended to the truncated value. If zero, no truncation is performed. | `25` |
+| &nbsp;`--addl-cols`&nbsp; | flag | Add additional columns to the dictionary from the Summary Statistics. |  |
+| &nbsp;`--addl-cols-list`&nbsp; | string | A comma-separated list of additional stats columns to add to the dictionary. The columns must be present in the Summary Statistics. If the columns are not present in the Summary Statistics or already in the dictionary, they will be ignored. | `sort_order, sortiness, mean, median, mad, stddev, variance, cv` |
 
 <a name="tag-options"></a>
 
@@ -228,11 +228,11 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--num-tags` | string | The maximum number of tags to infer when the --tags option is used. Maximum allowed value is 50. | `10` |
-| `--tag-vocab` | string | The CSV file containing the tag vocabulary to use for inferring tags. If no tag vocabulary file is provided, the model will use free-form tags. Supports local files, remote URLs (http/https), CKAN resources (ckan://), and dathere:// scheme. Remote resources are cached locally. The CSV file must have two columns with headers: first column is the tag, second column is the description. Note that qsvlite only supports local files. |  |
-| `--cache-dir` | string | The directory to use for caching downloaded tag vocabulary resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
-| `--ckan-api` | string | The URL of the CKAN API to use for downloading tag vocabulary resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
-| `--ckan-token` | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. |  |
+| &nbsp;`--num-tags`&nbsp; | string | The maximum number of tags to infer when the --tags option is used. Maximum allowed value is 50. | `10` |
+| &nbsp;`--tag-vocab`&nbsp; | string | The CSV file containing the tag vocabulary to use for inferring tags. If no tag vocabulary file is provided, the model will use free-form tags. Supports local files, remote URLs (http/https), CKAN resources (ckan://), and dathere:// scheme. Remote resources are cached locally. The CSV file must have two columns with headers: first column is the tag, second column is the description. Note that qsvlite only supports local files. |  |
+| &nbsp;`--cache-dir`&nbsp; | string | The directory to use for caching downloaded tag vocabulary resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
+| &nbsp;`--ckan-api`&nbsp; | string | The URL of the CKAN API to use for downloading tag vocabulary resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
+| &nbsp;`--ckan-token`&nbsp; | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. |  |
 
 <a name="stats/frequency-options"></a>
 
@@ -240,9 +240,9 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--stats-options` | string | Options for the stats command used to generate summary statistics. If it starts with "file:" prefix, the statistics are read from the specified CSV file instead of running the stats command. e.g. "file:my_custom_stats.csv" | `--infer-dates --infer-boolean --mad --quartiles --percentiles --force --stats-jsonl` |
-| `--freq-options` | string | Options for the frequency command used to generate frequency distributions. You can use this to exclude certain variable types from frequency analysis (e.g., --select '!id,!uuid'), limit results differently per use case, or control output format. If --limit is specified here, it takes precedence over --enum-threshold. If it starts with "file:" prefix, the frequency data is read from the specified CSV file instead of running the frequency command. e.g. "file:my_custom_frequency.csv" | `--rank-strategy dense` |
-| `--enum-threshold` | string | The threshold for compiling Enumerations with the frequency command before bucketing other unique values into the "Other" category. This is a convenience shortcut for --freq-options --limit <n>. If --freq-options contains --limit, this flag is ignored. | `10` |
+| &nbsp;`--stats-options`&nbsp; | string | Options for the stats command used to generate summary statistics. If it starts with "file:" prefix, the statistics are read from the specified CSV file instead of running the stats command. e.g. "file:my_custom_stats.csv" | `--infer-dates --infer-boolean --mad --quartiles --percentiles --force --stats-jsonl` |
+| &nbsp;`--freq-options`&nbsp; | string | Options for the frequency command used to generate frequency distributions. You can use this to exclude certain variable types from frequency analysis (e.g., --select '!id,!uuid'), limit results differently per use case, or control output format. If --limit is specified here, it takes precedence over --enum-threshold. If it starts with "file:" prefix, the frequency data is read from the specified CSV file instead of running the frequency command. e.g. "file:my_custom_frequency.csv" | `--rank-strategy dense` |
+| &nbsp;`--enum-threshold`&nbsp; | string | The threshold for compiling Enumerations with the frequency command before bucketing other unique values into the "Other" category. This is a convenience shortcut for --freq-options --limit <n>. If --freq-options contains --limit, this flag is ignored. | `10` |
 
 <a name="custom-prompt-options"></a>
 
@@ -250,13 +250,13 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-p,`<br>`--prompt` | string | Custom prompt to answer questions about the dataset. The prompt will be answered based on the dataset's Summary Statistics, Frequency data & Data Dictionary. If the prompt CANNOT be answered by looking at these metadata, a SQL query will be generated to answer the question. If the "polars" or the "QSV_DESCRIBEGPT_DB_ENGINE" environment variable is set & the `--sql-results` option is used, the SQL query will be automatically executed and its results returned. Otherwise, the SQL query will be returned along with the reasoning behind it. If it starts with "file:" prefix, the prompt is read from the file specified. e.g. "file:my_long_prompt.txt" |  |
-| `--sql-results` | string | The file to save the SQL query results to. Only valid if the --prompt option is used & the "polars" or the "QSV_DESCRIBEGPT_DB_ENGINE" environment variable is set. If the SQL query executes successfully, the results will be saved with a ".csv" extension. Otherwise, it will be saved with a ".sql" extension so the user can inspect why it failed and modify it. |  |
-| `--prompt-file` | string | The configurable TOML file containing prompts to use for inferencing. If no file is provided, default prompts will be used. The prompt file uses the Mini Jinja template engine (<https://docs.rs/minijinja>) See <https://github.com/dathere/qsv/blob/master/resources/describegpt_defaults.toml> |  |
-| `--sample-size` | string | The number of rows to randomly sample from the input file for the sample data. Uses the INDEXED sampling method with the qsv sample command. | `100` |
-| `--fewshot-examples` | flag | By default, few-shot examples are NOT included in the LLM prompt when generating SQL queries. When this option is set, few-shot examples in the default prompt file are included. Though this will increase the quality of the generated SQL, it comes at a cost - increased LLM API call cost in terms of tokens and execution time. See <https://en.wikipedia.org/wiki/Prompt_engineering> for more info. |  |
-| `--session` | string | Enable stateful session mode for iterative SQL RAG refinement. The session name is the file path of the markdown file where session messages will be stored. When used with --prompt, subsequent queries in the same session will refine the baseline SQL query. SQL query results (10-row sample) and errors are automatically included in subsequent messages for context. |  |
-| `--session-len` | string | Maximum number of recent messages to keep in session context before summarizing older messages. Only used when --session is specified. | `10` |
+| &nbsp;`-p,`<br>`--prompt`&nbsp; | string | Custom prompt to answer questions about the dataset. The prompt will be answered based on the dataset's Summary Statistics, Frequency data & Data Dictionary. If the prompt CANNOT be answered by looking at these metadata, a SQL query will be generated to answer the question. If the "polars" or the "QSV_DESCRIBEGPT_DB_ENGINE" environment variable is set & the `--sql-results` option is used, the SQL query will be automatically executed and its results returned. Otherwise, the SQL query will be returned along with the reasoning behind it. If it starts with "file:" prefix, the prompt is read from the file specified. e.g. "file:my_long_prompt.txt" |  |
+| &nbsp;`--sql-results`&nbsp; | string | The file to save the SQL query results to. Only valid if the --prompt option is used & the "polars" or the "QSV_DESCRIBEGPT_DB_ENGINE" environment variable is set. If the SQL query executes successfully, the results will be saved with a ".csv" extension. Otherwise, it will be saved with a ".sql" extension so the user can inspect why it failed and modify it. |  |
+| &nbsp;`--prompt-file`&nbsp; | string | The configurable TOML file containing prompts to use for inferencing. If no file is provided, default prompts will be used. The prompt file uses the Mini Jinja template engine (<https://docs.rs/minijinja>) See <https://github.com/dathere/qsv/blob/master/resources/describegpt_defaults.toml> |  |
+| &nbsp;`--sample-size`&nbsp; | string | The number of rows to randomly sample from the input file for the sample data. Uses the INDEXED sampling method with the qsv sample command. | `100` |
+| &nbsp;`--fewshot-examples`&nbsp; | flag | By default, few-shot examples are NOT included in the LLM prompt when generating SQL queries. When this option is set, few-shot examples in the default prompt file are included. Though this will increase the quality of the generated SQL, it comes at a cost - increased LLM API call cost in terms of tokens and execution time. See <https://en.wikipedia.org/wiki/Prompt_engineering> for more info. |  |
+| &nbsp;`--session`&nbsp; | string | Enable stateful session mode for iterative SQL RAG refinement. The session name is the file path of the markdown file where session messages will be stored. When used with --prompt, subsequent queries in the same session will refine the baseline SQL query. SQL query results (10-row sample) and errors are automatically included in subsequent messages for context. |  |
+| &nbsp;`--session-len`&nbsp; | string | Maximum number of recent messages to keep in session context before summarizing older messages. Only used when --session is specified. | `10` |
 
 <a name="llm-api-options"></a>
 
@@ -264,15 +264,15 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-u,`<br>`--base-url` | string | The LLM API URL. Supports APIs & local LLMs compatible with the OpenAI API specification. Some common base URLs: OpenAI: <https://api.openai.com/v1> Gemini: <https://generativelanguage.googleapis.com/v1beta/openai> TogetherAI: <https://api.together.ai/v1> | `http://localhost:1234/v1` |
-| `-m,`<br>`--model` | string | The model to use for inferencing. If set, takes precedence over the QSV_LLM_MODEL environment variable. | `openai/gpt-oss-20b` |
-| `--language` | string | The output language/dialect to use for the response. (e.g., "Spanish", "French", "Hindi", "Mandarin", "Italian", "Castilian", "Franglais", "Taglish", "Pig Latin", "Valley Girl", "Pirate", "Shakespearean English", "Chavacano", "Gen Z", "Yoda", etc.) |  |
-| `--addl-props` | string | Additional model properties to pass to the LLM chat/completion API. Various models support different properties beyond the standard ones. For instance, gpt-oss-20b supports the "reasoning_effort" property. e.g. to set the "reasoning_effort" property to "high" & "temperature" to 0.5, use '{"reasoning_effort": "high", "temperature": 0.5}' |  |
-| `-k,`<br>`--api-key` | string | The API key to use. If set, takes precedence over the QSV_LLM_APIKEY envvar. Required when the base URL is not localhost. Set to NONE to suppress sending the API key. |  |
-| `-t,`<br>`--max-tokens` | string | Limits the number of generated tokens in the output. Set to 0 to disable token limits. If the --base-url is localhost, indicating a local LLM, the default is automatically set to 0. | `10000` |
-| `--timeout` | string | Timeout for completions in seconds. If 0, no timeout is used. | `300` |
-| `--user-agent` | string | Specify custom user agent. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
-| `--export-prompt` | string | Export the default prompts to the specified file that can be used with the --prompt-file option. The file will be saved with a .toml extension. If the file already exists, it will be overwritten. It will exit after exporting the prompts. |  |
+| &nbsp;`-u,`<br>`--base-url`&nbsp; | string | The LLM API URL. Supports APIs & local LLMs compatible with the OpenAI API specification. Some common base URLs: OpenAI: <https://api.openai.com/v1> Gemini: <https://generativelanguage.googleapis.com/v1beta/openai> TogetherAI: <https://api.together.ai/v1> | `http://localhost:1234/v1` |
+| &nbsp;`-m,`<br>`--model`&nbsp; | string | The model to use for inferencing. If set, takes precedence over the QSV_LLM_MODEL environment variable. | `openai/gpt-oss-20b` |
+| &nbsp;`--language`&nbsp; | string | The output language/dialect to use for the response. (e.g., "Spanish", "French", "Hindi", "Mandarin", "Italian", "Castilian", "Franglais", "Taglish", "Pig Latin", "Valley Girl", "Pirate", "Shakespearean English", "Chavacano", "Gen Z", "Yoda", etc.) |  |
+| &nbsp;`--addl-props`&nbsp; | string | Additional model properties to pass to the LLM chat/completion API. Various models support different properties beyond the standard ones. For instance, gpt-oss-20b supports the "reasoning_effort" property. e.g. to set the "reasoning_effort" property to "high" & "temperature" to 0.5, use '{"reasoning_effort": "high", "temperature": 0.5}' |  |
+| &nbsp;`-k,`<br>`--api-key`&nbsp; | string | The API key to use. If set, takes precedence over the QSV_LLM_APIKEY envvar. Required when the base URL is not localhost. Set to NONE to suppress sending the API key. |  |
+| &nbsp;`-t,`<br>`--max-tokens`&nbsp; | string | Limits the number of generated tokens in the output. Set to 0 to disable token limits. If the --base-url is localhost, indicating a local LLM, the default is automatically set to 0. | `10000` |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for completions in seconds. If 0, no timeout is used. | `300` |
+| &nbsp;`--user-agent`&nbsp; | string | Specify custom user agent. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
+| &nbsp;`--export-prompt`&nbsp; | string | Export the default prompts to the specified file that can be used with the --prompt-file option. The file will be saved with a .toml extension. If the file already exists, it will be overwritten. It will exit after exporting the prompts. |  |
 
 <a name="caching-options"></a>
 
@@ -280,12 +280,12 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--no-cache` | flag | Disable default disk cache. |  |
-| `--disk-cache-dir` | string | The directory <dir> to store the disk cache. Note that if the directory does not exist, it will be created. If the directory exists, it will be used as is, and will not be flushed. This option allows you to maintain several disk caches for different describegpt jobs (e.g. one for a data portal, another for internal data exchange, etc.) | `~/.qsv/cache/describegpt` |
-| `--redis-cache` | flag | Use Redis instead of the default disk cache to cache LLM completions. It connects to "redis://127.0.0.1:6379/3" by default, with a connection pool size of 20, with a TTL of 28 days, and cache hits NOT refreshing an existing cached value's TTL. This option automatically disables the disk cache. |  |
-| `--fresh` | flag | Send a fresh request to the LLM API, refreshing a cached response if it exists. When a --prompt SQL query fails, you can also use this option to request the LLM to generate a new SQL query. |  |
-| `--forget` | flag | Remove a cached response if it exists and then exit. |  |
-| `--flush-cache` | flag | Flush the current cache entries on startup. WARNING: This operation is irreversible. |  |
+| &nbsp;`--no-cache`&nbsp; | flag | Disable default disk cache. |  |
+| &nbsp;`--disk-cache-dir`&nbsp; | string | The directory <dir> to store the disk cache. Note that if the directory does not exist, it will be created. If the directory exists, it will be used as is, and will not be flushed. This option allows you to maintain several disk caches for different describegpt jobs (e.g. one for a data portal, another for internal data exchange, etc.) | `~/.qsv/cache/describegpt` |
+| &nbsp;`--redis-cache`&nbsp; | flag | Use Redis instead of the default disk cache to cache LLM completions. It connects to "redis://127.0.0.1:6379/3" by default, with a connection pool size of 20, with a TTL of 28 days, and cache hits NOT refreshing an existing cached value's TTL. This option automatically disables the disk cache. |  |
+| &nbsp;`--fresh`&nbsp; | flag | Send a fresh request to the LLM API, refreshing a cached response if it exists. When a --prompt SQL query fails, you can also use this option to request the LLM to generate a new SQL query. |  |
+| &nbsp;`--forget`&nbsp; | flag | Remove a cached response if it exists and then exit. |  |
+| &nbsp;`--flush-cache`&nbsp; | flag | Flush the current cache entries on startup. WARNING: This operation is irreversible. |  |
 
 <a name="common-options"></a>
 
@@ -293,10 +293,10 @@ qsv describegpt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `--format` | string | Output format: Markdown, TSV, JSON, or TOON. TOON is a compact, human-readable encoding of the JSON data model for LLM prompts. See <https://toonformat.dev/> for more info. | `Markdown` |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. If --format is set to TSV, separate files will be created for each prompt type with the pattern {filestem}.{kind}.tsv (e.g., output.dictionary.tsv, output.tags.tsv). |  |
-| `-q,`<br>`--quiet` | flag | Do not print status messages to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`--format`&nbsp; | string | Output format: Markdown, TSV, JSON, or TOON. TOON is a compact, human-readable encoding of the JSON data model for LLM prompts. See <https://toonformat.dev/> for more info. | `Markdown` |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. If --format is set to TSV, separate files will be created for each prompt type with the pattern {filestem}.{kind}.tsv (e.g., output.dictionary.tsv, output.tags.tsv). |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not print status messages to stderr. |  |
 
 ---
 **Source:** [`src/cmd/describegpt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/describegpt.rs)

--- a/docs/help/diff.md
+++ b/docs/help/diff.md
@@ -115,16 +115,16 @@ qsv diff --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--no-headers-left` | flag | When set, the first row will be considered as part of the left CSV to diff. (When not set, the first row is the header row and will be skipped during the diff. It will always appear in the output.) |  |
-| `--no-headers-right` | flag | When set, the first row will be considered as part of the right CSV to diff. (When not set, the first row is the header row and will be skipped during the diff. It will always appear in the output.) |  |
-| `--no-headers-output` | flag | When set, the diff result won't have a header row in its output. If not set and both CSVs have no headers, headers in the result will be: _col_1,_col_2, etc. |  |
-| `--delimiter-left` | string | The field delimiter for reading CSV data on the left. Must be a single character. (default: ,) |  |
-| `--delimiter-right` | string | The field delimiter for reading CSV data on the right. Must be a single character. (default: ,) |  |
-| `--delimiter-output` | string | The field delimiter for writing the CSV diff result. Must be a single character. (default: ,) |  |
-| `-k,`<br>`--key` | string | The column indices that uniquely identify a record as a comma separated list of 0-based indices, e.g. 0,1,2 or column names, e.g. name,age. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. (default: 0) |  |
-| `--sort-columns` | string | The column indices by which the diff result should be sorted as a comma separated list of indices, e.g. 0,1,2 or column names, e.g. name,age. Records in the diff result that are marked as "modified" ("delete" and "add" records that have the same key, but have different content) will always be kept together in the sorted diff result and so won't be sorted independently from each other. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. |  |
-| `--drop-equal-fields` | flag | Drop values of equal fields in modified rows of the CSV diff result (and replace them with the empty string). Key field values will not be dropped. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`--no-headers-left`&nbsp; | flag | When set, the first row will be considered as part of the left CSV to diff. (When not set, the first row is the header row and will be skipped during the diff. It will always appear in the output.) |  |
+| &nbsp;`--no-headers-right`&nbsp; | flag | When set, the first row will be considered as part of the right CSV to diff. (When not set, the first row is the header row and will be skipped during the diff. It will always appear in the output.) |  |
+| &nbsp;`--no-headers-output`&nbsp; | flag | When set, the diff result won't have a header row in its output. If not set and both CSVs have no headers, headers in the result will be: _col_1,_col_2, etc. |  |
+| &nbsp;`--delimiter-left`&nbsp; | string | The field delimiter for reading CSV data on the left. Must be a single character. (default: ,) |  |
+| &nbsp;`--delimiter-right`&nbsp; | string | The field delimiter for reading CSV data on the right. Must be a single character. (default: ,) |  |
+| &nbsp;`--delimiter-output`&nbsp; | string | The field delimiter for writing the CSV diff result. Must be a single character. (default: ,) |  |
+| &nbsp;`-k,`<br>`--key`&nbsp; | string | The column indices that uniquely identify a record as a comma separated list of 0-based indices, e.g. 0,1,2 or column names, e.g. name,age. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. (default: 0) |  |
+| &nbsp;`--sort-columns`&nbsp; | string | The column indices by which the diff result should be sorted as a comma separated list of indices, e.g. 0,1,2 or column names, e.g. name,age. Records in the diff result that are marked as "modified" ("delete" and "add" records that have the same key, but have different content) will always be kept together in the sorted diff result and so won't be sorted independently from each other. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. |  |
+| &nbsp;`--drop-equal-fields`&nbsp; | flag | Drop values of equal fields in modified rows of the CSV diff result (and replace them with the empty string). Key field values will not be dropped. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -132,9 +132,9 @@ qsv diff --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | Set ALL delimiters to this character. Overrides --delimiter-right, --delimiter-left and --delimiter-output. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | Set ALL delimiters to this character. Overrides --delimiter-right, --delimiter-left and --delimiter-output. |  |
 
 ---
 **Source:** [`src/cmd/diff.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/diff.rs)

--- a/docs/help/edit.md
+++ b/docs/help/edit.md
@@ -52,7 +52,7 @@ qsv edit --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--in-place` | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. |  |
+| &nbsp;`-i,`<br>`--in-place`&nbsp; | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. |  |
 
 <a name="common-options"></a>
 
@@ -60,9 +60,9 @@ qsv edit --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | Start row indices from the header row as 0 (allows editing the header row). |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | Start row indices from the header row as 0 (allows editing the header row). |  |
 
 ---
 **Source:** [`src/cmd/edit.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/edit.rs)

--- a/docs/help/enum.md
+++ b/docs/help/enum.md
@@ -174,14 +174,14 @@ qsv enum --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c,`<br>`--new-column` | string | Name of the column to create. Will default to "index". |  |
-| `--start` | string | The value to start the enumeration from. Only applies in Increment mode. (default: 0) |  |
-| `--increment` | string | The value to increment the enumeration by. Only applies in Increment mode. (default: 1) |  |
-| `--constant` | string | Fill a new column with the given value. Changes the default column name to "constant" unless overridden by --new-column. To specify a null value, pass the literal "<NULL>". |  |
-| `--copy` | string | Name of a column to copy. Changes the default column name to "{column}_copy" unless overridden by --new-column. |  |
-| `--uuid4` | flag | When set, the column will be populated with uuids (v4) instead of the incremental identifier. Changes the default column name to "uuid4" unless overridden by --new-column. |  |
-| `--uuid7` | flag | When set, the column will be populated with uuids (v7) instead of the incremental identifier. uuid v7 is a time-based uuid and is monotonically increasing. See <https://buildkite.com/blog/goodbye-integers-hello-uuids> Changes the default column name to "uuid7" unless overridden by --new-column. |  |
-| `--hash` | string | Create a new column filled with the hash of the given column/s. Use "1-" to hash all columns. Changes the default column name to "hash" unless overridden by --new-column. Will remove an existing "hash" column if it exists. |  |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | Name of the column to create. Will default to "index". |  |
+| &nbsp;`--start`&nbsp; | string | The value to start the enumeration from. Only applies in Increment mode. (default: 0) |  |
+| &nbsp;`--increment`&nbsp; | string | The value to increment the enumeration by. Only applies in Increment mode. (default: 1) |  |
+| &nbsp;`--constant`&nbsp; | string | Fill a new column with the given value. Changes the default column name to "constant" unless overridden by --new-column. To specify a null value, pass the literal "<NULL>". |  |
+| &nbsp;`--copy`&nbsp; | string | Name of a column to copy. Changes the default column name to "{column}_copy" unless overridden by --new-column. |  |
+| &nbsp;`--uuid4`&nbsp; | flag | When set, the column will be populated with uuids (v4) instead of the incremental identifier. Changes the default column name to "uuid4" unless overridden by --new-column. |  |
+| &nbsp;`--uuid7`&nbsp; | flag | When set, the column will be populated with uuids (v7) instead of the incremental identifier. uuid v7 is a time-based uuid and is monotonically increasing. See <https://buildkite.com/blog/goodbye-integers-hello-uuids> Changes the default column name to "uuid7" unless overridden by --new-column. |  |
+| &nbsp;`--hash`&nbsp; | string | Create a new column filled with the hash of the given column/s. Use "1-" to hash all columns. Changes the default column name to "hash" unless overridden by --new-column. Will remove an existing "hash" column if it exists. |  |
 
 <a name="common-options"></a>
 
@@ -189,10 +189,10 @@ qsv enum --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/enumerate.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/enumerate.rs)

--- a/docs/help/excel.md
+++ b/docs/help/excel.md
@@ -163,7 +163,7 @@ qsv excel --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The spreadsheet file to read. Use "-" to read from stdin. Supported formats: xls, xlsx, xlsm, xlsb, ods. |
+| &nbsp;`<input>`&nbsp; | The spreadsheet file to read. Use "-" to read from stdin. Supported formats: xls, xlsx, xlsm, xlsb, ods. |
 
 <a name="excel-options"></a>
 
@@ -171,18 +171,18 @@ qsv excel --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--sheet` | string | Name (case-insensitive) or zero-based index of sheet to export. Negative indices start from the end (-1 = last sheet). If the sheet cannot be found, qsv will read the first sheet. | `0` |
-| `--header-row` | string | The header row. Set if other than the first non-empty row of the sheet. |  |
-| `--metadata` | string | Outputs workbook metadata in CSV or JSON format: index, sheet_name, headers, type, visible, column_count, row_count, safe_headers, safe_headers_count, unsafe_headers, unsafe_headers_count and duplicate_headers_count, names, name_count, tables, table_count. headers is a list of the first row which is presumed to be the header row. type is the sheet type (WorkSheet, DialogSheet, MacroSheet, ChartSheet, Vba). visible is the sheet visibility (Visible, Hidden, VeryHidden). row_count includes all rows, including the first row. safe_headers is a list of headers with "safe"(PostgreSQL-ready) names. unsafe_headers is a list of headers with "unsafe" names. duplicate_headers_count is a count of duplicate header names. names is a list of defined names in the workbook, with the associated formula. name_count is the number of defined names in the workbook. tables is a list of tables in the workbook, along with the sheet where the table is found, the columns and the column_count.  (XLSX only) table_count is the number of tables in the workbook.  (XLSX only) | `none` |
-| `--table` | string | An Excel table (case-insensitive) to extract to a CSV. Only valid for XLSX files. The --sheet option is ignored as a table could be in any sheet. Overrides --range option. |  |
-| `--range` | string | An Excel format range - like RangeName, C:T, C3:T25 or 'Sheet1!C3:T25' to extract to the CSV. If the specified range contains the required sheet, the --sheet option is ignored. If the range is not found, qsv will exit with an error. |  |
-| `--cell` | string | A single cell reference - like C3 or 'Sheet1!C3' to extract. This is a convenience option equivalent to --range C3:C3. If both --cell and --range are specified, --cell takes precedence. |  |
-| `--error-format` | string | The format to use when formatting error cells. There are 3 formats: * "code": return the error code. (#DIV/0!; #N/A; #NAME?; #NULL!; #NUM!; #REF!; #VALUE!; #DATA!) * "formula": return the formula, prefixed with '#'. (e.g. #=A1/B1 where B1 is 0; #=100/0) * "both": return both error code and the formula. (e.g. #DIV/0!: =A1/B1) | `code` |
-| `--flexible` | flag | Continue even if the number of columns is different from row to row. |  |
-| `--trim` | flag | Trim all fields so that leading & trailing whitespaces are removed. Also removes embedded linebreaks. |  |
-| `--date-format` | string | Optional date format to use when formatting dates. See <https://docs.rs/chrono/latest/chrono/format/strftime/index.html> for the full list of supported format specifiers. Note that if a date format is invalid, qsv will fall back and return the date as if no date-format was specified. |  |
-| `--keep-zero-time` | flag | Keep the time part of a date-time field if it is 00:00:00. By default, qsv will remove the time part if it is 00:00:00. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-s,`<br>`--sheet`&nbsp; | string | Name (case-insensitive) or zero-based index of sheet to export. Negative indices start from the end (-1 = last sheet). If the sheet cannot be found, qsv will read the first sheet. | `0` |
+| &nbsp;`--header-row`&nbsp; | string | The header row. Set if other than the first non-empty row of the sheet. |  |
+| &nbsp;`--metadata`&nbsp; | string | Outputs workbook metadata in CSV or JSON format: index, sheet_name, headers, type, visible, column_count, row_count, safe_headers, safe_headers_count, unsafe_headers, unsafe_headers_count and duplicate_headers_count, names, name_count, tables, table_count. headers is a list of the first row which is presumed to be the header row. type is the sheet type (WorkSheet, DialogSheet, MacroSheet, ChartSheet, Vba). visible is the sheet visibility (Visible, Hidden, VeryHidden). row_count includes all rows, including the first row. safe_headers is a list of headers with "safe"(PostgreSQL-ready) names. unsafe_headers is a list of headers with "unsafe" names. duplicate_headers_count is a count of duplicate header names. names is a list of defined names in the workbook, with the associated formula. name_count is the number of defined names in the workbook. tables is a list of tables in the workbook, along with the sheet where the table is found, the columns and the column_count.  (XLSX only) table_count is the number of tables in the workbook.  (XLSX only) | `none` |
+| &nbsp;`--table`&nbsp; | string | An Excel table (case-insensitive) to extract to a CSV. Only valid for XLSX files. The --sheet option is ignored as a table could be in any sheet. Overrides --range option. |  |
+| &nbsp;`--range`&nbsp; | string | An Excel format range - like RangeName, C:T, C3:T25 or 'Sheet1!C3:T25' to extract to the CSV. If the specified range contains the required sheet, the --sheet option is ignored. If the range is not found, qsv will exit with an error. |  |
+| &nbsp;`--cell`&nbsp; | string | A single cell reference - like C3 or 'Sheet1!C3' to extract. This is a convenience option equivalent to --range C3:C3. If both --cell and --range are specified, --cell takes precedence. |  |
+| &nbsp;`--error-format`&nbsp; | string | The format to use when formatting error cells. There are 3 formats: * "code": return the error code. (#DIV/0!; #N/A; #NAME?; #NULL!; #NUM!; #REF!; #VALUE!; #DATA!) * "formula": return the formula, prefixed with '#'. (e.g. #=A1/B1 where B1 is 0; #=100/0) * "both": return both error code and the formula. (e.g. #DIV/0!: =A1/B1) | `code` |
+| &nbsp;`--flexible`&nbsp; | flag | Continue even if the number of columns is different from row to row. |  |
+| &nbsp;`--trim`&nbsp; | flag | Trim all fields so that leading & trailing whitespaces are removed. Also removes embedded linebreaks. |  |
+| &nbsp;`--date-format`&nbsp; | string | Optional date format to use when formatting dates. See <https://docs.rs/chrono/latest/chrono/format/strftime/index.html> for the full list of supported format specifiers. Note that if a date format is invalid, qsv will fall back and return the date as if no date-format was specified. |  |
+| &nbsp;`--keep-zero-time`&nbsp; | flag | Keep the time part of a date-time field if it is 00:00:00. By default, qsv will remove the time part if it is 00:00:00. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -190,10 +190,10 @@ qsv excel --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
-| `-q,`<br>`--quiet` | flag | Do not display export summary message. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not display export summary message. |  |
 
 ---
 **Source:** [`src/cmd/excel.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/excel.rs)

--- a/docs/help/exclude.md
+++ b/docs/help/exclude.md
@@ -110,8 +110,8 @@ qsv exclude --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input1>` | is the file from which data will be removed. |
-| `<input2>` | is the file containing the data to be removed from <input1> e.g. 'qsv exclude id records.csv id previously-processed.csv' |
+| &nbsp;`<input1>`&nbsp; | is the file from which data will be removed. |
+| &nbsp;`<input2>`&nbsp; | is the file containing the data to be removed from <input1> e.g. 'qsv exclude id records.csv id previously-processed.csv' |
 
 <a name="exclude-options"></a>
 
@@ -119,8 +119,8 @@ qsv exclude --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--ignore-case` | flag | When set, matching is done case insensitively. |  |
-| `-v,`<br>`--invert` | flag | When set, matching rows will be the only ones included, forming set intersection, instead of the ones discarded. |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | When set, matching is done case insensitively. |  |
+| &nbsp;`-v,`<br>`--invert`&nbsp; | flag | When set, matching rows will be the only ones included, forming set intersection, instead of the ones discarded. |  |
 
 <a name="common-options"></a>
 
@@ -128,10 +128,10 @@ qsv exclude --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/exclude.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/exclude.rs)

--- a/docs/help/explode.md
+++ b/docs/help/explode.md
@@ -43,7 +43,7 @@ qsv explode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-r,`<br>`--rename` | string | New name for the exploded column. |  |
+| &nbsp;`-r,`<br>`--rename`&nbsp; | string | New name for the exploded column. |  |
 
 <a name="common-options"></a>
 
@@ -51,10 +51,10 @@ qsv explode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/explode.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/explode.rs)

--- a/docs/help/extdedup.md
+++ b/docs/help/extdedup.md
@@ -46,12 +46,12 @@ qsv extdedup --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--select` | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extdedup will work in LINE MODE, deduping the input as a text file on a line-by-line basis. |  |
-| `--no-output` | flag | Do not write deduplicated output to <output>. Use this if you only want to know the duplicate count. |  |
-| `-D,`<br>`--dupes-output` | string | Write duplicates to <file>. Note that the file will NOT be a valid CSV. It is a list of duplicate lines, with the row number of the duplicate separated by a tab from the duplicate line itself. |  |
-| `-H,`<br>`--human-readable` | flag | Comma separate duplicate count. |  |
-| `--memory-limit` | string | The maximum amount of memory to buffer the on-disk hash table. If less than 50, this is a percentage of total memory. If more than 50, this is the memory in MB to allocate, capped at 90 percent of total memory. | `10` |
-| `--temp-dir` | string | Directory to store temporary hash table file. If not specified, defaults to operating system temp directory. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to dedup. Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extdedup will work in LINE MODE, deduping the input as a text file on a line-by-line basis. |  |
+| &nbsp;`--no-output`&nbsp; | flag | Do not write deduplicated output to <output>. Use this if you only want to know the duplicate count. |  |
+| &nbsp;`-D,`<br>`--dupes-output`&nbsp; | string | Write duplicates to <file>. Note that the file will NOT be a valid CSV. It is a list of duplicate lines, with the row number of the duplicate separated by a tab from the duplicate line itself. |  |
+| &nbsp;`-H,`<br>`--human-readable`&nbsp; | flag | Comma separate duplicate count. |  |
+| &nbsp;`--memory-limit`&nbsp; | string | The maximum amount of memory to buffer the on-disk hash table. If less than 50, this is a percentage of total memory. If more than 50, this is the memory in MB to allocate, capped at 90 percent of total memory. | `10` |
+| &nbsp;`--temp-dir`&nbsp; | string | Directory to store temporary hash table file. If not specified, defaults to operating system temp directory. |  |
 
 <a name="csv-mode-only-options"></a>
 
@@ -59,10 +59,10 @@ qsv extdedup --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be deduped with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-q,`<br>`--quiet` | flag | Do not print duplicate count to stderr. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. That is, it will be deduped with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not print duplicate count to stderr. |  |
 
 ---
 **Source:** [`src/cmd/extdedup.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/extdedup.rs)

--- a/docs/help/extsort.md
+++ b/docs/help/extsort.md
@@ -39,11 +39,11 @@ qsv extsort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--select` | string | Select a subset of columns to sort (CSV MODE). Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extsort will work in LINE MODE, sorting the input as a text file on a line-by-line basis. |  |
-| `-R,`<br>`--reverse` | flag | Reverse order |  |
-| `--memory-limit` | string | The maximum amount of memory to buffer the external merge sort. If less than 50, this is a percentage of total memory. If more than 50, this is the memory in MB to allocate, capped at 90 percent of total memory. | `20` |
-| `--tmp-dir` | string | The directory to use for externally sorting file segments. | `./` |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to sort (CSV MODE). Note that the outputs will remain at the full width of the CSV. If --select is NOT set, extsort will work in LINE MODE, sorting the input as a text file on a line-by-line basis. |  |
+| &nbsp;`-R,`<br>`--reverse`&nbsp; | flag | Reverse order |  |
+| &nbsp;`--memory-limit`&nbsp; | string | The maximum amount of memory to buffer the external merge sort. If less than 50, this is a percentage of total memory. If more than 50, this is the memory in MB to allocate, capped at 90 percent of total memory. | `20` |
+| &nbsp;`--tmp-dir`&nbsp; | string | The directory to use for externally sorting file segments. | `./` |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="csv-mode-only-options"></a>
 
@@ -51,9 +51,9 @@ qsv extsort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers and will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers and will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
 
 ---
 **Source:** [`src/cmd/extsort.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/extsort.rs)

--- a/docs/help/fetch.md
+++ b/docs/help/fetch.md
@@ -183,20 +183,20 @@ qsv fetch --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--url-template` | string | URL template to use. Use column names enclosed with curly braces to insert the CSV data for a record. Mutually exclusive with url-column. |  |
-| `-c,`<br>`--new-column` | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
-| `--jaq` | string | Apply jaq selector to API returned JSON value. Mutually exclusive with --jaqfile, |  |
-| `--jaqfile` | string | Load jaq selector from file instead. Mutually exclusive with --jaq. |  |
-| `--pretty` | flag | Prettify JSON responses. Otherwise, they're minified. If the response is not in JSON format, it's passed through. Note that --pretty requires the --new-column option. |  |
-| `--rate-limit` | string | Rate Limit in Queries Per Second (max: 1000). Note that fetch dynamically throttles as well based on rate-limit and retry-after response headers. Set to 0 to go as fast as possible, automatically throttling as required. CAUTION: Only use zero for APIs that use RateLimit and/or Retry-After headers, otherwise your fetch job may look like a Denial Of Service attack. Even though zero is the default, this is mitigated by --max-errors having a default of 10. | `0` |
-| `--timeout` | string | Timeout for each URL request. | `30` |
-| `-H,`<br>`--http-header` | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
-| `--max-retries` | string | Maximum number of retries per record before an error is raised. | `5` |
-| `--max-errors` | string | Maximum number of errors before aborting. Set to zero (0) to continue despite errors. | `10` |
-| `--store-error` | flag | On error, store error code/message instead of blank value. |  |
-| `--cookies` | flag | Allow cookies. |  |
-| `--user-agent` | string | Specify custom user agent. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
-| `--report` | string | Creates a report of the fetch job. The report has the same name as the input file with the ".fetch-report" suffix. There are two kinds of report - d for "detailed" & s for "short". The detailed report has the same columns as the input CSV with six additional columns - qsv_fetch_url, qsv_fetch_status, qsv_fetch_cache_hit, qsv_fetch_retries, qsv_fetch_elapsed_ms & qsv_fetch_response. The short report only has the six columns without the "qsv_fetch_" prefix. | `none` |
+| &nbsp;`--url-template`&nbsp; | string | URL template to use. Use column names enclosed with curly braces to insert the CSV data for a record. Mutually exclusive with url-column. |  |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
+| &nbsp;`--jaq`&nbsp; | string | Apply jaq selector to API returned JSON value. Mutually exclusive with --jaqfile, |  |
+| &nbsp;`--jaqfile`&nbsp; | string | Load jaq selector from file instead. Mutually exclusive with --jaq. |  |
+| &nbsp;`--pretty`&nbsp; | flag | Prettify JSON responses. Otherwise, they're minified. If the response is not in JSON format, it's passed through. Note that --pretty requires the --new-column option. |  |
+| &nbsp;`--rate-limit`&nbsp; | string | Rate Limit in Queries Per Second (max: 1000). Note that fetch dynamically throttles as well based on rate-limit and retry-after response headers. Set to 0 to go as fast as possible, automatically throttling as required. CAUTION: Only use zero for APIs that use RateLimit and/or Retry-After headers, otherwise your fetch job may look like a Denial Of Service attack. Even though zero is the default, this is mitigated by --max-errors having a default of 10. | `0` |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for each URL request. | `30` |
+| &nbsp;`-H,`<br>`--http-header`&nbsp; | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
+| &nbsp;`--max-retries`&nbsp; | string | Maximum number of retries per record before an error is raised. | `5` |
+| &nbsp;`--max-errors`&nbsp; | string | Maximum number of errors before aborting. Set to zero (0) to continue despite errors. | `10` |
+| &nbsp;`--store-error`&nbsp; | flag | On error, store error code/message instead of blank value. |  |
+| &nbsp;`--cookies`&nbsp; | flag | Allow cookies. |  |
+| &nbsp;`--user-agent`&nbsp; | string | Specify custom user agent. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
+| &nbsp;`--report`&nbsp; | string | Creates a report of the fetch job. The report has the same name as the input file with the ".fetch-report" suffix. There are two kinds of report - d for "detailed" & s for "short". The detailed report has the same columns as the input CSV with six additional columns - qsv_fetch_url, qsv_fetch_status, qsv_fetch_cache_hit, qsv_fetch_retries, qsv_fetch_elapsed_ms & qsv_fetch_response. The short report only has the six columns without the "qsv_fetch_" prefix. | `none` |
 
 <a name="caching-options"></a>
 
@@ -204,13 +204,13 @@ qsv fetch --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--no-cache` | flag | Do not cache responses. |  |
-| `--mem-cache-size` | string | Maximum number of entries in the in-memory LRU cache. | `2000000` |
-| `--disk-cache` | flag | Use a persistent disk cache for responses. The cache is stored in the directory specified by --disk-cache-dir. If the directory does not exist, it will be created. If the directory exists, it will be used as is. It has a default Time To Live (TTL)/lifespan of 28 days and cache hits do not refresh the TTL of cached values. Adjust the QSV_DISKCACHE_TTL_SECS & QSV_DISKCACHE_TTL_REFRESH env vars to change DiskCache settings. |  |
-| `--disk-cache-dir` | string | The directory <dir> to store the disk cache. Note that if the directory does not exist, it will be created. If the directory exists, it will be used as is, and will not be flushed. This option allows you to maintain several disk caches for different fetch jobs (e.g. one for geocoding, another for weather, etc.) | `~/.qsv/cache/fetch` |
-| `--redis-cache` | flag | Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/1" with a connection pool size of 20, with a TTL of 28 days, and a cache hit NOT renewing an entry's TTL. Adjust the QSV_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS & QSV_REDIS_TTL_REFRESH env vars respectively to change Redis settings. This option is ignored if the --disk-cache option is enabled. |  |
-| `--cache-error` | flag | Cache error responses even if a request fails. If an identical URL is requested, the cached error is returned. Otherwise, the fetch is attempted again for --max-retries. |  |
-| `--flush-cache` | flag | Flush all the keys in the current cache on startup. This only applies to Disk and Redis caches. |  |
+| &nbsp;`--no-cache`&nbsp; | flag | Do not cache responses. |  |
+| &nbsp;`--mem-cache-size`&nbsp; | string | Maximum number of entries in the in-memory LRU cache. | `2000000` |
+| &nbsp;`--disk-cache`&nbsp; | flag | Use a persistent disk cache for responses. The cache is stored in the directory specified by --disk-cache-dir. If the directory does not exist, it will be created. If the directory exists, it will be used as is. It has a default Time To Live (TTL)/lifespan of 28 days and cache hits do not refresh the TTL of cached values. Adjust the QSV_DISKCACHE_TTL_SECS & QSV_DISKCACHE_TTL_REFRESH env vars to change DiskCache settings. |  |
+| &nbsp;`--disk-cache-dir`&nbsp; | string | The directory <dir> to store the disk cache. Note that if the directory does not exist, it will be created. If the directory exists, it will be used as is, and will not be flushed. This option allows you to maintain several disk caches for different fetch jobs (e.g. one for geocoding, another for weather, etc.) | `~/.qsv/cache/fetch` |
+| &nbsp;`--redis-cache`&nbsp; | flag | Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/1" with a connection pool size of 20, with a TTL of 28 days, and a cache hit NOT renewing an entry's TTL. Adjust the QSV_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS & QSV_REDIS_TTL_REFRESH env vars respectively to change Redis settings. This option is ignored if the --disk-cache option is enabled. |  |
+| &nbsp;`--cache-error`&nbsp; | flag | Cache error responses even if a request fails. If an identical URL is requested, the cached error is returned. Otherwise, the fetch is attempted again for --max-retries. |  |
+| &nbsp;`--flush-cache`&nbsp; | flag | Flush all the keys in the current cache on startup. This only applies to Disk and Redis caches. |  |
 
 <a name="common-options"></a>
 
@@ -218,11 +218,11 @@ qsv fetch --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/fetch.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fetch.rs)

--- a/docs/help/fetchpost.md
+++ b/docs/help/fetchpost.md
@@ -170,8 +170,8 @@ qsv fetchpost --help
 
 | Argument | Description |
 |----------|-------------|
-| `<url-column>` | Name of the column with the URL. Otherwise, if the argument starts with `http`, the URL to use. |
-| `<column-list>` | Comma-delimited list of columns to insert into the HTTP Post body. Uses `qsv select` syntax - i.e. Columns can be referenced by index or by name if there is a header row (duplicate column names can be disambiguated with more indexing). Column ranges can also be specified. Finally, columns can be selected using regular expressions. See 'qsv select --help' for examples. |
+| &nbsp;`<url-column>`&nbsp; | Name of the column with the URL. Otherwise, if the argument starts with `http`, the URL to use. |
+| &nbsp;`<column-list>`&nbsp; | Comma-delimited list of columns to insert into the HTTP Post body. Uses `qsv select` syntax - i.e. Columns can be referenced by index or by name if there is a header row (duplicate column names can be disambiguated with more indexing). Column ranges can also be specified. Finally, columns can be selected using regular expressions. See 'qsv select --help' for examples. |
 
 <a name="fetchpost-options"></a>
 
@@ -179,23 +179,23 @@ qsv fetchpost --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-t,`<br>`--payload-tpl` | string | Instead of <column-list>, use a MiniJinja template file to render a JSON payload in the HTTP Post body. You can also use --payload-tpl to render a non-JSON payload, but --content-type will have to be set manually. If a rendered JSON is invalid, `fetchpost` will abort and return an error. |  |
-| `--content-type` | string | Overrides automatic content types for `<column-list>` (`application/x-www-form-urlencoded`) and `--payload-tpl` (`application/json`). Typical alternative values are `multipart/form-data` and `text/plain`. It is the responsibility of the user to format the payload accordingly when using --payload-tpl. |  |
-| `-j,`<br>`--globals-json` | string | A JSON file containing global variables. When posting as an HTML Form, this file is added to the Form data. When constructing a payload using a MiniJinja template, the JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.api_key}}, {{qsv_g.base_url}}). |  |
-| `-c,`<br>`--new-column` | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
-| `--jaq` | string | Apply jaq selector to API returned JSON response. Mutually exclusive with --jaqfile. |  |
-| `--jaqfile` | string | Load jaq selector from file instead. Mutually exclusive with --jaq. |  |
-| `--pretty` | flag | Prettify JSON responses. Otherwise, they're minified. If the response is not in JSON format, it's passed through unchanged. Note that --pretty requires the --new-column option. |  |
-| `--rate-limit` | string | Rate Limit in Queries Per Second (max: 1000). Note that fetch dynamically throttles as well based on rate-limit and retry-after response headers. Set to 0 to go as fast as possible, automatically throttling as required. CAUTION: Only use zero for APIs that use RateLimit and/or Retry-After headers, otherwise your fetchpost job may look like a Denial Of Service attack. Even though zero is the default, this is mitigated by --max-errors having a default of 10. | `0` |
-| `--timeout` | string | Timeout for each URL request. | `30` |
-| `-H,`<br>`--http-header` | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
-| `--compress` | flag | Compress the HTTP request body using gzip. Note that most servers do not support compressed request bodies unless they are specifically configured to do so. This should only be enabled for trusted scenarios where "zip bombs" are not a concern. see <https://github.com/postmanlabs/httpbin/issues/577#issuecomment-875814469> for more info. |  |
-| `--max-retries` | string | Maximum number of retries per record before an error is raised. | `5` |
-| `--max-errors` | string | Maximum number of errors before aborting. Set to zero (0) to continue despite errors. | `10` |
-| `--store-error` | flag | On error, store error code/message instead of blank value. |  |
-| `--cookies` | flag | Allow cookies. |  |
-| `--user-agent` | string | Specify custom user agent. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
-| `--report` | string | Creates a report of the fetchpost job. The report has the same name as the input file with the ".fetchpost-report" suffix. There are two kinds of report - d for "detailed" & s for "short". The detailed report has the same columns as the input CSV with seven additional columns - qsv_fetchp_url, qsv_fetchp_form, qsv_fetchp_status, qsv_fetchp_cache_hit, qsv_fetchp_retries, qsv_fetchp_elapsed_ms & qsv_fetchp_response. The short report only has the seven columns without the "qsv_fetchp_" prefix. | `none` |
+| &nbsp;`-t,`<br>`--payload-tpl`&nbsp; | string | Instead of <column-list>, use a MiniJinja template file to render a JSON payload in the HTTP Post body. You can also use --payload-tpl to render a non-JSON payload, but --content-type will have to be set manually. If a rendered JSON is invalid, `fetchpost` will abort and return an error. |  |
+| &nbsp;`--content-type`&nbsp; | string | Overrides automatic content types for `<column-list>` (`application/x-www-form-urlencoded`) and `--payload-tpl` (`application/json`). Typical alternative values are `multipart/form-data` and `text/plain`. It is the responsibility of the user to format the payload accordingly when using --payload-tpl. |  |
+| &nbsp;`-j,`<br>`--globals-json`&nbsp; | string | A JSON file containing global variables. When posting as an HTML Form, this file is added to the Form data. When constructing a payload using a MiniJinja template, the JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.api_key}}, {{qsv_g.base_url}}). |  |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | Put the fetched values in a new column. Specifying this option results in a CSV. Otherwise, the output is in JSONL format. |  |
+| &nbsp;`--jaq`&nbsp; | string | Apply jaq selector to API returned JSON response. Mutually exclusive with --jaqfile. |  |
+| &nbsp;`--jaqfile`&nbsp; | string | Load jaq selector from file instead. Mutually exclusive with --jaq. |  |
+| &nbsp;`--pretty`&nbsp; | flag | Prettify JSON responses. Otherwise, they're minified. If the response is not in JSON format, it's passed through unchanged. Note that --pretty requires the --new-column option. |  |
+| &nbsp;`--rate-limit`&nbsp; | string | Rate Limit in Queries Per Second (max: 1000). Note that fetch dynamically throttles as well based on rate-limit and retry-after response headers. Set to 0 to go as fast as possible, automatically throttling as required. CAUTION: Only use zero for APIs that use RateLimit and/or Retry-After headers, otherwise your fetchpost job may look like a Denial Of Service attack. Even though zero is the default, this is mitigated by --max-errors having a default of 10. | `0` |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for each URL request. | `30` |
+| &nbsp;`-H,`<br>`--http-header`&nbsp; | string | Append custom header(s) to the HTTP header. Pass multiple key-value pairs by adding this option multiple times, once for each pair. The key and value should be separated by a colon. |  |
+| &nbsp;`--compress`&nbsp; | flag | Compress the HTTP request body using gzip. Note that most servers do not support compressed request bodies unless they are specifically configured to do so. This should only be enabled for trusted scenarios where "zip bombs" are not a concern. see <https://github.com/postmanlabs/httpbin/issues/577#issuecomment-875814469> for more info. |  |
+| &nbsp;`--max-retries`&nbsp; | string | Maximum number of retries per record before an error is raised. | `5` |
+| &nbsp;`--max-errors`&nbsp; | string | Maximum number of errors before aborting. Set to zero (0) to continue despite errors. | `10` |
+| &nbsp;`--store-error`&nbsp; | flag | On error, store error code/message instead of blank value. |  |
+| &nbsp;`--cookies`&nbsp; | flag | Allow cookies. |  |
+| &nbsp;`--user-agent`&nbsp; | string | Specify custom user agent. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
+| &nbsp;`--report`&nbsp; | string | Creates a report of the fetchpost job. The report has the same name as the input file with the ".fetchpost-report" suffix. There are two kinds of report - d for "detailed" & s for "short". The detailed report has the same columns as the input CSV with seven additional columns - qsv_fetchp_url, qsv_fetchp_form, qsv_fetchp_status, qsv_fetchp_cache_hit, qsv_fetchp_retries, qsv_fetchp_elapsed_ms & qsv_fetchp_response. The short report only has the seven columns without the "qsv_fetchp_" prefix. | `none` |
 
 <a name="caching-options"></a>
 
@@ -203,13 +203,13 @@ qsv fetchpost --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--no-cache` | flag | Do not cache responses. |  |
-| `--mem-cache-size` | string | Maximum number of entries in the in-memory LRU cache. | `2000000` |
-| `--disk-cache` | flag | Use a persistent disk cache for responses. The cache is stored in the directory specified by --disk-cache-dir. If the directory does not exist, it will be created. If the directory exists, it will be used as is. It has a default Time To Live (TTL)/lifespan of 28 days and cache hits do not refresh the TTL of cached values. Adjust the QSV_DISKCACHE_TTL_SECS & QSV_DISKCACHE_TTL_REFRESH env vars to change DiskCache settings. |  |
-| `--disk-cache-dir` | string | The directory <dir> to store the disk cache. Note that if the directory does not exist, it will be created. If the directory exists, it will be used as is, and will not be flushed. This option allows you to maintain several disk caches for different fetchpost jobs (e.g. one for geocoding, another for weather, etc.) | `~/.qsv/cache/fetchpost` |
-| `--redis-cache` | flag | Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/2" with a connection pool size of 20, with a TTL of 28 days, and a cache hit NOT renewing an entry's TTL. Adjust the QSV_FP_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS & QSV_REDIS_TTL_REFRESH respectively to change Redis settings. |  |
-| `--cache-error` | flag | Cache error responses even if a request fails. If an identical URL is requested, the cached error is returned. Otherwise, the fetch is attempted again for --max-retries. |  |
-| `--flush-cache` | flag | Flush all the keys in the current cache on startup. This only applies to Disk and Redis caches. |  |
+| &nbsp;`--no-cache`&nbsp; | flag | Do not cache responses. |  |
+| &nbsp;`--mem-cache-size`&nbsp; | string | Maximum number of entries in the in-memory LRU cache. | `2000000` |
+| &nbsp;`--disk-cache`&nbsp; | flag | Use a persistent disk cache for responses. The cache is stored in the directory specified by --disk-cache-dir. If the directory does not exist, it will be created. If the directory exists, it will be used as is. It has a default Time To Live (TTL)/lifespan of 28 days and cache hits do not refresh the TTL of cached values. Adjust the QSV_DISKCACHE_TTL_SECS & QSV_DISKCACHE_TTL_REFRESH env vars to change DiskCache settings. |  |
+| &nbsp;`--disk-cache-dir`&nbsp; | string | The directory <dir> to store the disk cache. Note that if the directory does not exist, it will be created. If the directory exists, it will be used as is, and will not be flushed. This option allows you to maintain several disk caches for different fetchpost jobs (e.g. one for geocoding, another for weather, etc.) | `~/.qsv/cache/fetchpost` |
+| &nbsp;`--redis-cache`&nbsp; | flag | Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/2" with a connection pool size of 20, with a TTL of 28 days, and a cache hit NOT renewing an entry's TTL. Adjust the QSV_FP_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS & QSV_REDIS_TTL_REFRESH respectively to change Redis settings. |  |
+| &nbsp;`--cache-error`&nbsp; | flag | Cache error responses even if a request fails. If an identical URL is requested, the cached error is returned. Otherwise, the fetch is attempted again for --max-retries. |  |
+| &nbsp;`--flush-cache`&nbsp; | flag | Flush all the keys in the current cache on startup. This only applies to Disk and Redis caches. |  |
 
 <a name="common-options"></a>
 
@@ -217,11 +217,11 @@ qsv fetchpost --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/fetchpost.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fetchpost.rs)

--- a/docs/help/fill.md
+++ b/docs/help/fill.md
@@ -59,10 +59,10 @@ qsv fill --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g,`<br>`--groupby` | string | Group by specified columns. |  |
-| `-f,`<br>`--first` | flag | Fill using the first valid value of a column, instead of the latest. |  |
-| `-b,`<br>`--backfill` | flag | Fill initial empty values with the first valid value. |  |
-| `-v,`<br>`--default` | string | Fill using this default value. |  |
+| &nbsp;`-g,`<br>`--groupby`&nbsp; | string | Group by specified columns. |  |
+| &nbsp;`-f,`<br>`--first`&nbsp; | flag | Fill using the first valid value of a column, instead of the latest. |  |
+| &nbsp;`-b,`<br>`--backfill`&nbsp; | flag | Fill initial empty values with the first valid value. |  |
+| &nbsp;`-v,`<br>`--default`&nbsp; | string | Fill using this default value. |  |
 
 <a name="common-options"></a>
 
@@ -70,10 +70,10 @@ qsv fill --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/fill.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fill.rs)

--- a/docs/help/fixlengths.md
+++ b/docs/help/fixlengths.md
@@ -38,11 +38,11 @@ qsv fixlengths --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-l,`<br>`--length` | string | Forcefully set the length of each record. If a record is not the size given, then it is truncated or expanded as appropriate. |  |
-| `-r,`<br>`--remove-empty` | flag | Remove empty columns. |  |
-| `-i,`<br>`--insert` | string | If empty fields need to be inserted, insert them at <pos>. If <pos> is zero, then it is inserted at the end of each record. If <pos> is negative, it is inserted from the END of each record going backwards. If <pos> is positive, it is inserted from the BEGINNING of each record going forward. | `0` |
-| `--quote` | string | The quote character to use. | `"` |
-| `--escape` | string | The escape character to use. When not specified, quotes are escaped by doubling them. |  |
+| &nbsp;`-l,`<br>`--length`&nbsp; | string | Forcefully set the length of each record. If a record is not the size given, then it is truncated or expanded as appropriate. |  |
+| &nbsp;`-r,`<br>`--remove-empty`&nbsp; | flag | Remove empty columns. |  |
+| &nbsp;`-i,`<br>`--insert`&nbsp; | string | If empty fields need to be inserted, insert them at <pos>. If <pos> is zero, then it is inserted at the end of each record. If <pos> is negative, it is inserted from the END of each record going backwards. If <pos> is positive, it is inserted from the BEGINNING of each record going forward. | `0` |
+| &nbsp;`--quote`&nbsp; | string | The quote character to use. | `"` |
+| &nbsp;`--escape`&nbsp; | string | The escape character to use. When not specified, quotes are escaped by doubling them. |  |
 
 <a name="common-options"></a>
 
@@ -50,10 +50,10 @@ qsv fixlengths --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-q,`<br>`--quiet` | flag | Don't print removed column information. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Don't print removed column information. |  |
 
 ---
 **Source:** [`src/cmd/fixlengths.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fixlengths.rs)

--- a/docs/help/flatten.md
+++ b/docs/help/flatten.md
@@ -37,9 +37,9 @@ qsv flatten --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c,`<br>`--condense` | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
-| `-f,`<br>`--field-separator` | string | A string of character to write between a column name and its value. |  |
-| `-s,`<br>`--separator` | string | A string of characters to write after each record. When non-empty, a new line is automatically appended to the separator. | `#` |
+| &nbsp;`-c,`<br>`--condense`&nbsp; | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
+| &nbsp;`-f,`<br>`--field-separator`&nbsp; | string | A string of character to write between a column name and its value. |  |
+| &nbsp;`-s,`<br>`--separator`&nbsp; | string | A string of characters to write after each record. When non-empty, a new line is automatically appended to the separator. | `#` |
 
 <a name="common-options"></a>
 
@@ -47,9 +47,9 @@ qsv flatten --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. When set, the name of each field will be its index. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. When set, the name of each field will be its index. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/flatten.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/flatten.rs)

--- a/docs/help/fmt.md
+++ b/docs/help/fmt.md
@@ -37,14 +37,14 @@ qsv fmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-t,`<br>`--out-delimiter` | string | The field delimiter for writing CSV data. Must be a single character. If set to "T", uses tab as the delimiter. | `,` |
-| `--crlf` | flag | Use '\r\n' line endings in the output. |  |
-| `--ascii` | flag | Use ASCII field and record separators. Use Substitute (U+00A1) as the quote character. |  |
-| `--quote` | string | The quote character to use. | `"` |
-| `--quote-always` | flag | Put quotes around every value. |  |
-| `--quote-never` | flag | Never put quotes around any value. |  |
-| `--escape` | string | The escape character to use. When not specified, quotes are escaped by doubling them. |  |
-| `--no-final-newline` | flag | Do not write a newline at the end of the output. This makes it easier to paste the output into Excel. |  |
+| &nbsp;`-t,`<br>`--out-delimiter`&nbsp; | string | The field delimiter for writing CSV data. Must be a single character. If set to "T", uses tab as the delimiter. | `,` |
+| &nbsp;`--crlf`&nbsp; | flag | Use '\r\n' line endings in the output. |  |
+| &nbsp;`--ascii`&nbsp; | flag | Use ASCII field and record separators. Use Substitute (U+00A1) as the quote character. |  |
+| &nbsp;`--quote`&nbsp; | string | The quote character to use. | `"` |
+| &nbsp;`--quote-always`&nbsp; | flag | Put quotes around every value. |  |
+| &nbsp;`--quote-never`&nbsp; | flag | Never put quotes around any value. |  |
+| &nbsp;`--escape`&nbsp; | string | The escape character to use. When not specified, quotes are escaped by doubling them. |  |
+| &nbsp;`--no-final-newline`&nbsp; | flag | Do not write a newline at the end of the output. This makes it easier to paste the output into Excel. |  |
 
 <a name="common-options"></a>
 
@@ -52,9 +52,9 @@ qsv fmt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/fmt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/fmt.rs)

--- a/docs/help/foreach.md
+++ b/docs/help/foreach.md
@@ -66,9 +66,9 @@ qsv foreach --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-u,`<br>`--unify` | flag | If the output of the executed command is a CSV, unify the result by skipping headers on each subsequent command. Does not work when --dry-run is true. |  |
-| `-c,`<br>`--new-column` | string | If unifying, add a new column with given name and copying the value of the current input file line. |  |
-| `--dry-run` | string | If set to true (the default for safety reasons), the commands are sent to stdout instead of executing them. If set to a file, the commands will be written to the specified text file instead of executing them. Only if set to false will the commands be actually executed. | `true` |
+| &nbsp;`-u,`<br>`--unify`&nbsp; | flag | If the output of the executed command is a CSV, unify the result by skipping headers on each subsequent command. Does not work when --dry-run is true. |  |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | If unifying, add a new column with given name and copying the value of the current input file line. |  |
+| &nbsp;`--dry-run`&nbsp; | string | If set to true (the default for safety reasons), the commands are sent to stdout instead of executing them. If set to a file, the commands will be written to the specified text file instead of executing them. Only if set to false will the commands be actually executed. | `true` |
 
 <a name="common-options"></a>
 
@@ -76,10 +76,10 @@ qsv foreach --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the file will be considered to have no headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the file will be considered to have no headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/foreach.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/foreach.rs)

--- a/docs/help/frequency.md
+++ b/docs/help/frequency.md
@@ -97,27 +97,27 @@ qsv frequency --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--select` | string | Select a subset of columns to compute frequencies for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv frequency' will disable the use of indexing. |  |
-| `-l,`<br>`--limit` | string | Limit the frequency table to the N most common items. Set to '0' to disable a limit. If negative, only return values with an occurrence count >= absolute value of the negative limit. e.g. --limit -2 will only return values with an occurrence count >= 2. | `10` |
-| `-u,`<br>`--unq-limit` | string | If a column has all unique values, limit the frequency table to a sample of N unique items. Set to '0' to disable a unique_limit. | `10` |
-| `--lmt-threshold` | string | The threshold for which --limit and --unq-limit will be applied. If the number of unique items in a column >= threshold, the limits will be applied. Set to '0' to disable the threshold and always apply limits. | `0` |
-| `-r,`<br>`--rank-strategy` | string | The strategy to use when there are count-tied values in the frequency table. See <https://en.wikipedia.org/wiki/Ranking> for more info. | `dense` |
-| `--pct-dec-places` | string | The number of decimal places to round the percentage to. If negative, the number of decimal places will be set automatically to the minimum number of decimal places needed to represent the percentage accurately, up to the absolute value of the negative number. | `-5` |
-| `--other-sorted` | flag | By default, the "Other" category is placed at the end of the frequency table for a field. If this is enabled, the "Other" category will be sorted with the rest of the values by count. |  |
-| `--other-text` | string | The text to use for the "Other" category. If set to "<NONE>", the "Other" category will not be included in the frequency table. | `Other` |
-| `--no-other` | flag | Don't include the "Other" category in the frequency table. This is equivalent to --other-text "<NONE>". |  |
-| `--null-sorted` | flag | By default, the NULL category (controlled by --null-text) is placed at the end of the frequency table for a field, after "Other" if present. If this is enabled, the NULL category will be sorted with the rest of the values by count. |  |
-| `-a,`<br>`--asc` | flag | Sort the frequency tables in ascending order by count. The default is descending order. Note that this option will also reverse ranking - i.e. the LEAST frequent values will have a rank of 1. |  |
-| `--no-trim` | flag | Don't trim whitespace from values when computing frequencies. The default is to trim leading and trailing whitespaces. |  |
-| `--null-text` | string | The text to use for NULL values. If set to "<NONE>", NULLs will not be included in the frequency table (equivalent to --no-nulls). | `(NULL)` |
-| `--no-nulls` | flag | Don't include NULLs in the frequency table. This is equivalent to --null-text "<NONE>". |  |
-| `--pct-nulls` | flag | Include NULL values in percentage and rank calculations. When disabled (default), percentages are "valid percentages" calculated with NULLs excluded from the denominator, and NULL entries display empty percentage and rank values. When enabled, NULLs are included in the denominator (original behavior). Has no effect when --no-nulls is set. |  |
-| `-i,`<br>`--ignore-case` | flag | Ignore case when computing frequencies. |  |
-| `--no-float` | string | Exclude Float columns from frequency analysis. Floats typically contain continuous values where frequency tables are not meaningful. To exclude ALL Float columns, use --no-float "*" To exclude Floats except specific columns, specify a comma-separated list of Float columns to INCLUDE. e.g. "--no-float *" excludes all Floats "--no-float price,rate" excludes Floats except 'price' and 'rate' Requires stats cache for type detection. |  |
-| `--stats-filter` | string | Filter columns based on their statistics using a Luau expression. Columns where the expression evaluates to `true` are EXCLUDED. Available fields: field, type, is_ascii, cardinality, nullcount, sum, min, max, range, sort_order, min_length, max_length, mean, stddev, variance, cv, sparsity, q1, q2_median, q3, iqr, mad, skewness, mode, antimode, n_negative, n_zero, n_positive, etc. e.g. "nullcount > 1000" - exclude columns with many nulls "type == 'Float'" - exclude Float columns "cardinality > 500 and nullcount > 0" - compound expression Requires stats cache and the "luau" feature. |  |
-| `--all-unique-text` | string | The text to use for the "<ALL_UNIQUE>" category. | `<ALL_UNIQUE>` |
-| `--vis-whitespace` | flag | Visualize whitespace characters in the output. See <https://github.com/dathere/qsv/wiki/Supplemental#whitespace-markers> for the list of whitespace markers. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to compute frequencies for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv frequency' will disable the use of indexing. |  |
+| &nbsp;`-l,`<br>`--limit`&nbsp; | string | Limit the frequency table to the N most common items. Set to '0' to disable a limit. If negative, only return values with an occurrence count >= absolute value of the negative limit. e.g. --limit -2 will only return values with an occurrence count >= 2. | `10` |
+| &nbsp;`-u,`<br>`--unq-limit`&nbsp; | string | If a column has all unique values, limit the frequency table to a sample of N unique items. Set to '0' to disable a unique_limit. | `10` |
+| &nbsp;`--lmt-threshold`&nbsp; | string | The threshold for which --limit and --unq-limit will be applied. If the number of unique items in a column >= threshold, the limits will be applied. Set to '0' to disable the threshold and always apply limits. | `0` |
+| &nbsp;`-r,`<br>`--rank-strategy`&nbsp; | string | The strategy to use when there are count-tied values in the frequency table. See <https://en.wikipedia.org/wiki/Ranking> for more info. | `dense` |
+| &nbsp;`--pct-dec-places`&nbsp; | string | The number of decimal places to round the percentage to. If negative, the number of decimal places will be set automatically to the minimum number of decimal places needed to represent the percentage accurately, up to the absolute value of the negative number. | `-5` |
+| &nbsp;`--other-sorted`&nbsp; | flag | By default, the "Other" category is placed at the end of the frequency table for a field. If this is enabled, the "Other" category will be sorted with the rest of the values by count. |  |
+| &nbsp;`--other-text`&nbsp; | string | The text to use for the "Other" category. If set to "<NONE>", the "Other" category will not be included in the frequency table. | `Other` |
+| &nbsp;`--no-other`&nbsp; | flag | Don't include the "Other" category in the frequency table. This is equivalent to --other-text "<NONE>". |  |
+| &nbsp;`--null-sorted`&nbsp; | flag | By default, the NULL category (controlled by --null-text) is placed at the end of the frequency table for a field, after "Other" if present. If this is enabled, the NULL category will be sorted with the rest of the values by count. |  |
+| &nbsp;`-a,`<br>`--asc`&nbsp; | flag | Sort the frequency tables in ascending order by count. The default is descending order. Note that this option will also reverse ranking - i.e. the LEAST frequent values will have a rank of 1. |  |
+| &nbsp;`--no-trim`&nbsp; | flag | Don't trim whitespace from values when computing frequencies. The default is to trim leading and trailing whitespaces. |  |
+| &nbsp;`--null-text`&nbsp; | string | The text to use for NULL values. If set to "<NONE>", NULLs will not be included in the frequency table (equivalent to --no-nulls). | `(NULL)` |
+| &nbsp;`--no-nulls`&nbsp; | flag | Don't include NULLs in the frequency table. This is equivalent to --null-text "<NONE>". |  |
+| &nbsp;`--pct-nulls`&nbsp; | flag | Include NULL values in percentage and rank calculations. When disabled (default), percentages are "valid percentages" calculated with NULLs excluded from the denominator, and NULL entries display empty percentage and rank values. When enabled, NULLs are included in the denominator (original behavior). Has no effect when --no-nulls is set. |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Ignore case when computing frequencies. |  |
+| &nbsp;`--no-float`&nbsp; | string | Exclude Float columns from frequency analysis. Floats typically contain continuous values where frequency tables are not meaningful. To exclude ALL Float columns, use --no-float "*" To exclude Floats except specific columns, specify a comma-separated list of Float columns to INCLUDE. e.g. "--no-float *" excludes all Floats "--no-float price,rate" excludes Floats except 'price' and 'rate' Requires stats cache for type detection. |  |
+| &nbsp;`--stats-filter`&nbsp; | string | Filter columns based on their statistics using a Luau expression. Columns where the expression evaluates to `true` are EXCLUDED. Available fields: field, type, is_ascii, cardinality, nullcount, sum, min, max, range, sort_order, min_length, max_length, mean, stddev, variance, cv, sparsity, q1, q2_median, q3, iqr, mad, skewness, mode, antimode, n_negative, n_zero, n_positive, etc. e.g. "nullcount > 1000" - exclude columns with many nulls "type == 'Float'" - exclude Float columns "cardinality > 500 and nullcount > 0" - compound expression Requires stats cache and the "luau" feature. |  |
+| &nbsp;`--all-unique-text`&nbsp; | string | The text to use for the "<ALL_UNIQUE>" category. | `<ALL_UNIQUE>` |
+| &nbsp;`--vis-whitespace`&nbsp; | flag | Visualize whitespace characters in the output. See <https://github.com/dathere/qsv/wiki/Supplemental#whitespace-markers> for the list of whitespace markers. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
 <a name="json-output-options"></a>
 
@@ -125,11 +125,11 @@ qsv frequency --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--json` | flag | Output frequency table as nested JSON instead of CSV. The JSON output includes additional metadata: row count, field count, data type, cardinality, null count, sparsity, uniqueness_ratio and 17 additional stats (e.g. sum, min, max, range, sort_order, mean, sem, etc.). |  |
-| `--pretty-json` | flag | Same as --json but pretty prints the JSON output. |  |
-| `--toon` | flag | Output frequency table and select stats in TOON format instead of CSV. TOON is a compact, human-readable encoding of the JSON data model for LLM prompts. See <https://toonformat.dev/> for more info. |  |
-| `--no-stats` | flag | When using the JSON or TOON output mode, do not include the additional stats. |  |
-| `--weight` | string | Compute weighted frequencies using the specified column as weights. The weight column must be numeric. When specified, frequency counts are multiplied by the weight value for each row. The weight column is automatically excluded from frequency computation. Missing or unparsable weights default to 1.0. Zero, negative, NaN and infinite weights are ignored and do not contribute to frequencies. |  |
+| &nbsp;`--json`&nbsp; | flag | Output frequency table as nested JSON instead of CSV. The JSON output includes additional metadata: row count, field count, data type, cardinality, null count, sparsity, uniqueness_ratio and 17 additional stats (e.g. sum, min, max, range, sort_order, mean, sem, etc.). |  |
+| &nbsp;`--pretty-json`&nbsp; | flag | Same as --json but pretty prints the JSON output. |  |
+| &nbsp;`--toon`&nbsp; | flag | Output frequency table and select stats in TOON format instead of CSV. TOON is a compact, human-readable encoding of the JSON data model for LLM prompts. See <https://toonformat.dev/> for more info. |  |
+| &nbsp;`--no-stats`&nbsp; | flag | When using the JSON or TOON output mode, do not include the additional stats. |  |
+| &nbsp;`--weight`&nbsp; | string | Compute weighted frequencies using the specified column as weights. The weight column must be numeric. When specified, frequency counts are multiplied by the weight value for each row. The weight column is automatically excluded from frequency computation. Missing or unparsable weights default to 1.0. Zero, negative, NaN and infinite weights are ignored and do not contribute to frequencies. |  |
 
 <a name="common-options"></a>
 
@@ -137,11 +137,11 @@ qsv frequency --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be included in the frequency table. Additionally, the 'field' column will be 1-based indices instead of header names. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will NOT be included in the frequency table. Additionally, the 'field' column will be 1-based indices instead of header names. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---
 **Source:** [`src/cmd/frequency.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/frequency.rs)

--- a/docs/help/geocode.md
+++ b/docs/help/geocode.md
@@ -352,10 +352,10 @@ qsv geocode --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The input file to read from. If not specified, reads from stdin. |
-| `<column>` | The column to geocode. Used by suggest, reverse & countryinfo subcommands. For suggest, it must be a column with a City string pattern. For reverse, it must be a column using WGS 84 coordinates in "lat, long" or "(lat, long)" format. For countryinfo, it must be a column with a ISO 3166-1 alpha-2 country code. For iplookup, it must be a column with an IP address or a URL. Note that you can use column selector syntax to select the column, but only the first column will be used. See `select --help` for more information. |
-| `<location>` | The location to geocode for suggestnow, reversenow, countryinfonow and iplookupnow subcommands. For suggestnow, its a City string pattern. For reversenow, it must be a WGS 84 coordinate. For countryinfonow, it must be a ISO 3166-1 alpha-2 code. For iplookupnow, it must be an IP address or a URL. |
-| `<index-file>` | The alternate geonames index file to use. It must be a .rkyv file. For convenience, if this is set to 500, 1000, 5000 or 15000, it will download the corresponding English-only Geonames index rkyv file from the qsv GitHub repo for the current qsv version and use it. Only used by the index-load subcommand. |
+| &nbsp;`<input>`&nbsp; | The input file to read from. If not specified, reads from stdin. |
+| &nbsp;`<column>`&nbsp; | The column to geocode. Used by suggest, reverse & countryinfo subcommands. For suggest, it must be a column with a City string pattern. For reverse, it must be a column using WGS 84 coordinates in "lat, long" or "(lat, long)" format. For countryinfo, it must be a column with a ISO 3166-1 alpha-2 country code. For iplookup, it must be a column with an IP address or a URL. Note that you can use column selector syntax to select the column, but only the first column will be used. See `select --help` for more information. |
+| &nbsp;`<location>`&nbsp; | The location to geocode for suggestnow, reversenow, countryinfonow and iplookupnow subcommands. For suggestnow, its a City string pattern. For reversenow, it must be a WGS 84 coordinate. For countryinfonow, it must be a ISO 3166-1 alpha-2 code. For iplookupnow, it must be an IP address or a URL. |
+| &nbsp;`<index-file>`&nbsp; | The alternate geonames index file to use. It must be a .rkyv file. For convenience, if this is set to 500, 1000, 5000 or 15000, it will download the corresponding English-only Geonames index rkyv file from the qsv GitHub repo for the current qsv version and use it. Only used by the index-load subcommand. |
 
 <a name="geocode-options"></a>
 
@@ -363,9 +363,9 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-c,`<br>`--new-column` | string | Put the transformed values in a new column instead. Not valid when using the '%dyncols:' --formatstr option. |  |
-| `-r,`<br>`--rename` | string | New name for the transformed column. |  |
-| `--country` | string | The comma-delimited, case-insensitive list of countries to filter for. Country is specified as a ISO 3166-1 alpha-2 (two-letter) country code. <https://en.wikipedia.org/wiki/ISO_3166-2> |  |
+| &nbsp;`-c,`<br>`--new-column`&nbsp; | string | Put the transformed values in a new column instead. Not valid when using the '%dyncols:' --formatstr option. |  |
+| &nbsp;`-r,`<br>`--rename`&nbsp; | string | New name for the transformed column. |  |
+| &nbsp;`--country`&nbsp; | string | The comma-delimited, case-insensitive list of countries to filter for. Country is specified as a ISO 3166-1 alpha-2 (two-letter) country code. <https://en.wikipedia.org/wiki/ISO_3166-2> |  |
 
 <a name="suggest-only-options"></a>
 
@@ -373,8 +373,8 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--min-score` | string | The minimum Jaro-Winkler distance score. | `0.8` |
-| `--admin1` | string | The comma-delimited, case-insensitive list of admin1s to filter for. |  |
+| &nbsp;`--min-score`&nbsp; | string | The minimum Jaro-Winkler distance score. | `0.8` |
+| &nbsp;`--admin1`&nbsp; | string | The comma-delimited, case-insensitive list of admin1s to filter for. |  |
 
 <a name="reverse-only-option"></a>
 
@@ -382,7 +382,7 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-k,`<br>`--k_weight` | string | Use population-weighted distance for reverse subcommand. (i.e. nearest.distance - k * city.population) Larger values will favor more populated cities. If not set (default), the population is not used and the nearest city is returned. |  |
+| &nbsp;`-k,`<br>`--k_weight`&nbsp; | string | Use population-weighted distance for reverse subcommand. (i.e. nearest.distance - k * city.population) Larger values will favor more populated cities. If not set (default), the population is not used and the nearest city is returned. |  |
 
 <a name="dynamic-formatting-options"></a>
 
@@ -390,12 +390,12 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-l,`<br>`--language` | string | The language to use when geocoding. The language is specified as a ISO 639-1 code. Note that the Geonames index must have been built with the specified language using the `index-update` subcommand with the --languages option. If the language is not available, the first language in the index is used. | `en` |
-| `--invalid-result` | string | The string to return when the geocode result is empty/invalid. If not set, the original value is used. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
-| `--timeout` | string | Timeout for downloading Geonames cities index. | `120` |
-| `--cache-dir` | string | The directory to use for caching the Geonames cities index. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
+| &nbsp;`-l,`<br>`--language`&nbsp; | string | The language to use when geocoding. The language is specified as a ISO 639-1 code. Note that the Geonames index must have been built with the specified language using the `index-update` subcommand with the --languages option. If the language is not available, the first language in the index is used. | `en` |
+| &nbsp;`--invalid-result`&nbsp; | string | The string to return when the geocode result is empty/invalid. If not set, the original value is used. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for downloading Geonames cities index. | `120` |
+| &nbsp;`--cache-dir`&nbsp; | string | The directory to use for caching the Geonames cities index. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
 
 <a name="index-update-only-options"></a>
 
@@ -403,9 +403,9 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--languages` | string | The comma-delimited, case-insensitive list of languages to use when building the Geonames cities index. The languages are specified as a comma-separated list of ISO 639-2 codes. See <https://download.geonames.org/export/dump/iso-languagecodes.txt> to look up codes and <https://download.geonames.org/export/dump/alternatenames/> for the supported language files. 253 languages are currently supported. | `en` |
-| `--cities-url` | string | The URL to download the Geonames cities file from. There are several available at <https://download.geonames.org/export/dump/>. cities500.zip   - cities with populations > 500; ~200k cities, 56mb cities1000.zip  - population > 1000; ~140k cities, 44mb cities5000.zip  - population > 5000; ~53k cities, 21mb cities15000.zip - population > 15000; ~26k cities, 13mb Note that the more cities are included, the larger the local index file will be, lookup times will be slower, and the search results will be different. For convenience, if this is set to 500, 1000, 5000 or 15000, it will be converted to a geonames cities URL. | `https://download.geonames.org/export/dump/cities15000.zip` |
-| `--force` | flag | Force update the Geonames cities index. If not set, qsv will check if there are updates available at Geonames.org before updating the index. |  |
+| &nbsp;`--languages`&nbsp; | string | The comma-delimited, case-insensitive list of languages to use when building the Geonames cities index. The languages are specified as a comma-separated list of ISO 639-2 codes. See <https://download.geonames.org/export/dump/iso-languagecodes.txt> to look up codes and <https://download.geonames.org/export/dump/alternatenames/> for the supported language files. 253 languages are currently supported. | `en` |
+| &nbsp;`--cities-url`&nbsp; | string | The URL to download the Geonames cities file from. There are several available at <https://download.geonames.org/export/dump/>. cities500.zip   - cities with populations > 500; ~200k cities, 56mb cities1000.zip  - population > 1000; ~140k cities, 44mb cities5000.zip  - population > 5000; ~53k cities, 21mb cities15000.zip - population > 15000; ~26k cities, 13mb Note that the more cities are included, the larger the local index file will be, lookup times will be slower, and the search results will be different. For convenience, if this is set to 500, 1000, 5000 or 15000, it will be converted to a geonames cities URL. | `https://download.geonames.org/export/dump/cities15000.zip` |
+| &nbsp;`--force`&nbsp; | flag | Force update the Geonames cities index. If not set, qsv will check if there are updates available at Geonames.org before updating the index. |  |
 
 <a name="common-options"></a>
 
@@ -413,10 +413,10 @@ qsv geocode --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Will also show the cache hit rate upon completion. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/geocode.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/geocode.rs)

--- a/docs/help/geoconvert.md
+++ b/docs/help/geoconvert.md
@@ -57,9 +57,9 @@ qsv geoconvert --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The spatial file to convert. To use stdin instead, use a dash "-". Note: SHP input must be a path to a .shp file and cannot use stdin. |
-| `<input-format>` | Valid values are "geojson", "shp", and "csv" |
-| `<output-format>` | Valid values are: |
+| &nbsp;`<input>`&nbsp; | The spatial file to convert. To use stdin instead, use a dash "-". Note: SHP input must be a path to a .shp file and cannot use stdin. |
+| &nbsp;`<input-format>`&nbsp; | Valid values are "geojson", "shp", and "csv" |
+| &nbsp;`<output-format>`&nbsp; | Valid values are: |
 
 <a name="geoconvert-options"></a>
 
@@ -67,10 +67,10 @@ qsv geoconvert --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g,`<br>`--geometry` | string | The name of the column that has WKT geometry. Alternative to --latitude and --longitude. |  |
-| `-y,`<br>`--latitude` | string | The name of the column with northing values. |  |
-| `-x,`<br>`--longitude` | string | The name of the column with easting values. |  |
-| `-l,`<br>`--max-length` | string | The maximum column length when the output format is CSV. Oftentimes, the geometry column is too long to fit in a CSV file, causing other tools like Python & PostgreSQL to fail. If a column is too long, it will be truncated to the specified length and an ellipsis ("...") will be appended. |  |
+| &nbsp;`-g,`<br>`--geometry`&nbsp; | string | The name of the column that has WKT geometry. Alternative to --latitude and --longitude. |  |
+| &nbsp;`-y,`<br>`--latitude`&nbsp; | string | The name of the column with northing values. |  |
+| &nbsp;`-x,`<br>`--longitude`&nbsp; | string | The name of the column with easting values. |  |
+| &nbsp;`-l,`<br>`--max-length`&nbsp; | string | The maximum column length when the output format is CSV. Oftentimes, the geometry column is too long to fit in a CSV file, causing other tools like Python & PostgreSQL to fail. If a column is too long, it will be truncated to the specified length and an ellipsis ("...") will be appended. |  |
 
 <a name="common-options"></a>
 
@@ -78,8 +78,8 @@ qsv geoconvert --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
 
 ---
 **Source:** [`src/cmd/geoconvert.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/geoconvert.rs)

--- a/docs/help/headers.md
+++ b/docs/help/headers.md
@@ -37,7 +37,7 @@ qsv headers --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | ...             The CSV file(s) to read. Use '-' for standard input. If input is a directory, all files in the directory will be read as input. If the input is a file with a '.infile-list' extension, the file will be read as a list of input files. If the input are snappy-compressed files(s), it will be decompressed automatically. |
+| &nbsp;`<input>`&nbsp; | ...             The CSV file(s) to read. Use '-' for standard input. If input is a directory, all files in the directory will be read as input. If the input is a file with a '.infile-list' extension, the file will be read as a list of input files. If the input are snappy-compressed files(s), it will be decompressed automatically. |
 
 <a name="headers-options"></a>
 
@@ -45,10 +45,10 @@ qsv headers --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-j,`<br>`--just-names` | flag | Only show the header names (hide column index). This is automatically enabled if more than one input is given. |  |
-| `-J,`<br>`--just-count` | flag | Only show the number of headers. |  |
-| `--intersect` | flag | Shows the intersection of all headers in all of the inputs given. |  |
-| `--trim` | flag | Trim space & quote characters from header name. |  |
+| &nbsp;`-j,`<br>`--just-names`&nbsp; | flag | Only show the header names (hide column index). This is automatically enabled if more than one input is given. |  |
+| &nbsp;`-J,`<br>`--just-count`&nbsp; | flag | Only show the number of headers. |  |
+| &nbsp;`--intersect`&nbsp; | flag | Shows the intersection of all headers in all of the inputs given. |  |
+| &nbsp;`--trim`&nbsp; | flag | Trim space & quote characters from header name. |  |
 
 <a name="common-options"></a>
 
@@ -56,8 +56,8 @@ qsv headers --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/headers.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/headers.rs)

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -40,7 +40,7 @@ qsv index --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-o,`<br>`--output` | string | Write index to <file> instead of <input>.idx. Generally, this is not currently useful because the only way to use an index is if it is specially named <input>.idx. |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write index to <file> instead of <input>.idx. Generally, this is not currently useful because the only way to use an index is if it is specially named <input>.idx. |  |
 
 <a name="common-options"></a>
 
@@ -48,7 +48,7 @@ qsv index --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/index.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/index.rs)

--- a/docs/help/input.md
+++ b/docs/help/input.md
@@ -53,17 +53,17 @@ qsv input --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--quote` | string | The quote character to use. | `"` |
-| `--escape` | string | The escape character to use. When not specified, quotes are escaped by doubling them. |  |
-| `--no-quoting` | flag | Disable quoting completely when reading CSV data. |  |
-| `--quote-style` | string | The quoting style to use when writing CSV data. Possible values: all, necessary, nonnumeric and never. All: Quotes all fields. Necessary: Quotes fields only when necessary - when fields contain a quote, delimiter or record terminator. Quotes are also necessary when writing an empty record (which is indistinguishable from a record with one empty field). NonNumeric: Quotes all fields that are non-numeric. Never: Never write quotes. Even if it produces invalid CSV. | `necessary` |
-| `--skip-lines` | string | The number of preamble lines to skip. |  |
-| `--auto-skip` | flag | Sniffs a CSV for preamble lines and automatically skips them. Takes precedence over --skip-lines option. Does not work with <stdin>. |  |
-| `--skip-lastlines` | string | The number of epilogue lines to skip. |  |
-| `--trim-headers` | flag | Trim leading & trailing whitespace & quotes from header values. |  |
-| `--trim-fields` | flag | Trim leading & trailing whitespace from field values. |  |
-| `--comment` | string | The comment character to use. When set, lines starting with this character will be skipped. |  |
-| `--encoding-errors` | string | How to handle UTF-8 encoding errors. Possible values: replace, skip, strict. replace: Replace invalid UTF-8 sequences with �. skip: Fields with encoding errors are "<SKIPPED>". strict: Fail on any encoding errors. | `replace` |
+| &nbsp;`--quote`&nbsp; | string | The quote character to use. | `"` |
+| &nbsp;`--escape`&nbsp; | string | The escape character to use. When not specified, quotes are escaped by doubling them. |  |
+| &nbsp;`--no-quoting`&nbsp; | flag | Disable quoting completely when reading CSV data. |  |
+| &nbsp;`--quote-style`&nbsp; | string | The quoting style to use when writing CSV data. Possible values: all, necessary, nonnumeric and never. All: Quotes all fields. Necessary: Quotes fields only when necessary - when fields contain a quote, delimiter or record terminator. Quotes are also necessary when writing an empty record (which is indistinguishable from a record with one empty field). NonNumeric: Quotes all fields that are non-numeric. Never: Never write quotes. Even if it produces invalid CSV. | `necessary` |
+| &nbsp;`--skip-lines`&nbsp; | string | The number of preamble lines to skip. |  |
+| &nbsp;`--auto-skip`&nbsp; | flag | Sniffs a CSV for preamble lines and automatically skips them. Takes precedence over --skip-lines option. Does not work with <stdin>. |  |
+| &nbsp;`--skip-lastlines`&nbsp; | string | The number of epilogue lines to skip. |  |
+| &nbsp;`--trim-headers`&nbsp; | flag | Trim leading & trailing whitespace & quotes from header values. |  |
+| &nbsp;`--trim-fields`&nbsp; | flag | Trim leading & trailing whitespace from field values. |  |
+| &nbsp;`--comment`&nbsp; | string | The comment character to use. When set, lines starting with this character will be skipped. |  |
+| &nbsp;`--encoding-errors`&nbsp; | string | How to handle UTF-8 encoding errors. Possible values: replace, skip, strict. replace: Replace invalid UTF-8 sequences with �. skip: Fields with encoding errors are "<SKIPPED>". strict: Fail on any encoding errors. | `replace` |
 
 <a name="common-options"></a>
 
@@ -71,9 +71,9 @@ qsv input --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/input.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/input.rs)

--- a/docs/help/join.md
+++ b/docs/help/join.md
@@ -38,9 +38,9 @@ qsv join --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input1>` | is the first CSV data set to join. |
-| `<input2>` | is the second CSV data set to join. |
-| `<columns1>` | & <columns2> are the columns to join on for each input. |
+| &nbsp;`<input1>`&nbsp; | is the first CSV data set to join. |
+| &nbsp;`<input2>`&nbsp; | is the second CSV data set to join. |
+| &nbsp;`<columns1>`&nbsp; | & <columns2> are the columns to join on for each input. |
 
 <a name="join-options"></a>
 
@@ -48,16 +48,16 @@ qsv join --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--left` | flag | Do a 'left outer' join. This returns all rows in first CSV data set, including rows with no corresponding row in the second data set. When no corresponding row exists, it is padded out with empty fields. |  |
-| `--left-anti` | flag | Do a 'left anti' join. This returns all rows in first CSV data set that has no match with the second data set. |  |
-| `--left-semi` | flag | Do a 'left semi' join. This returns all rows in first CSV data set that has a match with the second data set. |  |
-| `--right` | flag | Do a 'right outer' join. This returns all rows in second CSV data set, including rows with no corresponding row in the first data set. When no corresponding row exists, it is padded out with empty fields. (This is the reverse of 'outer left'.) |  |
-| `--right-anti` | flag | This returns only the rows in the second CSV data set that do not have a corresponding row in the first data set. The output schema is the same as the second dataset. |  |
-| `--right-semi` | flag | This returns only the rows in the second CSV data set that have a corresponding row in the first data set. The output schema is the same as the second data set. |  |
-| `--full` | flag | Do a 'full outer' join. This returns all rows in both data sets with matching records joined. If there is no match, the missing side will be padded out with empty fields. (This is the combination of 'outer left' and 'outer right'.) |  |
-| `--cross` | flag | USE WITH CAUTION. This returns the cartesian product of the CSV data sets given. The number of rows return is equal to N * M, where N and M correspond to the number of rows in the given data sets, respectively. |  |
-| `--nulls` | flag | When set, joins will work on empty fields. Otherwise, empty fields are completely ignored. (In fact, any row that has an empty field in the key specified is ignored.) |  |
-| `--keys-output` | string | Write successfully joined keys to <file>. This means that the keys are written to the output file when a match is found, with the exception of anti joins, where keys are written when NO match is found. Cross joins do not write keys. |  |
+| &nbsp;`--left`&nbsp; | flag | Do a 'left outer' join. This returns all rows in first CSV data set, including rows with no corresponding row in the second data set. When no corresponding row exists, it is padded out with empty fields. |  |
+| &nbsp;`--left-anti`&nbsp; | flag | Do a 'left anti' join. This returns all rows in first CSV data set that has no match with the second data set. |  |
+| &nbsp;`--left-semi`&nbsp; | flag | Do a 'left semi' join. This returns all rows in first CSV data set that has a match with the second data set. |  |
+| &nbsp;`--right`&nbsp; | flag | Do a 'right outer' join. This returns all rows in second CSV data set, including rows with no corresponding row in the first data set. When no corresponding row exists, it is padded out with empty fields. (This is the reverse of 'outer left'.) |  |
+| &nbsp;`--right-anti`&nbsp; | flag | This returns only the rows in the second CSV data set that do not have a corresponding row in the first data set. The output schema is the same as the second dataset. |  |
+| &nbsp;`--right-semi`&nbsp; | flag | This returns only the rows in the second CSV data set that have a corresponding row in the first data set. The output schema is the same as the second data set. |  |
+| &nbsp;`--full`&nbsp; | flag | Do a 'full outer' join. This returns all rows in both data sets with matching records joined. If there is no match, the missing side will be padded out with empty fields. (This is the combination of 'outer left' and 'outer right'.) |  |
+| &nbsp;`--cross`&nbsp; | flag | USE WITH CAUTION. This returns the cartesian product of the CSV data sets given. The number of rows return is equal to N * M, where N and M correspond to the number of rows in the given data sets, respectively. |  |
+| &nbsp;`--nulls`&nbsp; | flag | When set, joins will work on empty fields. Otherwise, empty fields are completely ignored. (In fact, any row that has an empty field in the key specified is ignored.) |  |
+| &nbsp;`--keys-output`&nbsp; | string | Write successfully joined keys to <file>. This means that the keys are written to the output file when a match is found, with the exception of anti joins, where keys are written when NO match is found. Cross joins do not write keys. |  |
 
 <a name="join-key-transformation-options"></a>
 
@@ -65,8 +65,8 @@ qsv join --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--ignore-case` | flag | When set, joins are done case insensitively. |  |
-| `-z,`<br>`--ignore-leading-zeros` | flag | When set, leading zeros are ignored in join keys. |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | When set, joins are done case insensitively. |  |
+| &nbsp;`-z,`<br>`--ignore-leading-zeros`&nbsp; | flag | When set, leading zeros are ignored in join keys. |  |
 
 <a name="common-options"></a>
 
@@ -74,10 +74,10 @@ qsv join --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/join.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/join.rs)

--- a/docs/help/joinp.md
+++ b/docs/help/joinp.md
@@ -42,19 +42,19 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--left` | flag | Do a 'left outer' join. This returns all rows in first CSV data set, including rows with no corresponding row in the second data set. When no corresponding row exists, it is padded out with empty fields. |  |
-| `--left-anti` | flag | This returns only the rows in the first CSV data set that do not have a corresponding row in the second data set. The output schema is the same as the first dataset. |  |
-| `--left-semi` | flag | This returns only the rows in the first CSV data set that have a corresponding row in the second data set. The output schema is the same as the first data set. |  |
-| `--right` | flag | Do a 'right outer' join. This returns all rows in second CSV data set, including rows with no corresponding row in the first data set. When no corresponding row exists, it is padded out with empty fields. (This is the reverse of 'outer left'.) |  |
-| `--right-anti` | flag | This returns only the rows in the second CSV data set that do not have a corresponding row in the first data set. The output schema is the same as the second dataset. |  |
-| `--right-semi` | flag | This returns only the rows in the second CSV data set that have a corresponding row in the first data set. The output schema is the same as the second data set. |  |
-| `--full` | flag | Do a 'full outer' join. This returns all rows in both data sets with matching records joined. If there is no match, the missing side will be padded out with empty fields. |  |
-| `--cross` | flag | USE WITH CAUTION. This returns the cartesian product of the CSV data sets given. The number of rows return is equal to N * M, where N and M correspond to the number of rows in the given data sets, respectively. The columns1 and columns2 arguments are ignored. |  |
-| `--non-equi` | string | Do a non-equi join. The given expression is evaluated for each row in the left dataset and can refer to columns in the left and right dataset. If the expression evaluates to true, the row is joined with the corresponding row in the right dataset. The expression is a valid Polars SQL where clause, with each column name followed by "_left" or "_right" suffixes to indicate which data set the column belongs to. (e.g. "salary_left >= min_salary_right AND \ salary_left <= max_salary_right AND \ experience_left >= min_exp_right") |  |
-| `--coalesce` | flag | Force the join to coalesce columns with the same name. For inner joins, this is not necessary as the join columns are automatically coalesced. |  |
-| `--filter-left` | string | Filter the left CSV data set by the given Polars SQL expression BEFORE the join. Only rows that evaluates to true are used in the join. |  |
-| `--filter-right` | string | Filter the right CSV data set by the given Polars SQL expression BEFORE the join. Only rows that evaluates to true are used in the join. |  |
-| `--validate` | string | Validate the join keys BEFORE performing the join. | `none` |
+| &nbsp;`--left`&nbsp; | flag | Do a 'left outer' join. This returns all rows in first CSV data set, including rows with no corresponding row in the second data set. When no corresponding row exists, it is padded out with empty fields. |  |
+| &nbsp;`--left-anti`&nbsp; | flag | This returns only the rows in the first CSV data set that do not have a corresponding row in the second data set. The output schema is the same as the first dataset. |  |
+| &nbsp;`--left-semi`&nbsp; | flag | This returns only the rows in the first CSV data set that have a corresponding row in the second data set. The output schema is the same as the first data set. |  |
+| &nbsp;`--right`&nbsp; | flag | Do a 'right outer' join. This returns all rows in second CSV data set, including rows with no corresponding row in the first data set. When no corresponding row exists, it is padded out with empty fields. (This is the reverse of 'outer left'.) |  |
+| &nbsp;`--right-anti`&nbsp; | flag | This returns only the rows in the second CSV data set that do not have a corresponding row in the first data set. The output schema is the same as the second dataset. |  |
+| &nbsp;`--right-semi`&nbsp; | flag | This returns only the rows in the second CSV data set that have a corresponding row in the first data set. The output schema is the same as the second data set. |  |
+| &nbsp;`--full`&nbsp; | flag | Do a 'full outer' join. This returns all rows in both data sets with matching records joined. If there is no match, the missing side will be padded out with empty fields. |  |
+| &nbsp;`--cross`&nbsp; | flag | USE WITH CAUTION. This returns the cartesian product of the CSV data sets given. The number of rows return is equal to N * M, where N and M correspond to the number of rows in the given data sets, respectively. The columns1 and columns2 arguments are ignored. |  |
+| &nbsp;`--non-equi`&nbsp; | string | Do a non-equi join. The given expression is evaluated for each row in the left dataset and can refer to columns in the left and right dataset. If the expression evaluates to true, the row is joined with the corresponding row in the right dataset. The expression is a valid Polars SQL where clause, with each column name followed by "_left" or "_right" suffixes to indicate which data set the column belongs to. (e.g. "salary_left >= min_salary_right AND \ salary_left <= max_salary_right AND \ experience_left >= min_exp_right") |  |
+| &nbsp;`--coalesce`&nbsp; | flag | Force the join to coalesce columns with the same name. For inner joins, this is not necessary as the join columns are automatically coalesced. |  |
+| &nbsp;`--filter-left`&nbsp; | string | Filter the left CSV data set by the given Polars SQL expression BEFORE the join. Only rows that evaluates to true are used in the join. |  |
+| &nbsp;`--filter-right`&nbsp; | string | Filter the right CSV data set by the given Polars SQL expression BEFORE the join. Only rows that evaluates to true are used in the join. |  |
+| &nbsp;`--validate`&nbsp; | string | Validate the join keys BEFORE performing the join. | `none` |
 
 <a name="join-options"></a>
 
@@ -62,9 +62,9 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--maintain-order` | string | Which row order to preserve, if any. Valid values are: none, left, right, left_right, right_left Do not rely on any observed ordering without explicitly setting this parameter. Not specifying any order can improve performance. Supported for inner, left, right and full joins. | `none` |
-| `--nulls` | flag | When set, joins will work on empty fields. Otherwise, empty fields are completely ignored. |  |
-| `--streaming` | flag | When set, the join will be done in a streaming fashion. Only use this when you get out of memory errors. |  |
+| &nbsp;`--maintain-order`&nbsp; | string | Which row order to preserve, if any. Valid values are: none, left, right, left_right, right_left Do not rely on any observed ordering without explicitly setting this parameter. Not specifying any order can improve performance. Supported for inner, left, right and full joins. | `none` |
+| &nbsp;`--nulls`&nbsp; | flag | When set, joins will work on empty fields. Otherwise, empty fields are completely ignored. |  |
+| &nbsp;`--streaming`&nbsp; | flag | When set, the join will be done in a streaming fashion. Only use this when you get out of memory errors. |  |
 
 <a name="polars-csv-parsing-options"></a>
 
@@ -72,13 +72,13 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--try-parsedates` | flag | When set, will attempt to parse the columns as dates. If the parse fails, columns remain as strings. This is useful when the join keys are formatted as dates with differing date formats, as the date formats will be normalized. Note that this will be automatically enabled when using asof joins. |  |
-| `--infer-len` | string | The number of rows to scan when inferring the schema of the CSV. Set to 0 to do a full table scan (warning: very slow). Only used when --cache-schema is 0 or 1 and no cached schema exists or when --infer-len is 0. | `10000` |
-| `--cache-schema` | string | Create and cache Polars schema JSON files. Ignored when --infer-len is 0. ‎ -2: treat all columns as String. A Polars schema file is created & cached. ‎ -1: treat all columns as String. No Polars schema file is created. 0: do not cache Polars schema. Uses --infer-len to infer schema. 1: cache Polars schema with the following behavior: * If schema file exists and is newer than input: use cached schema * If schema file missing/outdated and stats cache exists: derive schema from stats and cache it * If no schema or stats cache: infer schema using --infer-len and cache the result Schema files use the same name as input with .pschema.json extension (e.g., data.csv -> data.pschema.json) NOTE: If the input files have pschema.json files that are newer or created at the same time as the input files, they will be used to inform the join operation regardless of the value of --cache-schema unless --infer-len is 0. | `0` |
-| `--low-memory` | flag | Use low memory mode when parsing CSVs. This will use less memory but will be slower. It will also process the join in streaming mode. Only use this when you get out of memory errors. |  |
-| `--no-optimizations` | flag | Disable non-default join optimizations. This will make joins slower. Only use this when you get join errors. |  |
-| `--ignore-errors` | flag | Ignore errors when parsing CSVs. If set, rows with errors will be skipped. If not set, the query will fail. Only use this when debugging queries, as polars does batched parsing and will skip the entire batch where the error occurred. To get more detailed error messages, set the environment variable POLARS_BACKTRACE_IN_ERR=1 before running the join. |  |
-| `--decimal-comma` | flag | Use comma as the decimal separator when parsing & writing CSVs. Otherwise, use period as the decimal separator. Note that you'll need to set --delimiter to an alternate delimiter other than the default comma if you are using this option. |  |
+| &nbsp;`--try-parsedates`&nbsp; | flag | When set, will attempt to parse the columns as dates. If the parse fails, columns remain as strings. This is useful when the join keys are formatted as dates with differing date formats, as the date formats will be normalized. Note that this will be automatically enabled when using asof joins. |  |
+| &nbsp;`--infer-len`&nbsp; | string | The number of rows to scan when inferring the schema of the CSV. Set to 0 to do a full table scan (warning: very slow). Only used when --cache-schema is 0 or 1 and no cached schema exists or when --infer-len is 0. | `10000` |
+| &nbsp;`--cache-schema`&nbsp; | string | Create and cache Polars schema JSON files. Ignored when --infer-len is 0. ‎ -2: treat all columns as String. A Polars schema file is created & cached. ‎ -1: treat all columns as String. No Polars schema file is created. 0: do not cache Polars schema. Uses --infer-len to infer schema. 1: cache Polars schema with the following behavior: * If schema file exists and is newer than input: use cached schema * If schema file missing/outdated and stats cache exists: derive schema from stats and cache it * If no schema or stats cache: infer schema using --infer-len and cache the result Schema files use the same name as input with .pschema.json extension (e.g., data.csv -> data.pschema.json) NOTE: If the input files have pschema.json files that are newer or created at the same time as the input files, they will be used to inform the join operation regardless of the value of --cache-schema unless --infer-len is 0. | `0` |
+| &nbsp;`--low-memory`&nbsp; | flag | Use low memory mode when parsing CSVs. This will use less memory but will be slower. It will also process the join in streaming mode. Only use this when you get out of memory errors. |  |
+| &nbsp;`--no-optimizations`&nbsp; | flag | Disable non-default join optimizations. This will make joins slower. Only use this when you get join errors. |  |
+| &nbsp;`--ignore-errors`&nbsp; | flag | Ignore errors when parsing CSVs. If set, rows with errors will be skipped. If not set, the query will fail. Only use this when debugging queries, as polars does batched parsing and will skip the entire batch where the error occurred. To get more detailed error messages, set the environment variable POLARS_BACKTRACE_IN_ERR=1 before running the join. |  |
+| &nbsp;`--decimal-comma`&nbsp; | flag | Use comma as the decimal separator when parsing & writing CSVs. Otherwise, use period as the decimal separator. Note that you'll need to set --delimiter to an alternate delimiter other than the default comma if you are using this option. |  |
 
 <a name="asof-join-options"></a>
 
@@ -86,13 +86,13 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--asof` | flag | Do an 'asof' join. This is similar to a left inner join, except we match on nearest key rather than equal keys (see --allow-exact-matches). Particularly useful for time series data. Note that both CSV data sets will be SORTED on the join columns by default, unless --no-sort is set. |  |
-| `--no-sort` | flag | Do not sort the CSV data sets on the join columns by default. Note that asof joins REQUIRE the join keys to be sorted, so this option should only be used as a performance optimization when you know the CSV join keys are already sorted. If the CSV join keys are not sorted, the asof join will fail or return incorrect results. |  |
-| `--left_by` | string | Do an 'asof_by' join - a special implementation of the asof join that searches for the nearest keys within a subgroup set by the asof_by columns. This specifies the column/s for the left CSV. Columns are referenced by name. Specify multiple columns by separating them with a comma. |  |
-| `--right_by` | string | Do an 'asof_by' join. This specifies the column/s for the right CSV. |  |
-| `--strategy` | string | The strategy to use for the asof join: backward - For each row in the first CSV data set, we find the last row in the second data set whose key is less than or equal to the key in the first data set. forward -  For each row in the first CSV data set, we find the first row in the second data set whose key is greater than or equal to the key in the first data set. nearest -  selects the last row in the second data set whose value is nearest to the value in the first data set. | `backward` |
-| `--tolerance` | string | The tolerance for the nearest asof join. This is only used when the nearest strategy is used. The tolerance is a positive integer that specifies the maximum number of rows to search for a match. |  |
-| `-X,`<br>`--allow-exact-matches` | flag | When set, the asof join will allow exact matches. (i.e. less-than-or-equal-to or greater-than-or-equal-to) Otherwise, the asof join will only allow nearest matches (strictly less-than or greater-than) by default. |  |
+| &nbsp;`--asof`&nbsp; | flag | Do an 'asof' join. This is similar to a left inner join, except we match on nearest key rather than equal keys (see --allow-exact-matches). Particularly useful for time series data. Note that both CSV data sets will be SORTED on the join columns by default, unless --no-sort is set. |  |
+| &nbsp;`--no-sort`&nbsp; | flag | Do not sort the CSV data sets on the join columns by default. Note that asof joins REQUIRE the join keys to be sorted, so this option should only be used as a performance optimization when you know the CSV join keys are already sorted. If the CSV join keys are not sorted, the asof join will fail or return incorrect results. |  |
+| &nbsp;`--left_by`&nbsp; | string | Do an 'asof_by' join - a special implementation of the asof join that searches for the nearest keys within a subgroup set by the asof_by columns. This specifies the column/s for the left CSV. Columns are referenced by name. Specify multiple columns by separating them with a comma. |  |
+| &nbsp;`--right_by`&nbsp; | string | Do an 'asof_by' join. This specifies the column/s for the right CSV. |  |
+| &nbsp;`--strategy`&nbsp; | string | The strategy to use for the asof join: backward - For each row in the first CSV data set, we find the last row in the second data set whose key is less than or equal to the key in the first data set. forward -  For each row in the first CSV data set, we find the first row in the second data set whose key is greater than or equal to the key in the first data set. nearest -  selects the last row in the second data set whose value is nearest to the value in the first data set. | `backward` |
+| &nbsp;`--tolerance`&nbsp; | string | The tolerance for the nearest asof join. This is only used when the nearest strategy is used. The tolerance is a positive integer that specifies the maximum number of rows to search for a match. |  |
+| &nbsp;`-X,`<br>`--allow-exact-matches`&nbsp; | flag | When set, the asof join will allow exact matches. (i.e. less-than-or-equal-to or greater-than-or-equal-to) Otherwise, the asof join will only allow nearest matches (strictly less-than or greater-than) by default. |  |
 
 <a name="output-format-options"></a>
 
@@ -100,12 +100,12 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--sql-filter` | string | The SQL expression to apply against the join result. Used to select columns and filter rows AFTER running the join. Be sure to select from the "join_result" table when formulating the SQL expression. (e.g. "select c1, c2 as colname from join_result where c2 > 20") |  |
-| `--datetime-format` | string | The datetime format to use writing datetimes. See <https://docs.rs/chrono/latest/chrono/format/strftime/index.html> for the list of valid format specifiers. |  |
-| `--date-format` | string | The date format to use writing dates. |  |
-| `--time-format` | string | The time format to use writing times. |  |
-| `--float-precision` | string | The number of digits of precision to use when writing floats. (default: 6) |  |
-| `--null-value` | string | The string to use when writing null values. (default: <empty string>) |  |
+| &nbsp;`--sql-filter`&nbsp; | string | The SQL expression to apply against the join result. Used to select columns and filter rows AFTER running the join. Be sure to select from the "join_result" table when formulating the SQL expression. (e.g. "select c1, c2 as colname from join_result where c2 > 20") |  |
+| &nbsp;`--datetime-format`&nbsp; | string | The datetime format to use writing datetimes. See <https://docs.rs/chrono/latest/chrono/format/strftime/index.html> for the list of valid format specifiers. |  |
+| &nbsp;`--date-format`&nbsp; | string | The date format to use writing dates. |  |
+| &nbsp;`--time-format`&nbsp; | string | The time format to use writing times. |  |
+| &nbsp;`--float-precision`&nbsp; | string | The number of digits of precision to use when writing floats. (default: 6) |  |
+| &nbsp;`--null-value`&nbsp; | string | The string to use when writing null values. (default: <empty string>) |  |
 
 <a name="join-key-transformation-options"></a>
 
@@ -113,9 +113,9 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--ignore-case` | flag | When set, joins are done case insensitively. |  |
-| `-z,`<br>`--ignore-leading-zeros` | flag | When set, joins are done ignoring leading zeros. Note that this is only applied to the join keys for both numeric and string columns. Also note that Polars will automatically remove leading zeros from numeric columns when it infers the schema. To force the schema to be all String types, set --cache-schema to -1 or -2. |  |
-| `-N,`<br>`--norm-unicode` | string | When set, join keys are Unicode normalized. | `none` |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | When set, joins are done case insensitively. |  |
+| &nbsp;`-z,`<br>`--ignore-leading-zeros`&nbsp; | flag | When set, joins are done ignoring leading zeros. Note that this is only applied to the join keys for both numeric and string columns. Also note that Polars will automatically remove leading zeros from numeric columns when it infers the schema. To force the schema to be all String types, set --cache-schema to -1 or -2. |  |
+| &nbsp;`-N,`<br>`--norm-unicode`&nbsp; | string | When set, join keys are Unicode normalized. | `none` |
 
 <a name="common-options"></a>
 
@@ -123,10 +123,10 @@ qsv joinp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
-| `-q,`<br>`--quiet` | flag | Do not return join shape to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not return join shape to stderr. |  |
 
 ---
 **Source:** [`src/cmd/joinp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/joinp.rs)

--- a/docs/help/json.md
+++ b/docs/help/json.md
@@ -162,8 +162,8 @@ qsv json --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--jaq` | string | Filter JSON data using jaq syntax (<https://github.com/01mf02/jaq>), which is identical to the popular JSON command-line tool - jq. <https://jqlang.github.io/jq/> Note that the filter is applied BEFORE converting JSON to CSV |  |
-| `-s,`<br>`--select` | string | Select, reorder or drop columns for output. Otherwise, all the columns will be output in the same order as the first object's keys in the JSON data. See 'qsv select --help' for the full syntax. Note however that <cols> NEED to be a comma-delimited list of column NAMES and NOT column INDICES. | `1-` |
+| &nbsp;`--jaq`&nbsp; | string | Filter JSON data using jaq syntax (<https://github.com/01mf02/jaq>), which is identical to the popular JSON command-line tool - jq. <https://jqlang.github.io/jq/> Note that the filter is applied BEFORE converting JSON to CSV |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select, reorder or drop columns for output. Otherwise, all the columns will be output in the same order as the first object's keys in the JSON data. See 'qsv select --help' for the full syntax. Note however that <cols> NEED to be a comma-delimited list of column NAMES and NOT column INDICES. | `1-` |
 
 <a name="common-options"></a>
 
@@ -171,8 +171,8 @@ qsv json --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
 
 ---
 **Source:** [`src/cmd/json.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/json.rs)

--- a/docs/help/jsonl.md
+++ b/docs/help/jsonl.md
@@ -38,9 +38,9 @@ qsv jsonl --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--ignore-errors` | flag | Skip malformed input lines. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| &nbsp;`--ignore-errors`&nbsp; | flag | Skip malformed input lines. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 
 <a name="common-options"></a>
 
@@ -48,9 +48,9 @@ qsv jsonl --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The delimiter to use when writing CSV data. Must be a single character. | `,` |
 
 ---
 **Source:** [`src/cmd/jsonl.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/jsonl.rs)

--- a/docs/help/lens.md
+++ b/docs/help/lens.md
@@ -137,21 +137,21 @@ qsv lens --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-d,`<br>`--delimiter` | string | Delimiter character (comma by default) "auto" to auto-detect the delimiter |  |
-| `-t,`<br>`--tab-separated` | flag | Use tab separation. Shortcut for -d '\t' |  |
-| `--no-headers` | flag | Do not interpret the first row as headers |  |
-| `--columns` | string | Use this regex to select columns to display by default. Example: "col1\|col2\|col3" to select columns "col1", "col2" and "col3" and also columns like "col1_1", "col22" and "col3-more". |  |
-| `--filter` | string | Use this regex to filter rows to display by default. The regex is matched against each cell in every column. Example: "val1\|val2" filters rows with any cells containing "val1", "val2" or text like "my_val1" or "val234". |  |
-| `--find` | string | Use this regex to find and highlight matches by default. Automatically sets --monochrome to true so the matches are easier to see. The regex is matched against each cell in every column. Example: "val1\|val2" highlights text containing "val1", "val2" or longer text like "val1_ok" or "val2_error". |  |
-| `-i,`<br>`--ignore-case` | flag | Searches ignore case. Ignored if any uppercase letters are present in the search string |  |
-| `-f,`<br>`--freeze-columns` | string | Freeze the first N columns | `1` |
-| `-m,`<br>`--monochrome` | flag | Disable color output |  |
-| `-W,`<br>`--wrap-mode` | string | Set the wrap mode for the output. | `disabled` |
-| `-A,`<br>`--auto-reload` | flag | Automatically reload the data when the file changes. |  |
-| `-S,`<br>`--streaming-stdin` | flag | Enable streaming stdin (load input as it's being piped in) NOTE: This option only applies to stdin input. |  |
-| `-P,`<br>`--prompt` | string | Set a custom prompt in the status bar. Normally paired w/ --echo-column: qsv lens --prompt 'Select City:' --echo-column 'City' Supports ANSI escape codes for colored or styled text. When using escape codes, ensure it's properly escaped. For example, in bash/zsh, the $'...' syntax is used to do so: qsv lens --prompt $'\033[1;5;31mBlinking red, bold text\033[0m' see <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors> or <https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797> for more info on ANSI escape codes. Typing a complicated prompt on the command line can be tricky. If the prompt starts with "file:", it's interpreted as a filepath from which to load the prompt, e.g. qsv lens --prompt "file:prompt.txt" |  |
-| `--echo-column` | string | Print the value of this column to stdout for the selected row |  |
-| `--debug` | flag | Show stats for debugging |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | Delimiter character (comma by default) "auto" to auto-detect the delimiter |  |
+| &nbsp;`-t,`<br>`--tab-separated`&nbsp; | flag | Use tab separation. Shortcut for -d '\t' |  |
+| &nbsp;`--no-headers`&nbsp; | flag | Do not interpret the first row as headers |  |
+| &nbsp;`--columns`&nbsp; | string | Use this regex to select columns to display by default. Example: "col1\|col2\|col3" to select columns "col1", "col2" and "col3" and also columns like "col1_1", "col22" and "col3-more". |  |
+| &nbsp;`--filter`&nbsp; | string | Use this regex to filter rows to display by default. The regex is matched against each cell in every column. Example: "val1\|val2" filters rows with any cells containing "val1", "val2" or text like "my_val1" or "val234". |  |
+| &nbsp;`--find`&nbsp; | string | Use this regex to find and highlight matches by default. Automatically sets --monochrome to true so the matches are easier to see. The regex is matched against each cell in every column. Example: "val1\|val2" highlights text containing "val1", "val2" or longer text like "val1_ok" or "val2_error". |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Searches ignore case. Ignored if any uppercase letters are present in the search string |  |
+| &nbsp;`-f,`<br>`--freeze-columns`&nbsp; | string | Freeze the first N columns | `1` |
+| &nbsp;`-m,`<br>`--monochrome`&nbsp; | flag | Disable color output |  |
+| &nbsp;`-W,`<br>`--wrap-mode`&nbsp; | string | Set the wrap mode for the output. | `disabled` |
+| &nbsp;`-A,`<br>`--auto-reload`&nbsp; | flag | Automatically reload the data when the file changes. |  |
+| &nbsp;`-S,`<br>`--streaming-stdin`&nbsp; | flag | Enable streaming stdin (load input as it's being piped in) NOTE: This option only applies to stdin input. |  |
+| &nbsp;`-P,`<br>`--prompt`&nbsp; | string | Set a custom prompt in the status bar. Normally paired w/ --echo-column: qsv lens --prompt 'Select City:' --echo-column 'City' Supports ANSI escape codes for colored or styled text. When using escape codes, ensure it's properly escaped. For example, in bash/zsh, the $'...' syntax is used to do so: qsv lens --prompt $'\033[1;5;31mBlinking red, bold text\033[0m' see <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors> or <https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797> for more info on ANSI escape codes. Typing a complicated prompt on the command line can be tricky. If the prompt starts with "file:", it's interpreted as a filepath from which to load the prompt, e.g. qsv lens --prompt "file:prompt.txt" |  |
+| &nbsp;`--echo-column`&nbsp; | string | Print the value of this column to stdout for the selected row |  |
+| &nbsp;`--debug`&nbsp; | flag | Show stats for debugging |  |
 
 <a name="common-options"></a>
 
@@ -159,7 +159,7 @@ qsv lens --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/lens.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/lens.rs)

--- a/docs/help/luau.md
+++ b/docs/help/luau.md
@@ -250,7 +250,7 @@ qsv luau --help
 
 | Argument | Description |
 |----------|-------------|
-| `<new-columns>` | is a comma-separated list of new computed columns to add to the CSV when using "luau map". The new columns are added to the CSV after the existing columns, unless the --remap option is used. |
+| &nbsp;`<new-columns>`&nbsp; | is a comma-separated list of new computed columns to add to the CSV when using "luau map". The new columns are added to the CSV after the existing columns, unless the --remap option is used. |
 
 <a name="luau-options"></a>
 
@@ -258,16 +258,16 @@ qsv luau --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-g,`<br>`--no-globals` | flag | Don't create Luau global variables for each column, only `col`. Useful when some column names mask standard Luau globals and to increase PERFORMANCE. Note: access to Luau globals thru _G remains even with -g. |  |
-| `--colindex` | flag | Create a 1-based column index. Useful when some column names mask standard Luau globals. Automatically enabled with --no-headers. |  |
-| `-r,`<br>`--remap` | flag | Only the listed new columns are written to the output CSV. Only applies to "map" subcommand. |  |
-| `-B,`<br>`--begin` | string | Luau script/file to execute in the BEGINning, before processing the CSV with the main-script. Typically used to initialize global variables. Takes precedence over an embedded BEGIN script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
-| `-E,`<br>`--end` | string | Luau script/file to execute at the END, after processing the CSV with the main-script. Typically used for aggregations. The output of the END script is sent to stderr. Takes precedence over an embedded END script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
-| `--max-errors` | string | The maximum number of errors to tolerate before aborting. Set to zero to disable error limit. | `10` |
-| `--timeout` | string | Timeout for downloading lookup_tables using the qsv_register_lookup() helper function. | `60` |
-| `--ckan-api` | string | The URL of the CKAN API to use for downloading lookup_table resources using the qsv_register_lookup() helper function with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
-| `--ckan-token` | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. |  |
-| `--cache-dir` | string | The directory to use for caching downloaded lookup_table resources using the qsv_register_lookup() helper function. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
+| &nbsp;`-g,`<br>`--no-globals`&nbsp; | flag | Don't create Luau global variables for each column, only `col`. Useful when some column names mask standard Luau globals and to increase PERFORMANCE. Note: access to Luau globals thru _G remains even with -g. |  |
+| &nbsp;`--colindex`&nbsp; | flag | Create a 1-based column index. Useful when some column names mask standard Luau globals. Automatically enabled with --no-headers. |  |
+| &nbsp;`-r,`<br>`--remap`&nbsp; | flag | Only the listed new columns are written to the output CSV. Only applies to "map" subcommand. |  |
+| &nbsp;`-B,`<br>`--begin`&nbsp; | string | Luau script/file to execute in the BEGINning, before processing the CSV with the main-script. Typically used to initialize global variables. Takes precedence over an embedded BEGIN script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
+| &nbsp;`-E,`<br>`--end`&nbsp; | string | Luau script/file to execute at the END, after processing the CSV with the main-script. Typically used for aggregations. The output of the END script is sent to stderr. Takes precedence over an embedded END script. If <script> begins with "file:" or ends with ".luau/.lua", it's interpreted as a filepath from which to load the script. |  |
+| &nbsp;`--max-errors`&nbsp; | string | The maximum number of errors to tolerate before aborting. Set to zero to disable error limit. | `10` |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for downloading lookup_tables using the qsv_register_lookup() helper function. | `60` |
+| &nbsp;`--ckan-api`&nbsp; | string | The URL of the CKAN API to use for downloading lookup_table resources using the qsv_register_lookup() helper function with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
+| &nbsp;`--ckan-token`&nbsp; | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. |  |
+| &nbsp;`--cache-dir`&nbsp; | string | The directory to use for caching downloaded lookup_table resources using the qsv_register_lookup() helper function. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
 
 <a name="common-options"></a>
 
@@ -275,11 +275,11 @@ qsv luau --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Automatically enables --colindex option. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. Ignored in qsvdp. In SEQUENTIAL MODE, the progress bar will show the number of rows processed. In RANDOM ACCESS MODE, the progress bar will show the position of the current row being processed. Enabling this option will also suppress stderr output from the END script. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Automatically enables --colindex option. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. Ignored in qsvdp. In SEQUENTIAL MODE, the progress bar will show the number of rows processed. In RANDOM ACCESS MODE, the progress bar will show the position of the current row being processed. Enabling this option will also suppress stderr output from the END script. |  |
 
 ---
 **Source:** [`src/cmd/luau.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/luau.rs)

--- a/docs/help/moarstats.md
+++ b/docs/help/moarstats.md
@@ -260,13 +260,13 @@ qsv moarstats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--advanced` | flag | Compute Kurtosis, Shannon Entropy, Bimodality Coefficient, Gini Coefficient and Atkinson Index. These advanced statistics computations require reading the original CSV file to collect all values for computation and are computationally expensive. Further, Entropy computation requires the frequency command to be run with --limit 0 to collect all frequencies. An index will be auto-created for the original CSV file if it doesn't already exist to enable parallel processing. |  |
-| `-e,`<br>`--epsilon` | string | The Atkinson Index Inequality Aversion parameter. Epsilon controls the sensitivity of the Atkinson Index to inequality. The higher the epsilon, the more sensitive the index is to inequality. Typical values are 0.5 (standard in economic research), 1.0 (natural boundary), or 2.0 (useful for poverty analysis). | `1.0` |
-| `--stats-options` | string | Options to pass to the stats command if baseline stats need to be generated. The options are passed as a single string that will be split by whitespace. | `--infer-dates --infer-boolean --mad --quartiles --percentiles --force --stats-jsonl` |
-| `--round` | string | Round statistics to <n> decimal places. Rounding follows Midpoint Nearest Even (Bankers Rounding) rule. | `4` |
-| `--use-percentiles` | flag | Use percentiles instead of Q1/Q3 for winsorization/trimming. Requires percentiles to be computed in the stats CSV. |  |
-| `--pct-thresholds` | string | Comma-separated percentile pair (e.g., "10,90") to use for winsorization/trimming when --use-percentiles is set. Both values must be between 0 and 100, and lower < upper. | `5,95` |
-| `--xsd-gdate-scan` | string | Gregorian XSD date type detection mode. "quick": Fast detection using min/max values. Produces types with ?? suffix (less confident). "thorough": Comprehensive detection checking all percentile values. Slower but ensures all values match the pattern. Produces types with ? suffix (more confident). | `quick` |
+| &nbsp;`--advanced`&nbsp; | flag | Compute Kurtosis, Shannon Entropy, Bimodality Coefficient, Gini Coefficient and Atkinson Index. These advanced statistics computations require reading the original CSV file to collect all values for computation and are computationally expensive. Further, Entropy computation requires the frequency command to be run with --limit 0 to collect all frequencies. An index will be auto-created for the original CSV file if it doesn't already exist to enable parallel processing. |  |
+| &nbsp;`-e,`<br>`--epsilon`&nbsp; | string | The Atkinson Index Inequality Aversion parameter. Epsilon controls the sensitivity of the Atkinson Index to inequality. The higher the epsilon, the more sensitive the index is to inequality. Typical values are 0.5 (standard in economic research), 1.0 (natural boundary), or 2.0 (useful for poverty analysis). | `1.0` |
+| &nbsp;`--stats-options`&nbsp; | string | Options to pass to the stats command if baseline stats need to be generated. The options are passed as a single string that will be split by whitespace. | `--infer-dates --infer-boolean --mad --quartiles --percentiles --force --stats-jsonl` |
+| &nbsp;`--round`&nbsp; | string | Round statistics to <n> decimal places. Rounding follows Midpoint Nearest Even (Bankers Rounding) rule. | `4` |
+| &nbsp;`--use-percentiles`&nbsp; | flag | Use percentiles instead of Q1/Q3 for winsorization/trimming. Requires percentiles to be computed in the stats CSV. |  |
+| &nbsp;`--pct-thresholds`&nbsp; | string | Comma-separated percentile pair (e.g., "10,90") to use for winsorization/trimming when --use-percentiles is set. Both values must be between 0 and 100, and lower < upper. | `5,95` |
+| &nbsp;`--xsd-gdate-scan`&nbsp; | string | Gregorian XSD date type detection mode. "quick": Fast detection using min/max values. Produces types with ?? suffix (less confident). "thorough": Comprehensive detection checking all percentile values. Slower but ensures all values match the pattern. Produces types with ? suffix (more confident). | `quick` |
 
 <a name="bivariate-statistics-options"></a>
 
@@ -274,13 +274,13 @@ qsv moarstats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-B,`<br>`--bivariate` | flag | Enable bivariate statistics computation. Requires indexed CSV file (index will be auto-created if missing). Computes pairwise correlations, covariances, mutual information, and normalized mutual information between columns. The bivariate statistics |  |
-| `-S,`<br>`--bivariate-stats` | string | Comma-separated list of bivariate statistics to compute. Options: pearson, spearman, kendall, covariance, mi (mutual information), nmi (normalized mutual information) Use "all" to compute all statistics or "fast" to compute only pearson & covariance, which is much faster as it doesn't require storing all values and uses streaming algorithms. | `fast` |
-| `-C,`<br>`--cardinality-threshold` | string | Skip mutual information computation for field pairs where either field has cardinality exceeding this threshold. Helps avoid expensive computations for high-cardinality fields. | `1000000` |
-| `-J,`<br>`--join-inputs` | string | Additional datasets to join. Comma-separated list of CSV files to join with the primary input. e.g.: --join-inputs customers.csv,products.csv |  |
-| `-K,`<br>`--join-keys` | string | Join keys for each dataset. Comma-separated list of join key column names, one per dataset. Must specify same number of keys as datasets (primary + addl). e.g.: --join-keys customer_id,customer_id,product_id |  |
-| `-T,`<br>`--join-type` | string | Join type when using --join-inputs. Valid values: inner, left, right, full | `inner` |
-| `-p,`<br>`--progressbar` | flag | Show progress bars when computing bivariate statistics. |  |
+| &nbsp;`-B,`<br>`--bivariate`&nbsp; | flag | Enable bivariate statistics computation. Requires indexed CSV file (index will be auto-created if missing). Computes pairwise correlations, covariances, mutual information, and normalized mutual information between columns. The bivariate statistics |  |
+| &nbsp;`-S,`<br>`--bivariate-stats`&nbsp; | string | Comma-separated list of bivariate statistics to compute. Options: pearson, spearman, kendall, covariance, mi (mutual information), nmi (normalized mutual information) Use "all" to compute all statistics or "fast" to compute only pearson & covariance, which is much faster as it doesn't require storing all values and uses streaming algorithms. | `fast` |
+| &nbsp;`-C,`<br>`--cardinality-threshold`&nbsp; | string | Skip mutual information computation for field pairs where either field has cardinality exceeding this threshold. Helps avoid expensive computations for high-cardinality fields. | `1000000` |
+| &nbsp;`-J,`<br>`--join-inputs`&nbsp; | string | Additional datasets to join. Comma-separated list of CSV files to join with the primary input. e.g.: --join-inputs customers.csv,products.csv |  |
+| &nbsp;`-K,`<br>`--join-keys`&nbsp; | string | Join keys for each dataset. Comma-separated list of join key column names, one per dataset. Must specify same number of keys as datasets (primary + addl). e.g.: --join-keys customer_id,customer_id,product_id |  |
+| &nbsp;`-T,`<br>`--join-type`&nbsp; | string | Join type when using --join-inputs. Valid values: inner, left, right, full | `inner` |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars when computing bivariate statistics. |  |
 
 <a name="common-options"></a>
 
@@ -288,10 +288,10 @@ qsv moarstats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--force` | flag | Force recomputing stats even if valid precomputed stats cache exists. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of overwriting the stats CSV file. |  |
+| &nbsp;`--force`&nbsp; | flag | Force recomputing stats even if valid precomputed stats cache exists. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of overwriting the stats CSV file. |  |
 
 ---
 **Source:** [`src/cmd/moarstats.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/moarstats.rs)

--- a/docs/help/partition.md
+++ b/docs/help/partition.md
@@ -57,9 +57,9 @@ qsv partition --help
 
 | Argument | Description |
 |----------|-------------|
-| `<column>` | The column to use as a key for partitioning. You can use the `--select` option to select the column by name or index, but only one column can be used for partitioning. See `select` command for more details. |
-| `<outdir>` | The directory to write the output files to. |
-| `<input>` | The CSV file to read from. If not specified, then the input will be read from stdin. |
+| &nbsp;`<column>`&nbsp; | The column to use as a key for partitioning. You can use the `--select` option to select the column by name or index, but only one column can be used for partitioning. See `select` command for more details. |
+| &nbsp;`<outdir>`&nbsp; | The directory to write the output files to. |
+| &nbsp;`<input>`&nbsp; | The CSV file to read from. If not specified, then the input will be read from stdin. |
 
 <a name="partition-options"></a>
 
@@ -67,10 +67,10 @@ qsv partition --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--filename` | string | A filename template to use when constructing the names of the output files.  The string '{}' will be replaced by a value based on the partition column, but sanitized for shell safety. | `{}.csv` |
-| `-p,`<br>`--prefix-length` | string | Truncate the partition column after the specified number of bytes when creating the output file. |  |
-| `--drop` | flag | Drop the partition column from results. |  |
-| `--limit` | string | Limit the number of simultaneously open files. Useful for partitioning large datasets with many unique values to avoid "too many open files" errors. Data is processed in batches until all unique values are processed. If not set, it will be automatically set to the system limit with a 10% safety margin. If set to 0, it will process all data at once, regardless of the system's open files limit. |  |
+| &nbsp;`--filename`&nbsp; | string | A filename template to use when constructing the names of the output files.  The string '{}' will be replaced by a value based on the partition column, but sanitized for shell safety. | `{}.csv` |
+| &nbsp;`-p,`<br>`--prefix-length`&nbsp; | string | Truncate the partition column after the specified number of bytes when creating the output file. |  |
+| &nbsp;`--drop`&nbsp; | flag | Drop the partition column from results. |  |
+| &nbsp;`--limit`&nbsp; | string | Limit the number of simultaneously open files. Useful for partitioning large datasets with many unique values to avoid "too many open files" errors. Data is processed in batches until all unique values are processed. If not set, it will be automatically set to the system limit with a 10% safety margin. If set to 0, it will process all data at once, regardless of the system's open files limit. |  |
 
 <a name="common-options"></a>
 
@@ -78,9 +78,9 @@ qsv partition --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/partition.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/partition.rs)

--- a/docs/help/pivotp.md
+++ b/docs/help/pivotp.md
@@ -37,8 +37,8 @@ qsv pivotp --help
 
 | Argument | Description |
 |----------|-------------|
-| `<on-cols>` | The column(s) to pivot on (creates new columns). |
-| `<input>` | is the input CSV file. The file must have headers. If the file has a pschema.json file, it will be used to inform the pivot operation unless --infer-len is explicitly set to a value other than the default of 10,000 rows. Stdin is not supported. |
+| &nbsp;`<on-cols>`&nbsp; | The column(s) to pivot on (creates new columns). |
+| &nbsp;`<input>`&nbsp; | is the input CSV file. The file must have headers. If the file has a pschema.json file, it will be used to inform the pivot operation unless --infer-len is explicitly set to a value other than the default of 10,000 rows. Stdin is not supported. |
 
 <a name="pivotp-options"></a>
 
@@ -46,17 +46,17 @@ qsv pivotp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--index` | string | The column(s) to use as the index (row labels). Specify multiple columns by separating them with a comma. The output will have one row for each unique combination of the index's values. If None, all remaining columns not specified on --on and --values will be used. At least one of --index and --values must be specified. |  |
-| `-v,`<br>`--values` | string | The column(s) containing values to aggregate. If an aggregation is specified, these are the values on which the aggregation will be computed. If None, all remaining columns not specified on --on and --index will be used. At least one of --index and --values must be specified. |  |
-| `-a,`<br>`--agg` | string | The aggregation function to use: first - First value encountered last - Last value encountered sum - Sum of values min - Minimum value max - Maximum value mean - Average value median - Median value len - Count of values item - Get single value from group. Raises error if there are multiple values. smart - use value column data type & statistics to pick an aggregation. Will only work if there is one value column, otherwise it falls back to `first` | `smart` |
-| `--sort-columns` | flag | Sort the transposed columns by name. |  |
-| `--maintain-order` | flag | Maintain the order of the input columns. |  |
-| `--col-separator` | string | The separator in generated column names in case of multiple --values columns. | `_` |
-| `--validate` | flag | Validate a pivot by checking the pivot column(s)' cardinality. |  |
-| `--try-parsedates` | flag | When set, will attempt to parse columns as dates. |  |
-| `--infer-len` | string | Number of rows to scan when inferring schema. Set to 0 to scan entire file. | `10000` |
-| `--decimal-comma` | flag | Use comma as decimal separator when READING the input. Note that you will need to specify an alternate --delimiter. |  |
-| `--ignore-errors` | flag | Skip rows that can't be parsed. |  |
+| &nbsp;`-i,`<br>`--index`&nbsp; | string | The column(s) to use as the index (row labels). Specify multiple columns by separating them with a comma. The output will have one row for each unique combination of the index's values. If None, all remaining columns not specified on --on and --values will be used. At least one of --index and --values must be specified. |  |
+| &nbsp;`-v,`<br>`--values`&nbsp; | string | The column(s) containing values to aggregate. If an aggregation is specified, these are the values on which the aggregation will be computed. If None, all remaining columns not specified on --on and --index will be used. At least one of --index and --values must be specified. |  |
+| &nbsp;`-a,`<br>`--agg`&nbsp; | string | The aggregation function to use: first - First value encountered last - Last value encountered sum - Sum of values min - Minimum value max - Maximum value mean - Average value median - Median value len - Count of values item - Get single value from group. Raises error if there are multiple values. smart - use value column data type & statistics to pick an aggregation. Will only work if there is one value column, otherwise it falls back to `first` | `smart` |
+| &nbsp;`--sort-columns`&nbsp; | flag | Sort the transposed columns by name. |  |
+| &nbsp;`--maintain-order`&nbsp; | flag | Maintain the order of the input columns. |  |
+| &nbsp;`--col-separator`&nbsp; | string | The separator in generated column names in case of multiple --values columns. | `_` |
+| &nbsp;`--validate`&nbsp; | flag | Validate a pivot by checking the pivot column(s)' cardinality. |  |
+| &nbsp;`--try-parsedates`&nbsp; | flag | When set, will attempt to parse columns as dates. |  |
+| &nbsp;`--infer-len`&nbsp; | string | Number of rows to scan when inferring schema. Set to 0 to scan entire file. | `10000` |
+| &nbsp;`--decimal-comma`&nbsp; | flag | Use comma as decimal separator when READING the input. Note that you will need to specify an alternate --delimiter. |  |
+| &nbsp;`--ignore-errors`&nbsp; | flag | Skip rows that can't be parsed. |  |
 
 <a name="common-options"></a>
 
@@ -64,10 +64,10 @@ qsv pivotp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
-| `-q,`<br>`--quiet` | flag | Do not return smart aggregation chosen nor pivot result shape to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not return smart aggregation chosen nor pivot result shape to stderr. |  |
 
 ---
 **Source:** [`src/cmd/pivotp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pivotp.rs)

--- a/docs/help/pragmastat.md
+++ b/docs/help/pragmastat.md
@@ -104,9 +104,9 @@ qsv pragmastat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-t,`<br>`--twosample` | flag | Compute two-sample estimators for all column pairs. |  |
-| `-s,`<br>`--select` | string | Select columns for analysis. Uses qsv's column selection syntax. Non-numeric columns appear with n=0. In two-sample mode, all pairs of selected columns are computed. |  |
-| `-m,`<br>`--misrate` | string | Probability that bounds fail to contain the true parameter. Lower values produce wider bounds. Must be achievable for the given sample size. | `0.001` |
+| &nbsp;`-t,`<br>`--twosample`&nbsp; | flag | Compute two-sample estimators for all column pairs. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select columns for analysis. Uses qsv's column selection syntax. Non-numeric columns appear with n=0. In two-sample mode, all pairs of selected columns are computed. |  |
+| &nbsp;`-m,`<br>`--misrate`&nbsp; | string | Probability that bounds fail to contain the true parameter. Lower values produce wider bounds. Must be achievable for the given sample size. | `0.001` |
 
 <a name="common-options"></a>
 
@@ -114,10 +114,10 @@ qsv pragmastat --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be treated as headers. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be treated as headers. |  |
 
 ---
 **Source:** [`src/cmd/pragmastat.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pragmastat.rs)

--- a/docs/help/pro.md
+++ b/docs/help/pro.md
@@ -37,7 +37,7 @@ qsv pro --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The input file path to send to the qsv pro API. This must be a local file path, not stdin. Workflow supports: CSV, TSV, SSV, TAB, XLSX, XLS, XLSB, XLSM, ODS. |
+| &nbsp;`<input>`&nbsp; | The input file path to send to the qsv pro API. This must be a local file path, not stdin. Workflow supports: CSV, TSV, SSV, TAB, XLSX, XLS, XLSB, XLSM, ODS. |
 
 <a name="common-options"></a>
 
@@ -45,7 +45,7 @@ qsv pro --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
 
 ---
 **Source:** [`src/cmd/pro.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pro.rs)

--- a/docs/help/prompt.md
+++ b/docs/help/prompt.md
@@ -52,12 +52,12 @@ qsv prompt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-m,`<br>`--msg` | string | The prompt message to display in the file dialog title. When not using --fd-output, the default is "Select a File". When using --fd-output, the default is "Save File As". |  |
-| `-F,`<br>`--filters` | string | The filter to use for the INPUT file dialog. Set to "None" to disable filters. Filters are comma-delimited file extensions. Defaults to csv,tsv,tab,ssv,xls,xlsx,xlsm,xlsb,ods. If the polars feature is enabled, it adds avro,arrow,ipc,parquet, json,jsonl,ndjson & gz,zst,zlib compressed files to the filter. |  |
-| `-d,`<br>`--workdir` | string | The directory to start the file dialog in. | `.` |
-| `-f,`<br>`--fd-output` | flag | Write output to a file by using a save file dialog. Used when piping into qsv prompt. Mutually exclusive with --output. |  |
-| `--save-fname` | string | The filename to save the output as when using --fd-output. | `output.csv` |
-| `--base-delay-ms` | string | The base delay in milliseconds to use when opening INPUT dialog. This is to ensure that the INPUT dialog is shown before/over the OUTPUT dialog when using the prompt command is used in both INPUT and OUTPUT modes in a single pipeline. | `200` |
+| &nbsp;`-m,`<br>`--msg`&nbsp; | string | The prompt message to display in the file dialog title. When not using --fd-output, the default is "Select a File". When using --fd-output, the default is "Save File As". |  |
+| &nbsp;`-F,`<br>`--filters`&nbsp; | string | The filter to use for the INPUT file dialog. Set to "None" to disable filters. Filters are comma-delimited file extensions. Defaults to csv,tsv,tab,ssv,xls,xlsx,xlsm,xlsb,ods. If the polars feature is enabled, it adds avro,arrow,ipc,parquet, json,jsonl,ndjson & gz,zst,zlib compressed files to the filter. |  |
+| &nbsp;`-d,`<br>`--workdir`&nbsp; | string | The directory to start the file dialog in. | `.` |
+| &nbsp;`-f,`<br>`--fd-output`&nbsp; | flag | Write output to a file by using a save file dialog. Used when piping into qsv prompt. Mutually exclusive with --output. |  |
+| &nbsp;`--save-fname`&nbsp; | string | The filename to save the output as when using --fd-output. | `output.csv` |
+| &nbsp;`--base-delay-ms`&nbsp; | string | The base delay in milliseconds to use when opening INPUT dialog. This is to ensure that the INPUT dialog is shown before/over the OUTPUT dialog when using the prompt command is used in both INPUT and OUTPUT modes in a single pipeline. | `200` |
 
 <a name="common-options"></a>
 
@@ -65,9 +65,9 @@ qsv prompt --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> without showing a save dialog. Mutually exclusive with --fd-output. |  |
-| `-q,`<br>`--quiet` | flag | Do not print --fd-output message to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> without showing a save dialog. Mutually exclusive with --fd-output. |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not print --fd-output message to stderr. |  |
 
 ---
 **Source:** [`src/cmd/prompt.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/prompt.rs)

--- a/docs/help/pseudo.md
+++ b/docs/help/pseudo.md
@@ -69,8 +69,8 @@ qsv pseudo --help
 
 | Argument | Description |
 |----------|-------------|
-| `<column>` | The column to pseudonymise. You can use the `--select` option to select the column by name or index. See `select` command for more details. |
-| `<input>` | The CSV file to read from. If not specified, then the input will be read from stdin. |
+| &nbsp;`<column>`&nbsp; | The column to pseudonymise. You can use the `--select` option to select the column by name or index. See `select` command for more details. |
+| &nbsp;`<input>`&nbsp; | The CSV file to read from. If not specified, then the input will be read from stdin. |
 
 <a name="common-options"></a>
 
@@ -78,13 +78,13 @@ qsv pseudo --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `--start` | string | The starting number for the incremental identifier. | `0` |
-| `--increment` | string | The increment for the incremental identifier. | `1` |
-| `--formatstr` | string | The format string for the incremental identifier. The format string must contain a single "{}" which will be replaced with the incremental identifier. | `{}` |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`--start`&nbsp; | string | The starting number for the incremental identifier. | `0` |
+| &nbsp;`--increment`&nbsp; | string | The increment for the incremental identifier. | `1` |
+| &nbsp;`--formatstr`&nbsp; | string | The format string for the incremental identifier. The format string must contain a single "{}" which will be replaced with the incremental identifier. | `{}` |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/pseudo.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/pseudo.rs)

--- a/docs/help/py.md
+++ b/docs/help/py.md
@@ -142,7 +142,7 @@ qsv py --help
 
 | Argument | Description |
 |----------|-------------|
-| `<expression>` | Can either be a Python expression, or if it starts with "file:" or ends with ".py" - the filepath from which to load the Python expression. Note that argument expects a SINGLE expression, and not a full-blown Python script. Use the --helper option to load helper code that you can call from the expression. |
+| &nbsp;`<expression>`&nbsp; | Can either be a Python expression, or if it starts with "file:" or ends with ".py" - the filepath from which to load the Python expression. Note that argument expects a SINGLE expression, and not a full-blown Python script. Use the --helper option to load helper code that you can call from the expression. |
 
 <a name="py-options"></a>
 
@@ -150,8 +150,8 @@ qsv py --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-f,`<br>`--helper` | string | File containing Python code that's loaded into the qsv_uh Python module. Functions with a return statement in the file can be called with the prefix "qsv_uh". The returned value is used in the map or filter operation. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to process before releasing memory and acquiring a new GILpool. Set to 0 to process the entire file in one batch. | `50000` |
+| &nbsp;`-f,`<br>`--helper`&nbsp; | string | File containing Python code that's loaded into the qsv_uh Python module. Functions with a return statement in the file can be called with the prefix "qsv_uh". The returned value is used in the map or filter operation. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to process before releasing memory and acquiring a new GILpool. Set to 0 to process the entire file in one batch. | `50000` |
 
 <a name="common-options"></a>
 
@@ -159,11 +159,11 @@ qsv py --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/python.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/python.rs)

--- a/docs/help/rename.md
+++ b/docs/help/rename.md
@@ -70,7 +70,7 @@ qsv rename --help
 
 | Argument | Description |
 |----------|-------------|
-| `<headers>` | The new headers to use for the CSV. Separate multiple headers with a comma. If "_all_generic" is given, the headers will be renamed to generic column names, where the column name uses the format "_col_N" where N is the 1-based column index. Alternatively, specify pairs of old,new column names to rename only specific columns. |
+| &nbsp;`<headers>`&nbsp; | The new headers to use for the CSV. Separate multiple headers with a comma. If "_all_generic" is given, the headers will be renamed to generic column names, where the column name uses the format "_col_N" where N is the 1-based column index. Alternatively, specify pairs of old,new column names to rename only specific columns. |
 
 <a name="common-options"></a>
 
@@ -78,10 +78,10 @@ qsv rename --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the header will be inserted on top. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the header will be inserted on top. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/rename.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/rename.rs)

--- a/docs/help/replace.md
+++ b/docs/help/replace.md
@@ -79,9 +79,9 @@ qsv replace --help
 
 | Argument | Description |
 |----------|-------------|
-| `<pattern>` | Regular expression pattern to match. Uses Rust regex syntax. See <https://docs.rs/regex/latest/regex/index.html#syntax> or <https://regex101.com> with the Rust flavor for more info. |
-| `<input>` | The CSV file to read. If not given, reads from stdin. |
-| `<replacement>` | Replacement string. Set to '<NULL>' if you want to replace matches with ''. |
+| &nbsp;`<pattern>`&nbsp; | Regular expression pattern to match. Uses Rust regex syntax. See <https://docs.rs/regex/latest/regex/index.html#syntax> or <https://regex101.com> with the Rust flavor for more info. |
+| &nbsp;`<input>`&nbsp; | The CSV file to read. If not given, reads from stdin. |
+| &nbsp;`<replacement>`&nbsp; | Replacement string. Set to '<NULL>' if you want to replace matches with ''. |
 
 <a name="replace-options"></a>
 
@@ -89,15 +89,15 @@ qsv replace --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
-| `--literal` | flag | Treat the regex pattern as a literal string. This allows you to search for matches that contain regex special characters. |  |
-| `--exact` | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
-| `-s,`<br>`--select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
-| `-u,`<br>`--unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
-| `--size-limit` | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. | `50` |
-| `--dfa-size-limit` | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. | `10` |
-| `--not-one` | flag | Use exit code 0 instead of 1 for no replacement found. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
+| &nbsp;`--literal`&nbsp; | flag | Treat the regex pattern as a literal string. This allows you to search for matches that contain regex special characters. |  |
+| &nbsp;`--exact`&nbsp; | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
+| &nbsp;`-u,`<br>`--unicode`&nbsp; | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
+| &nbsp;`--size-limit`&nbsp; | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. | `50` |
+| &nbsp;`--dfa-size-limit`&nbsp; | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. | `10` |
+| &nbsp;`--not-one`&nbsp; | flag | Use exit code 0 instead of 1 for no replacement found. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -105,12 +105,12 @@ qsv replace --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
-| `-q,`<br>`--quiet` | flag | Do not print number of replacements to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not print number of replacements to stderr. |  |
 
 ---
 **Source:** [`src/cmd/replace.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/replace.rs)

--- a/docs/help/reverse.md
+++ b/docs/help/reverse.md
@@ -35,11 +35,11 @@ qsv reverse --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be reversed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Namely, it will be reversed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---
 **Source:** [`src/cmd/reverse.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/reverse.rs)

--- a/docs/help/safenames.md
+++ b/docs/help/safenames.md
@@ -98,9 +98,9 @@ qsv safenames --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--mode` | string | Rename header names to "safe" names - i.e. guaranteed "database-ready" names. It has six modes - conditional, always, verify, Verbose, with Verbose having two submodes - JSON & pretty JSON. | `Always` |
-| `--reserved` | string | Comma-delimited list of additional case-insensitive reserved names that should be considered "unsafe." If a header name is found in the reserved list, it will be prefixed with "reserved_". | `_id` |
-| `--prefix` | string | Certain systems do not allow header names to start with "_" (e.g. CKAN Datastore). This option allows the specification of the unsafe prefix to use when a header starts with "_". | `unsafe_` |
+| &nbsp;`--mode`&nbsp; | string | Rename header names to "safe" names - i.e. guaranteed "database-ready" names. It has six modes - conditional, always, verify, Verbose, with Verbose having two submodes - JSON & pretty JSON. | `Always` |
+| &nbsp;`--reserved`&nbsp; | string | Comma-delimited list of additional case-insensitive reserved names that should be considered "unsafe." If a header name is found in the reserved list, it will be prefixed with "reserved_". | `_id` |
+| &nbsp;`--prefix`&nbsp; | string | Certain systems do not allow header names to start with "_" (e.g. CKAN Datastore). This option allows the specification of the unsafe prefix to use when a header starts with "_". | `unsafe_` |
 
 <a name="common-options"></a>
 
@@ -108,9 +108,9 @@ qsv safenames --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. Note that no output is generated for Verify and Verbose modes. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. Note that no output is generated for Verify and Verbose modes. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/safenames.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/safenames.rs)

--- a/docs/help/sample.md
+++ b/docs/help/sample.md
@@ -205,8 +205,8 @@ qsv sample --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The CSV file to sample. This can be a local file, stdin, or a URL (http and https schemes supported). |
-| `<sample-size>` | When using INDEXED, RESERVOIR or WEIGHTED sampling, the sample size. Can either be a whole number or a value between value between 0 and 1. If a fraction, specifies the sample size as a percentage of the population. (e.g. 0.15 - 15 percent of the CSV) When using BERNOULLI sampling, the probability of selecting each record (between 0 and 1). When using SYSTEMATIC sampling, the integer part is the interval between records to sample & the fractional part is the percentage of the population to sample. When there is no fractional part, it will select every nth record for the entire population. When using STRATIFIED sampling, the stratum sample size. When using CLUSTER sampling, the number of clusters. When using TIMESERIES sampling, the interval number (treated as hours by default, e.g., 1 = 1 hour). Use --ts-interval for custom intervals like "1d" (daily), "1w" (weekly), "1m" (monthly), "1y" (yearly), etc. |
+| &nbsp;`<input>`&nbsp; | The CSV file to sample. This can be a local file, stdin, or a URL (http and https schemes supported). |
+| &nbsp;`<sample-size>`&nbsp; | When using INDEXED, RESERVOIR or WEIGHTED sampling, the sample size. Can either be a whole number or a value between value between 0 and 1. If a fraction, specifies the sample size as a percentage of the population. (e.g. 0.15 - 15 percent of the CSV) When using BERNOULLI sampling, the probability of selecting each record (between 0 and 1). When using SYSTEMATIC sampling, the integer part is the interval between records to sample & the fractional part is the percentage of the population to sample. When there is no fractional part, it will select every nth record for the entire population. When using STRATIFIED sampling, the stratum sample size. When using CLUSTER sampling, the number of clusters. When using TIMESERIES sampling, the interval number (treated as hours by default, e.g., 1 = 1 hour). Use --ts-interval for custom intervals like "1d" (daily), "1w" (weekly), "1m" (monthly), "1y" (yearly), etc. |
 
 <a name="sample-options"></a>
 
@@ -214,8 +214,8 @@ qsv sample --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--seed` | string | Random Number Generator (RNG) seed. |  |
-| `--rng` | string | The Random Number Generator (RNG) algorithm to use. | `standard` |
+| &nbsp;`--seed`&nbsp; | string | Random Number Generator (RNG) seed. |  |
+| &nbsp;`--rng`&nbsp; | string | The Random Number Generator (RNG) algorithm to use. | `standard` |
 
 <a name="sampling-methods-options"></a>
 
@@ -223,12 +223,12 @@ qsv sample --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--bernoulli` | flag | Use Bernoulli sampling instead of indexed or reservoir sampling. When this flag is set, <sample-size> must be between 0 and 1 and represents the probability of selecting each record. |  |
-| `--systematic` | string | Use systematic sampling (every nth record as specified by <sample-size>). If <arg> is "random", the starting point is randomly chosen between 0 & n. If <arg> is "first", the starting point is the first record. The sample size must be a whole number. Uses CONSTANT memory - O(1). |  |
-| `--stratified` | string | Use stratified sampling. The strata column is specified by <col>. Can be either a column name or 0-based column index. The sample size must be a whole number. Uses MEMORY PROPORTIONAL to the number of strata (s) and samples per stratum (k) - O(s*k). |  |
-| `--weighted` | string | Use weighted sampling. The weight column is specified by <col>. Can be either a column name or 0-based column index. The column will be parsed as a number. Records with non-number weights will be skipped. Uses MEMORY PROPORTIONAL to the sample size (k) - O(k). |  |
-| `--cluster` | string | Use cluster sampling. The cluster column is specified by <col>. Can be either a column name or 0-based column index. Uses MEMORY PROPORTIONAL to the number of clusters (c) - O(c). |  |
-| `--timeseries` | string | Use time-series sampling. The time column is specified by <col>. Can be either a column name or 0-based column index. Sorts records by the specified time column and then groups by time intervals and selects one record per interval. Supports various date formats (19 formats recognized by qsv-dateparser). Uses MEMORY PROPORTIONAL to the number of records - O(n). |  |
+| &nbsp;`--bernoulli`&nbsp; | flag | Use Bernoulli sampling instead of indexed or reservoir sampling. When this flag is set, <sample-size> must be between 0 and 1 and represents the probability of selecting each record. |  |
+| &nbsp;`--systematic`&nbsp; | string | Use systematic sampling (every nth record as specified by <sample-size>). If <arg> is "random", the starting point is randomly chosen between 0 & n. If <arg> is "first", the starting point is the first record. The sample size must be a whole number. Uses CONSTANT memory - O(1). |  |
+| &nbsp;`--stratified`&nbsp; | string | Use stratified sampling. The strata column is specified by <col>. Can be either a column name or 0-based column index. The sample size must be a whole number. Uses MEMORY PROPORTIONAL to the number of strata (s) and samples per stratum (k) - O(s*k). |  |
+| &nbsp;`--weighted`&nbsp; | string | Use weighted sampling. The weight column is specified by <col>. Can be either a column name or 0-based column index. The column will be parsed as a number. Records with non-number weights will be skipped. Uses MEMORY PROPORTIONAL to the sample size (k) - O(k). |  |
+| &nbsp;`--cluster`&nbsp; | string | Use cluster sampling. The cluster column is specified by <col>. Can be either a column name or 0-based column index. Uses MEMORY PROPORTIONAL to the number of clusters (c) - O(c). |  |
+| &nbsp;`--timeseries`&nbsp; | string | Use time-series sampling. The time column is specified by <col>. Can be either a column name or 0-based column index. Sorts records by the specified time column and then groups by time intervals and selects one record per interval. Supports various date formats (19 formats recognized by qsv-dateparser). Uses MEMORY PROPORTIONAL to the number of records - O(n). |  |
 
 <a name="time-series-sampling-options"></a>
 
@@ -236,7 +236,7 @@ qsv sample --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--ts-interval` | string | Time interval for grouping records. Format: <number><unit> where unit is h (hour), d (day), w (week), m (month), y (year). |  |
+| &nbsp;`--ts-interval`&nbsp; | string | Time interval for grouping records. Format: <number><unit> where unit is h (hour), d (day), w (week), m (month), y (year). |  |
 
 <a name="common-options"></a>
 
@@ -244,10 +244,10 @@ qsv sample --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will be considered as part of the population to sample from. (When not set, the first row is the header row and will always appear in the output.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will be considered as part of the population to sample from. (When not set, the first row is the header row and will always appear in the output.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading/writing CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/sample.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sample.rs)

--- a/docs/help/schema.md
+++ b/docs/help/schema.md
@@ -80,18 +80,18 @@ qsv schema --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--enum-threshold` | string | Cardinality threshold for adding enum constraints. Enum constraints are compiled for String & Integer types. | `50` |
-| `-i,`<br>`--ignore-case` | flag | Ignore case when compiling unique values for enum constraints. Do note however that the `validate` command is case-sensitive when validating against enum constraints. |  |
-| `--strict-dates` | flag | Enforce Internet Datetime format (RFC-3339) for detected date/datetime columns. Otherwise, even if columns are inferred as date/datetime, they are set to type "string" in the schema instead of "date" or "date-time". |  |
-| `--strict-formats` | flag | Enforce JSON Schema format constraints for detected email, hostname, and IP address columns. When enabled, String fields are checked against email, hostname, IPv4, and IPv6 formats. Format constraints are only added if ALL unique values in the field match the detected format. |  |
-| `--pattern-columns` | string | Select columns to derive regex pattern constraints. That is, this will create a regular expression that matches all values for each specified column. Columns are selected using `select` syntax (see `qsv select --help` for details). |  |
-| `--dates-whitelist` | string | The case-insensitive patterns to look for when shortlisting fields for date inference. i.e. if the field's name has any of these patterns, it is shortlisted for date inferencing. Set to "all" to inspect ALL fields for date/datetime types. | `date,time,due,open,close,created` |
-| `--prefer-dmy` | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. |  |
-| `--force` | flag | Force recomputing cardinality and unique values even if stats cache file exists and is current. |  |
-| `--stdout` | flag | Send generated JSON schema file to stdout instead. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of using the default filename. For JSON Schema, the default is <input>.schema.json. For Polars schema, the default is <input>.pschema.json. |  |
-| `--polars` | flag | Infer a Polars schema instead of a JSON Schema. This option is only available if the `polars` feature is enabled. The generated Polars schema will be written to a file with the `.pschema.json` suffix appended to the input filename. |  |
+| &nbsp;`--enum-threshold`&nbsp; | string | Cardinality threshold for adding enum constraints. Enum constraints are compiled for String & Integer types. | `50` |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Ignore case when compiling unique values for enum constraints. Do note however that the `validate` command is case-sensitive when validating against enum constraints. |  |
+| &nbsp;`--strict-dates`&nbsp; | flag | Enforce Internet Datetime format (RFC-3339) for detected date/datetime columns. Otherwise, even if columns are inferred as date/datetime, they are set to type "string" in the schema instead of "date" or "date-time". |  |
+| &nbsp;`--strict-formats`&nbsp; | flag | Enforce JSON Schema format constraints for detected email, hostname, and IP address columns. When enabled, String fields are checked against email, hostname, IPv4, and IPv6 formats. Format constraints are only added if ALL unique values in the field match the detected format. |  |
+| &nbsp;`--pattern-columns`&nbsp; | string | Select columns to derive regex pattern constraints. That is, this will create a regular expression that matches all values for each specified column. Columns are selected using `select` syntax (see `qsv select --help` for details). |  |
+| &nbsp;`--dates-whitelist`&nbsp; | string | The case-insensitive patterns to look for when shortlisting fields for date inference. i.e. if the field's name has any of these patterns, it is shortlisted for date inferencing. Set to "all" to inspect ALL fields for date/datetime types. | `date,time,due,open,close,created` |
+| &nbsp;`--prefer-dmy`&nbsp; | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. |  |
+| &nbsp;`--force`&nbsp; | flag | Force recomputing cardinality and unique values even if stats cache file exists and is current. |  |
+| &nbsp;`--stdout`&nbsp; | flag | Send generated JSON schema file to stdout instead. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of using the default filename. For JSON Schema, the default is <input>.schema.json. For Polars schema, the default is <input>.pschema.json. |  |
+| &nbsp;`--polars`&nbsp; | flag | Infer a Polars schema instead of a JSON Schema. This option is only available if the `polars` feature is enabled. The generated Polars schema will be written to a file with the `.pschema.json` suffix appended to the input filename. |  |
 
 <a name="common-options"></a>
 
@@ -99,10 +99,10 @@ qsv schema --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be processed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Namely, it will be processed with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---
 **Source:** [`src/cmd/schema.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/schema.rs)

--- a/docs/help/search.md
+++ b/docs/help/search.md
@@ -98,8 +98,8 @@ qsv search --help
 
 | Argument | Description |
 |----------|-------------|
-| `<regex>` | Regular expression to match. Uses Rust regex syntax. See <https://docs.rs/regex/latest/regex/index.html#syntax> or <https://regex101.com> with the Rust flavor for more info. |
-| `<input>` | The CSV file to read. If not given, reads from stdin. |
+| &nbsp;`<regex>`&nbsp; | Regular expression to match. Uses Rust regex syntax. See <https://docs.rs/regex/latest/regex/index.html#syntax> or <https://regex101.com> with the Rust flavor for more info. |
+| &nbsp;`<input>`&nbsp; | The CSV file to read. If not given, reads from stdin. |
 
 <a name="search-options"></a>
 
@@ -107,21 +107,21 @@ qsv search --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
-| `--literal` | flag | Treat the regex as a literal string. This allows you to search for matches that contain regex special characters. |  |
-| `--exact` | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
-| `-s,`<br>`--select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
-| `-v,`<br>`--invert-match` | flag | Select only rows that did not match |  |
-| `-u,`<br>`--unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
-| `-f,`<br>`--flag` | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>, with the row numbers of the matched rows and 0 for the non-matched rows. If column is named M, only the M column will be written to the output, and only matched rows are returned. |  |
-| `-Q,`<br>`--quick` | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. |  |
-| `--preview-match` | string | Preview the first N matches or all the matches found in N milliseconds, whichever occurs first. Returns the preview to stderr. Output is still written to stdout or --output as usual. Only applicable when CSV is NOT indexed, as it's read sequentially. Forces a sequential search, even if the CSV is indexed. |  |
-| `-c,`<br>`--count` | flag | Return number of matches to stderr. |  |
-| `--size-limit` | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
-| `--dfa-size-limit` | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
-| `--json` | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). Automatically sets --quiet. |  |
-| `--not-one` | flag | Use exit code 0 instead of 1 for no match found. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
+| &nbsp;`--literal`&nbsp; | flag | Treat the regex as a literal string. This allows you to search for matches that contain regex special characters. |  |
+| &nbsp;`--exact`&nbsp; | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
+| &nbsp;`-v,`<br>`--invert-match`&nbsp; | flag | Select only rows that did not match |  |
+| &nbsp;`-u,`<br>`--unicode`&nbsp; | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
+| &nbsp;`-f,`<br>`--flag`&nbsp; | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>, with the row numbers of the matched rows and 0 for the non-matched rows. If column is named M, only the M column will be written to the output, and only matched rows are returned. |  |
+| &nbsp;`-Q,`<br>`--quick`&nbsp; | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. |  |
+| &nbsp;`--preview-match`&nbsp; | string | Preview the first N matches or all the matches found in N milliseconds, whichever occurs first. Returns the preview to stderr. Output is still written to stdout or --output as usual. Only applicable when CSV is NOT indexed, as it's read sequentially. Forces a sequential search, even if the CSV is indexed. |  |
+| &nbsp;`-c,`<br>`--count`&nbsp; | flag | Return number of matches to stderr. |  |
+| &nbsp;`--size-limit`&nbsp; | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
+| &nbsp;`--dfa-size-limit`&nbsp; | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
+| &nbsp;`--json`&nbsp; | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). Automatically sets --quiet. |  |
+| &nbsp;`--not-one`&nbsp; | flag | Use exit code 0 instead of 1 for no match found. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -129,12 +129,12 @@ qsv search --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. Only applicable when CSV is NOT indexed. |  |
-| `-q,`<br>`--quiet` | flag | Do not return number of matches to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. Only applicable when CSV is NOT indexed. |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not return number of matches to stderr. |  |
 
 ---
 **Source:** [`src/cmd/search.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/search.rs)

--- a/docs/help/searchset.md
+++ b/docs/help/searchset.md
@@ -51,8 +51,8 @@ qsv searchset --help
 
 | Argument | Description |
 |----------|-------------|
-| `<regexset-file>` | The file containing regular expressions to match, with a regular expression on each line. See <https://docs.rs/regex/latest/regex/index.html#syntax> or <https://regex101.com> with the Rust flavor for regex syntax. |
-| `<input>` | The CSV file to read. If not given, reads from stdin. |
+| &nbsp;`<regexset-file>`&nbsp; | The file containing regular expressions to match, with a regular expression on each line. See <https://docs.rs/regex/latest/regex/index.html#syntax> or <https://regex101.com> with the Rust flavor for regex syntax. |
+| &nbsp;`<input>`&nbsp; | The CSV file to read. If not given, reads from stdin. |
 
 <a name="searchset-options"></a>
 
@@ -60,22 +60,22 @@ qsv searchset --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-i,`<br>`--ignore-case` | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
-| `--literal` | flag | Treat the regex as a literal string. This allows you to search for matches that contain regex special characters. |  |
-| `--exact` | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
-| `-s,`<br>`--select` | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
-| `-v,`<br>`--invert-match` | flag | Select only rows that did not match |  |
-| `-u,`<br>`--unicode` | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
-| `-f,`<br>`--flag` | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>. For each found row, <column> is set to the row number of the row, followed by a semicolon, then a list of the matching regexes. |  |
-| `--flag-matches-only` | flag | When --flag is enabled, only rows that match are sent to output. Rows that do not match are filtered. |  |
-| `--unmatched-output` | string | When --flag-matches-only is enabled, output the rows that did not match to <file>. |  |
-| `-Q,`<br>`--quick` | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. Ignored if --json is enabled. |  |
-| `-c,`<br>`--count` | flag | Return number of matches to stderr. Ignored if --json is enabled. |  |
-| `-j,`<br>`--json` | flag | Return number of matches, number of rows with matches, and number of rows to stderr in JSON format. |  |
-| `--size-limit` | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
-| `--dfa-size-limit` | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
-| `--not-one` | flag | Use exit code 0 instead of 1 for no match found. |  |
-| `--jobs` | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Case insensitive search. This is equivalent to prefixing the regex with '(?i)'. |  |
+| &nbsp;`--literal`&nbsp; | flag | Treat the regex as a literal string. This allows you to search for matches that contain regex special characters. |  |
+| &nbsp;`--exact`&nbsp; | flag | Match the ENTIRE field exactly. Treats the pattern as a literal string (like --literal) and automatically anchors it to match the complete field value (^pattern$). |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
+| &nbsp;`-v,`<br>`--invert-match`&nbsp; | flag | Select only rows that did not match |  |
+| &nbsp;`-u,`<br>`--unicode`&nbsp; | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
+| &nbsp;`-f,`<br>`--flag`&nbsp; | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>. For each found row, <column> is set to the row number of the row, followed by a semicolon, then a list of the matching regexes. |  |
+| &nbsp;`--flag-matches-only`&nbsp; | flag | When --flag is enabled, only rows that match are sent to output. Rows that do not match are filtered. |  |
+| &nbsp;`--unmatched-output`&nbsp; | string | When --flag-matches-only is enabled, output the rows that did not match to <file>. |  |
+| &nbsp;`-Q,`<br>`--quick`&nbsp; | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. Ignored if --json is enabled. |  |
+| &nbsp;`-c,`<br>`--count`&nbsp; | flag | Return number of matches to stderr. Ignored if --json is enabled. |  |
+| &nbsp;`-j,`<br>`--json`&nbsp; | flag | Return number of matches, number of rows with matches, and number of rows to stderr in JSON format. |  |
+| &nbsp;`--size-limit`&nbsp; | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
+| &nbsp;`--dfa-size-limit`&nbsp; | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
+| &nbsp;`--not-one`&nbsp; | flag | Use exit code 0 instead of 1 for no match found. |  |
+| &nbsp;`--jobs`&nbsp; | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -83,12 +83,12 @@ qsv searchset --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
-| `-q,`<br>`--quiet` | flag | Do not return number of matches to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not return number of matches to stderr. |  |
 
 ---
 **Source:** [`src/cmd/searchset.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/searchset.rs)

--- a/docs/help/select.md
+++ b/docs/help/select.md
@@ -150,7 +150,7 @@ qsv select --help
 
 | Argument | Description |
 |----------|-------------|
-| `<selection>` | The columns to select. You can select columns by index, by name, by range, by regex and any combination of these. If the first character is '!', the selection will be inverted. If the selection contains embedded spaces or characters that conflict with selector syntax, it must be quoted. See examples above. |
+| &nbsp;`<selection>`&nbsp; | The columns to select. You can select columns by index, by name, by range, by regex and any combination of these. If the first character is '!', the selection will be inverted. If the selection contains embedded spaces or characters that conflict with selector syntax, it must be quoted. See examples above. |
 
 <a name="select-options"></a>
 
@@ -158,9 +158,9 @@ qsv select --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-R,`<br>`--random` | flag | Randomly shuffle the columns in the selection. |  |
-| `--seed` | string | Seed for the random number generator. |  |
-| `-S,`<br>`--sort` | flag | Sort the selected columns lexicographically, i.e. by their byte values. |  |
+| &nbsp;`-R,`<br>`--random`&nbsp; | flag | Randomly shuffle the columns in the selection. |  |
+| &nbsp;`--seed`&nbsp; | string | Seed for the random number generator. |  |
+| &nbsp;`-S,`<br>`--sort`&nbsp; | flag | Sort the selected columns lexicographically, i.e. by their byte values. |  |
 
 <a name="common-options"></a>
 
@@ -168,10 +168,10 @@ qsv select --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/select.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/select.rs)

--- a/docs/help/slice.md
+++ b/docs/help/slice.md
@@ -114,12 +114,12 @@ qsv slice --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--start` | string | The index of the record to slice from. If negative, starts from the last record. |  |
-| `-e,`<br>`--end` | string | The index of the record to slice to. |  |
-| `-l,`<br>`--len` | string | The length of the slice (can be used instead of --end). |  |
-| `-i,`<br>`--index` | string | Slice a single record (shortcut for -s N -l 1). If negative, starts from the last record. |  |
-| `--json` | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). |  |
-| `--invert` | flag | slice all records EXCEPT those in the specified range. |  |
+| &nbsp;`-s,`<br>`--start`&nbsp; | string | The index of the record to slice from. If negative, starts from the last record. |  |
+| &nbsp;`-e,`<br>`--end`&nbsp; | string | The index of the record to slice to. |  |
+| &nbsp;`-l,`<br>`--len`&nbsp; | string | The length of the slice (can be used instead of --end). |  |
+| &nbsp;`-i,`<br>`--index`&nbsp; | string | Slice a single record (shortcut for -s N -l 1). If negative, starts from the last record. |  |
+| &nbsp;`--json`&nbsp; | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). |  |
+| &nbsp;`--invert`&nbsp; | flag | slice all records EXCEPT those in the specified range. |  |
 
 <a name="common-options"></a>
 
@@ -127,10 +127,10 @@ qsv slice --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Otherwise, the first row will always appear in the output as the header row. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Otherwise, the first row will always appear in the output as the header row. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/slice.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/slice.rs)

--- a/docs/help/snappy.md
+++ b/docs/help/snappy.md
@@ -54,7 +54,7 @@ qsv snappy --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The input file to compress/decompress. This can be a local file, stdin, or a URL (http and https schemes supported). |
+| &nbsp;`<input>`&nbsp; | The input file to compress/decompress. This can be a local file, stdin, or a URL (http and https schemes supported). |
 
 <a name="snappy-options"></a>
 
@@ -62,8 +62,8 @@ qsv snappy --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--user-agent` | string | Specify custom user agent to use when the input is a URL. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
-| `--timeout` | string | Timeout for downloading URLs in seconds. | `60` |
+| &nbsp;`--user-agent`&nbsp; | string | Specify custom user agent to use when the input is a URL. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for downloading URLs in seconds. | `60` |
 
 <a name="common-options"></a>
 
@@ -71,11 +71,11 @@ qsv snappy --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <output> instead of stdout. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel when compressing. When not set, its set to the number of CPUs - 1 |  |
-| `-q,`<br>`--quiet` | flag | Suppress status messages to stderr. |  |
-| `-p,`<br>`--progressbar` | flag | Show download progress bars. Only valid for URL input. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <output> instead of stdout. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel when compressing. When not set, its set to the number of CPUs - 1 |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Suppress status messages to stderr. |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show download progress bars. Only valid for URL input. |  |
 
 ---
 **Source:** [`src/cmd/snappy.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/snappy.rs)

--- a/docs/help/sniff.md
+++ b/docs/help/sniff.md
@@ -88,7 +88,7 @@ qsv sniff --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The file to sniff. This can be a local file, stdin or a URL (http and https schemes supported). |
+| &nbsp;`<input>`&nbsp; | The file to sniff. This can be a local file, stdin or a URL (http and https schemes supported). |
 
 <a name="sniff-options"></a>
 
@@ -96,20 +96,20 @@ qsv sniff --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--sample` | string | First n rows to sample to sniff out the metadata. When sample size is between 0 and 1 exclusive, it is treated as a percentage of the CSV to sample (e.g. 0.20 is 20 percent). When it is zero, the entire file will be sampled. When the input is a URL, the sample size dictates how many lines to sample without having to download the entire file. Ignored when --no-infer is enabled. | `1000` |
-| `--prefer-dmy` | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. Ignored when --no-infer is enabled. |  |
-| `-d,`<br>`--delimiter` | string | The delimiter for reading CSV data. Specify this when the delimiter is known beforehand, as the delimiter inferencing algorithm can sometimes fail. Must be a single ascii character. |  |
-| `--quote` | string | The quote character for reading CSV data. Specify this when the quote character is known beforehand, as the quote char inferencing algorithm can sometimes fail. Must be a single ascii character - typically, double quote ("), single quote ('), or backtick (`). |  |
-| `--json` | flag | Return results in JSON format. |  |
-| `--pretty-json` | flag | Return results in pretty JSON format. |  |
-| `--save-urlsample` | string | Save the URL sample to a file. Valid only when input is a URL. |  |
-| `--timeout` | string | Timeout when sniffing URLs in seconds. If 0, no timeout is used. | `30` |
-| `--user-agent` | string | Specify custom user agent to use when sniffing a CSV on a URL. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
-| `--stats-types` | flag | Use the same data type names as `stats`. (Unsigned, Signed => Integer, Text => String, everything else the same) |  |
-| `--no-infer` | flag | Do not infer the schema. Only return the file's mime type, size and last modified date. Use this to use sniff as a general mime type detector. Note that CSV and TSV files will only be detected as mime type plain/text in this mode. |  |
-| `--just-mime` | flag | Only return the file's mime type. Use this to use sniff as a general mime type detector. Synonym for --no-infer. |  |
-| `-Q,`<br>`--quick` | flag | When sniffing a non-CSV remote file, only download the first chunk of the file before attempting to detect the mime type. This is faster but less accurate as some mime types cannot be detected with just the first downloaded chunk. |  |
-| `--harvest-mode` | flag | This is a convenience flag when using sniff in CKAN harvesters. It is equivalent to --quick --timeout 10 --stats-types --json and --user-agent "CKAN-harvest/$QSV_VERSION ($QSV_TARGET; $QSV_BIN_NAME)" |  |
+| &nbsp;`--sample`&nbsp; | string | First n rows to sample to sniff out the metadata. When sample size is between 0 and 1 exclusive, it is treated as a percentage of the CSV to sample (e.g. 0.20 is 20 percent). When it is zero, the entire file will be sampled. When the input is a URL, the sample size dictates how many lines to sample without having to download the entire file. Ignored when --no-infer is enabled. | `1000` |
+| &nbsp;`--prefer-dmy`&nbsp; | flag | Prefer to parse dates in dmy format. Otherwise, use mdy format. Ignored when --no-infer is enabled. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The delimiter for reading CSV data. Specify this when the delimiter is known beforehand, as the delimiter inferencing algorithm can sometimes fail. Must be a single ascii character. |  |
+| &nbsp;`--quote`&nbsp; | string | The quote character for reading CSV data. Specify this when the quote character is known beforehand, as the quote char inferencing algorithm can sometimes fail. Must be a single ascii character - typically, double quote ("), single quote ('), or backtick (`). |  |
+| &nbsp;`--json`&nbsp; | flag | Return results in JSON format. |  |
+| &nbsp;`--pretty-json`&nbsp; | flag | Return results in pretty JSON format. |  |
+| &nbsp;`--save-urlsample`&nbsp; | string | Save the URL sample to a file. Valid only when input is a URL. |  |
+| &nbsp;`--timeout`&nbsp; | string | Timeout when sniffing URLs in seconds. If 0, no timeout is used. | `30` |
+| &nbsp;`--user-agent`&nbsp; | string | Specify custom user agent to use when sniffing a CSV on a URL. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
+| &nbsp;`--stats-types`&nbsp; | flag | Use the same data type names as `stats`. (Unsigned, Signed => Integer, Text => String, everything else the same) |  |
+| &nbsp;`--no-infer`&nbsp; | flag | Do not infer the schema. Only return the file's mime type, size and last modified date. Use this to use sniff as a general mime type detector. Note that CSV and TSV files will only be detected as mime type plain/text in this mode. |  |
+| &nbsp;`--just-mime`&nbsp; | flag | Only return the file's mime type. Use this to use sniff as a general mime type detector. Synonym for --no-infer. |  |
+| &nbsp;`-Q,`<br>`--quick`&nbsp; | flag | When sniffing a non-CSV remote file, only download the first chunk of the file before attempting to detect the mime type. This is faster but less accurate as some mime types cannot be detected with just the first downloaded chunk. |  |
+| &nbsp;`--harvest-mode`&nbsp; | flag | This is a convenience flag when using sniff in CKAN harvesters. It is equivalent to --quick --timeout 10 --stats-types --json and --user-agent "CKAN-harvest/$QSV_VERSION ($QSV_TARGET; $QSV_BIN_NAME)" |  |
 
 <a name="common-options"></a>
 
@@ -117,8 +117,8 @@ qsv sniff --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Only valid for URL input. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Only valid for URL input. |  |
 
 ---
 **Source:** [`src/cmd/sniff.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sniff.rs)

--- a/docs/help/sort.md
+++ b/docs/help/sort.md
@@ -35,12 +35,12 @@ qsv sort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--select` | string | Select a subset of columns to sort. See 'qsv select --help' for the format details. |  |
-| `-N,`<br>`--numeric` | flag | Compare according to string numerical value |  |
-| `--natural` | flag | Compare strings using natural sort order (treats numbers within strings as actual numbers, e.g. "data1.txt", "data2.txt", "data10.txt", as opposed to "data1.txt", "data10.txt", "data2.txt" when sorting lexicographically) <https://en.wikipedia.org/wiki/Natural_sort_order> |  |
-| `-R,`<br>`--reverse` | flag | Reverse order |  |
-| `-i,`<br>`--ignore-case` | flag | Compare strings disregarding case |  |
-| `-u,`<br>`--unique` | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to sort. See 'qsv select --help' for the format details. |  |
+| &nbsp;`-N,`<br>`--numeric`&nbsp; | flag | Compare according to string numerical value |  |
+| &nbsp;`--natural`&nbsp; | flag | Compare strings using natural sort order (treats numbers within strings as actual numbers, e.g. "data1.txt", "data2.txt", "data10.txt", as opposed to "data1.txt", "data10.txt", "data2.txt" when sorting lexicographically) <https://en.wikipedia.org/wiki/Natural_sort_order> |  |
+| &nbsp;`-R,`<br>`--reverse`&nbsp; | flag | Reverse order |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Compare strings disregarding case |  |
+| &nbsp;`-u,`<br>`--unique`&nbsp; | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. |  |
 
 <a name="random-sorting-options"></a>
 
@@ -48,11 +48,11 @@ qsv sort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--random` | flag | Randomize (scramble) the data by row |  |
-| `--seed` | string | Random Number Generator (RNG) seed to use if --random is set |  |
-| `--rng` | string | The RNG algorithm to use if --random is set. | `standard` |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `--faster` | flag | When set, the sort will be faster. This is done by using a faster sorting algorithm that is not "stable" (i.e. the order of identical values is not guaranteed to be preserved). It has the added side benefit that the sort will also be in-place (i.e. does not allocate), which is useful for sorting large files that will otherwise NOT fit in memory using the default allocating stable sort. |  |
+| &nbsp;`--random`&nbsp; | flag | Randomize (scramble) the data by row |  |
+| &nbsp;`--seed`&nbsp; | string | Random Number Generator (RNG) seed to use if --random is set |  |
+| &nbsp;`--rng`&nbsp; | string | The RNG algorithm to use if --random is set. | `standard` |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`--faster`&nbsp; | flag | When set, the sort will be faster. This is done by using a faster sorting algorithm that is not "stable" (i.e. the order of identical values is not guaranteed to be preserved). It has the added side benefit that the sort will also be in-place (i.e. does not allocate), which is useful for sorting large files that will otherwise NOT fit in memory using the default allocating stable sort. |  |
 
 <a name="common-options"></a>
 
@@ -60,11 +60,11 @@ qsv sort --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. Ignored if --random or --faster is set. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Namely, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. Ignored if --random or --faster is set. |  |
 
 ---
 **Source:** [`src/cmd/sort.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sort.rs)

--- a/docs/help/sortcheck.md
+++ b/docs/help/sortcheck.md
@@ -50,11 +50,11 @@ qsv sortcheck --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--select` | string | Select a subset of columns to check for sort. See 'qsv select --help' for the format details. |  |
-| `-i,`<br>`--ignore-case` | flag | Compare strings disregarding case |  |
-| `--all` | flag | Check all records. Do not stop/short-circuit the check on the first unsorted record. |  |
-| `--json` | flag | Return results in JSON format, scanning --all records. The JSON result has the following properties - sorted (boolean), record_count (number), unsorted_breaks (number) & dupe_count (number). Unsorted breaks count the number of times two consecutive rows are unsorted (i.e. n row > n+1 row). Dupe count is the number of times two consecutive rows are equal. Note that dupe count does not apply if the file is not sorted and is set to -1. |  |
-| `--pretty-json` | flag | Same as --json but in pretty JSON format. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to check for sort. See 'qsv select --help' for the format details. |  |
+| &nbsp;`-i,`<br>`--ignore-case`&nbsp; | flag | Compare strings disregarding case |  |
+| &nbsp;`--all`&nbsp; | flag | Check all records. Do not stop/short-circuit the check on the first unsorted record. |  |
+| &nbsp;`--json`&nbsp; | flag | Return results in JSON format, scanning --all records. The JSON result has the following properties - sorted (boolean), record_count (number), unsorted_breaks (number) & dupe_count (number). Unsorted breaks count the number of times two consecutive rows are unsorted (i.e. n row > n+1 row). Dupe count is the number of times two consecutive rows are equal. Note that dupe count does not apply if the file is not sorted and is set to -1. |  |
+| &nbsp;`--pretty-json`&nbsp; | flag | Same as --json but in pretty JSON format. |  |
 
 <a name="common-options"></a>
 
@@ -62,10 +62,10 @@ qsv sortcheck --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/sortcheck.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sortcheck.rs)

--- a/docs/help/split.md
+++ b/docs/help/split.md
@@ -128,8 +128,8 @@ qsv split --help
 
 | Argument | Description |
 |----------|-------------|
-| `<outdir>` | The directory where the output files will be written. If it does not exist, it will be created. |
-| `<input>` | The CSV file to read. If not given, input is read from STDIN. |
+| &nbsp;`<outdir>`&nbsp; | The directory where the output files will be written. If it does not exist, it will be created. |
+| &nbsp;`<input>`&nbsp; | The CSV file to read. If not given, input is read from STDIN. |
 
 <a name="split-options"></a>
 
@@ -137,12 +137,12 @@ qsv split --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--size` | string | The number of records to write into each chunk. | `500` |
-| `-c,`<br>`--chunks` | string | The number of chunks to split the data into. This option is mutually exclusive with --size. The number of rows in each chunk is determined by the number of records in the CSV data and the number of desired chunks. If the number of records is not evenly divisible by the number of chunks, the last chunk will have fewer records. |  |
-| `-k,`<br>`--kb-size` | string | The size of each chunk in kilobytes. The number of rows in each chunk may vary, but the size of each chunk will not exceed the desired size. This option is mutually exclusive with --size and --chunks. |  |
-| `-j,`<br>`--jobs` | string | The number of splitting jobs to run in parallel. This only works when the given CSV data has an index already created. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `--filename` | string | A filename template to use when constructing the names of the output files.  The string '{}' will be replaced by the zero-based row number of the first row in the chunk. | `{}.csv` |
-| `--pad` | string | The zero padding width that is used in the generated filename. | `0` |
+| &nbsp;`-s,`<br>`--size`&nbsp; | string | The number of records to write into each chunk. | `500` |
+| &nbsp;`-c,`<br>`--chunks`&nbsp; | string | The number of chunks to split the data into. This option is mutually exclusive with --size. The number of rows in each chunk is determined by the number of records in the CSV data and the number of desired chunks. If the number of records is not evenly divisible by the number of chunks, the last chunk will have fewer records. |  |
+| &nbsp;`-k,`<br>`--kb-size`&nbsp; | string | The size of each chunk in kilobytes. The number of rows in each chunk may vary, but the size of each chunk will not exceed the desired size. This option is mutually exclusive with --size and --chunks. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of splitting jobs to run in parallel. This only works when the given CSV data has an index already created. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`--filename`&nbsp; | string | A filename template to use when constructing the names of the output files.  The string '{}' will be replaced by the zero-based row number of the first row in the chunk. | `{}.csv` |
+| &nbsp;`--pad`&nbsp; | string | The zero padding width that is used in the generated filename. | `0` |
 
 <a name="filter-options"></a>
 
@@ -150,9 +150,9 @@ qsv split --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--filter` | string | Run the specified command on each chunk after it is written. The command should use the FILE environment variable ($FILE on Linux/macOS, %FILE% on Windows), which is set to the path of the output file for each chunk. The string '{}' in the command will be replaced by the zero-based row number of the first row in the chunk. |  |
-| `--filter-cleanup` | flag | Cleanup the original output filename AFTER the filter command is run successfully for EACH chunk. If the filter command is not successful, the original filename is not removed. Only valid when --filter is used. |  |
-| `--filter-ignore-errors` | flag | Ignore errors when running the filter command. Only valid when --filter is used. |  |
+| &nbsp;`--filter`&nbsp; | string | Run the specified command on each chunk after it is written. The command should use the FILE environment variable ($FILE on Linux/macOS, %FILE% on Windows), which is set to the path of the output file for each chunk. The string '{}' in the command will be replaced by the zero-based row number of the first row in the chunk. |  |
+| &nbsp;`--filter-cleanup`&nbsp; | flag | Cleanup the original output filename AFTER the filter command is run successfully for EACH chunk. If the filter command is not successful, the original filename is not removed. Only valid when --filter is used. |  |
+| &nbsp;`--filter-ignore-errors`&nbsp; | flag | Ignore errors when running the filter command. Only valid when --filter is used. |  |
 
 <a name="common-options"></a>
 
@@ -160,10 +160,10 @@ qsv split --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-q,`<br>`--quiet` | flag | Do not display an output summary to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will NOT be interpreted as column names. Otherwise, the first row will appear in all chunks as the header row. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not display an output summary to stderr. |  |
 
 ---
 **Source:** [`src/cmd/split.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/split.rs)

--- a/docs/help/sqlp.md
+++ b/docs/help/sqlp.md
@@ -300,7 +300,7 @@ qsv sqlp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--format` | string | The output format to use. Valid values are: csv, json, jsonl, parquet, arrow, avro | `csv` |
+| &nbsp;`--format`&nbsp; | string | The output format to use. Valid values are: csv, json, jsonl, parquet, arrow, avro | `csv` |
 
 <a name="polars-csv-input-parsing-options"></a>
 
@@ -308,16 +308,16 @@ qsv sqlp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--try-parsedates` | flag | Automatically try to parse dates/datetimes and time. If parsing fails, columns remain as strings. Note that if dates are not well-formatted in your CSV, that you may want to try to set `--ignore-errors` to relax the CSV parsing of dates. |  |
-| `--infer-len` | string | The number of rows to scan when inferring the schema of the CSV. Set to 0 to do a full table scan (warning: can be slow). | `10000` |
-| `--cache-schema` | flag | Create and cache Polars schema JSON files. If the schema file/s exists, it will load the schema instead of inferring it (ignoring --infer-len) and attempt to use it for each corresponding Polars "table" with the same file stem. If specified and the schema file/s do not exist, it will check if a stats cache is available. If so, it will use it to derive a Polars schema and save it. If there's no stats cache, it will infer the schema using --infer-len and save the inferred schemas. Each schema file will have the same file stem as the corresponding input file, with the extension ".pschema.json" (data.csv's Polars schema file will be data.pschema.json) NOTE: You can edit the generated schema files to change the Polars schema and cast columns to the desired data type. For example, you can force a Float32 column to be a Float64 column by changing the "Float32" type to "Float64" in the schema file. You can also cast a Float to a Decimal with a desired precision and scale. (e.g. instead of "Float32", use "{Decimal" : [10, 3]}") The valid types are: `Boolean`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Int8`, `Int16`, `Int32`, `Int64`, `Float32`, `Float64`, `String`, `Date`, `Datetime`, `Duration`, `Time`, `Null`, `Categorical`, `Decimal` and `Enum`. |  |
-| `--streaming` | flag | Use streaming mode when parsing CSVs. This will use less memory but will be slower. Only use this when you get out of memory errors. |  |
-| `--low-memory` | flag | Use low memory mode when parsing CSVs. This will use less memory but will be slower. Only use this when you get out of memory errors. |  |
-| `--no-optimizations` | flag | Disable non-default query optimizations. This will make queries slower. Use this when you get query errors or to force CSV parsing when there is only one input file, no CSV parsing options are used and its not a SQL script. |  |
-| `--truncate-ragged-lines` | flag | Truncate ragged lines when parsing CSVs. If set, rows with more columns than the header will be truncated. If not set, the query will fail. Use this only when you get an error about ragged lines. |  |
-| `--ignore-errors` | flag | Ignore errors when parsing CSVs. If set, rows with errors will be skipped. If not set, the query will fail. Only use this when debugging queries, as Polars does batched parsing and will skip the entire batch where the error occurred. To get more detailed error messages, set the environment variable POLARS_BACKTRACE_IN_ERR=1 before running the query. |  |
-| `--rnull-values` | string | The comma-delimited list of case-sensitive strings to consider as null values when READING CSV files (e.g. NULL, NONE, <empty string>). Use "<empty string>" to consider an empty string a null value. | `<empty string>` |
-| `--decimal-comma` | flag | Use comma as the decimal separator when parsing & writing CSVs. Otherwise, use period as the decimal separator. Note that you'll need to set --delimiter to an alternate delimiter other than the default comma if you are using this option. |  |
+| &nbsp;`--try-parsedates`&nbsp; | flag | Automatically try to parse dates/datetimes and time. If parsing fails, columns remain as strings. Note that if dates are not well-formatted in your CSV, that you may want to try to set `--ignore-errors` to relax the CSV parsing of dates. |  |
+| &nbsp;`--infer-len`&nbsp; | string | The number of rows to scan when inferring the schema of the CSV. Set to 0 to do a full table scan (warning: can be slow). | `10000` |
+| &nbsp;`--cache-schema`&nbsp; | flag | Create and cache Polars schema JSON files. If the schema file/s exists, it will load the schema instead of inferring it (ignoring --infer-len) and attempt to use it for each corresponding Polars "table" with the same file stem. If specified and the schema file/s do not exist, it will check if a stats cache is available. If so, it will use it to derive a Polars schema and save it. If there's no stats cache, it will infer the schema using --infer-len and save the inferred schemas. Each schema file will have the same file stem as the corresponding input file, with the extension ".pschema.json" (data.csv's Polars schema file will be data.pschema.json) NOTE: You can edit the generated schema files to change the Polars schema and cast columns to the desired data type. For example, you can force a Float32 column to be a Float64 column by changing the "Float32" type to "Float64" in the schema file. You can also cast a Float to a Decimal with a desired precision and scale. (e.g. instead of "Float32", use "{Decimal" : [10, 3]}") The valid types are: `Boolean`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Int8`, `Int16`, `Int32`, `Int64`, `Float32`, `Float64`, `String`, `Date`, `Datetime`, `Duration`, `Time`, `Null`, `Categorical`, `Decimal` and `Enum`. |  |
+| &nbsp;`--streaming`&nbsp; | flag | Use streaming mode when parsing CSVs. This will use less memory but will be slower. Only use this when you get out of memory errors. |  |
+| &nbsp;`--low-memory`&nbsp; | flag | Use low memory mode when parsing CSVs. This will use less memory but will be slower. Only use this when you get out of memory errors. |  |
+| &nbsp;`--no-optimizations`&nbsp; | flag | Disable non-default query optimizations. This will make queries slower. Use this when you get query errors or to force CSV parsing when there is only one input file, no CSV parsing options are used and its not a SQL script. |  |
+| &nbsp;`--truncate-ragged-lines`&nbsp; | flag | Truncate ragged lines when parsing CSVs. If set, rows with more columns than the header will be truncated. If not set, the query will fail. Use this only when you get an error about ragged lines. |  |
+| &nbsp;`--ignore-errors`&nbsp; | flag | Ignore errors when parsing CSVs. If set, rows with errors will be skipped. If not set, the query will fail. Only use this when debugging queries, as Polars does batched parsing and will skip the entire batch where the error occurred. To get more detailed error messages, set the environment variable POLARS_BACKTRACE_IN_ERR=1 before running the query. |  |
+| &nbsp;`--rnull-values`&nbsp; | string | The comma-delimited list of case-sensitive strings to consider as null values when READING CSV files (e.g. NULL, NONE, <empty string>). Use "<empty string>" to consider an empty string a null value. | `<empty string>` |
+| &nbsp;`--decimal-comma`&nbsp; | flag | Use comma as the decimal separator when parsing & writing CSVs. Otherwise, use period as the decimal separator. Note that you'll need to set --delimiter to an alternate delimiter other than the default comma if you are using this option. |  |
 
 <a name="csv-output-format-only-options"></a>
 
@@ -325,11 +325,11 @@ qsv sqlp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--datetime-format` | string | The datetime format to use writing datetimes. See <https://docs.rs/chrono/latest/chrono/format/strftime/index.html> for the list of valid format specifiers. |  |
-| `--date-format` | string | The date format to use writing dates. |  |
-| `--time-format` | string | The time format to use writing times. |  |
-| `--float-precision` | string | The number of digits of precision to use when writing floats. |  |
-| `--wnull-value` | string | The string to use when WRITING null values. | `<empty string>` |
+| &nbsp;`--datetime-format`&nbsp; | string | The datetime format to use writing datetimes. See <https://docs.rs/chrono/latest/chrono/format/strftime/index.html> for the list of valid format specifiers. |  |
+| &nbsp;`--date-format`&nbsp; | string | The date format to use writing dates. |  |
+| &nbsp;`--time-format`&nbsp; | string | The time format to use writing times. |  |
+| &nbsp;`--float-precision`&nbsp; | string | The number of digits of precision to use when writing floats. |  |
+| &nbsp;`--wnull-value`&nbsp; | string | The string to use when WRITING null values. | `<empty string>` |
 
 <a name="arrow/avro/parquet-output-formats-only-options"></a>
 
@@ -337,7 +337,7 @@ qsv sqlp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--compression` | string | The compression codec to use when writing arrow or parquet files. For Arrow, valid values are: zstd, lz4, uncompressed For Avro, valid values are: deflate, snappy, uncompressed (default) For Parquet, valid values are: zstd, lz4raw, gzip, snappy, uncompressed | `zstd` |
+| &nbsp;`--compression`&nbsp; | string | The compression codec to use when writing arrow or parquet files. For Arrow, valid values are: zstd, lz4, uncompressed For Avro, valid values are: deflate, snappy, uncompressed (default) For Parquet, valid values are: zstd, lz4raw, gzip, snappy, uncompressed | `zstd` |
 
 <a name="parquet-output-format-only-options"></a>
 
@@ -345,8 +345,8 @@ qsv sqlp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--compress-level` | string | The compression level to use when using zstd or gzip compression. When using zstd, valid values are -7 to 22, with -7 being the lowest compression level and 22 being the highest compression level. When using gzip, valid values are 1-9, with 1 being the lowest compression level and 9 being the highest compression level. Higher compression levels are slower. The zstd default is 3, and the gzip default is 6. |  |
-| `--statistics` | flag | Compute column statistics when writing parquet files. |  |
+| &nbsp;`--compress-level`&nbsp; | string | The compression level to use when using zstd or gzip compression. When using zstd, valid values are -7 to 22, with -7 being the lowest compression level and 22 being the highest compression level. When using gzip, valid values are 1-9, with 1 being the lowest compression level and 9 being the highest compression level. Higher compression levels are slower. The zstd default is 3, and the gzip default is 6. |  |
+| &nbsp;`--statistics`&nbsp; | flag | Compute column statistics when writing parquet files. |  |
 
 <a name="common-options"></a>
 
@@ -354,10 +354,10 @@ qsv sqlp --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading and writing CSV data. Must be a single character. | `,` |
-| `-q,`<br>`--quiet` | flag | Do not return result shape to stderr. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading and writing CSV data. Must be a single character. | `,` |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not return result shape to stderr. |  |
 
 ---
 **Source:** [`src/cmd/sqlp.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/sqlp.rs)

--- a/docs/help/stats.md
+++ b/docs/help/stats.md
@@ -228,9 +228,9 @@ qsv stats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-s,`<br>`--select` | string | Select a subset of columns to compute stats for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv stats' will prevent the use of indexing. |  |
-| `-E,`<br>`--everything` | flag | Compute all statistics available. |  |
-| `--typesonly` | flag | Infer data types only and do not compute statistics. Note that if you want to infer dates and boolean types, you'll still need to use the --infer-dates & --infer-boolean options. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to compute stats for. See 'qsv select --help' for the format details. This is provided here because piping 'qsv select' into 'qsv stats' will prevent the use of indexing. |  |
+| &nbsp;`-E,`<br>`--everything`&nbsp; | flag | Compute all statistics available. |  |
+| &nbsp;`--typesonly`&nbsp; | flag | Infer data types only and do not compute statistics. Note that if you want to infer dates and boolean types, you'll still need to use the --infer-dates & --infer-boolean options. |  |
 
 <a name="boolean-inferencing-options"></a>
 
@@ -238,10 +238,10 @@ qsv stats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--infer-boolean` | flag | Infer boolean data type. This automatically enables the --cardinality option. When a column's cardinality is 2, and the 2 values' are in the true/false patterns specified by --boolean-patterns, the data type is inferred as boolean. |  |
-| `--boolean-patterns` | string | Comma-separated list of boolean pattern pairs in the format "true_pattern:false_pattern". Each pattern can be a string of any length. The patterns are case-insensitive. If a pattern ends with a "*", it is treated as a prefix. For example, "t*:f*,y*:n*" will match "true", "truthy", "Truth" as boolean true values so long as the corresponding false pattern (e.g. False, f, etc.) is also matched & cardinality is 2. Ignored if --infer-boolean is false. | `1:0,t*:f*,y*:n*` |
-| `--mode` | flag | Compute the mode/s & antimode/s. Multimodal-aware. If there are multiple modes/antimodes, they are separated by the QSV_STATS_SEPARATOR environment variable. If not set, the default separator is "\|". Uses memory proportional to the cardinality of each column. |  |
-| `--cardinality` | flag | Compute the cardinality and the uniqueness ratio. This is automatically enabled if --infer-boolean is enabled. <https://en.wikipedia.org/wiki/Cardinality_(SQL_statements)> Uses memory proportional to the number of unique values in each column. |  |
+| &nbsp;`--infer-boolean`&nbsp; | flag | Infer boolean data type. This automatically enables the --cardinality option. When a column's cardinality is 2, and the 2 values' are in the true/false patterns specified by --boolean-patterns, the data type is inferred as boolean. |  |
+| &nbsp;`--boolean-patterns`&nbsp; | string | Comma-separated list of boolean pattern pairs in the format "true_pattern:false_pattern". Each pattern can be a string of any length. The patterns are case-insensitive. If a pattern ends with a "*", it is treated as a prefix. For example, "t*:f*,y*:n*" will match "true", "truthy", "Truth" as boolean true values so long as the corresponding false pattern (e.g. False, f, etc.) is also matched & cardinality is 2. Ignored if --infer-boolean is false. | `1:0,t*:f*,y*:n*` |
+| &nbsp;`--mode`&nbsp; | flag | Compute the mode/s & antimode/s. Multimodal-aware. If there are multiple modes/antimodes, they are separated by the QSV_STATS_SEPARATOR environment variable. If not set, the default separator is "\|". Uses memory proportional to the cardinality of each column. |  |
+| &nbsp;`--cardinality`&nbsp; | flag | Compute the cardinality and the uniqueness ratio. This is automatically enabled if --infer-boolean is enabled. <https://en.wikipedia.org/wiki/Cardinality_(SQL_statements)> Uses memory proportional to the number of unique values in each column. |  |
 
 <a name="numeric-&-date/datetime-stats-that-require-in-memory-sorting-options"></a>
 
@@ -249,14 +249,14 @@ qsv stats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--median` | flag | Compute the median. Loads & sorts all the selected columns' data in memory. <https://en.wikipedia.org/wiki/Median> |  |
-| `--mad` | flag | Compute the median absolute deviation (MAD). <https://en.wikipedia.org/wiki/Median_absolute_deviation> |  |
-| `--quartiles` | flag | Compute the quartiles (using method 3), the IQR, the lower/upper, inner/outer fences and skewness. <https://en.wikipedia.org/wiki/Quartile#Method_3> |  |
-| `--percentiles` | flag | Compute custom percentiles using the nearest rank method. <https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method> |  |
-| `--percentile-list` | string | Comma-separated list of percentiles to compute. For example, "5,10,40,60,90,95" will compute percentiles 5th, 10th, 40th, 60th, 90th, and 95th. Multiple percentiles are separated by the QSV_STATS_SEPARATOR environment variable. If not set, the default separator is "\|". It is ignored if --percentiles is not set. Special values "deciles" and "quintiles" are automatically expanded to "10,20,30,40,50,60,70,80,90" and "20,40,60,80" respectively. | `5,10,40,60,90,95` |
-| `--round` | string | Round statistics to <decimal_places>. Rounding is done following Midpoint Nearest Even (aka "Bankers Rounding") rule. <https://docs.rs/rust_decimal/latest/rust_decimal/enum.RoundingStrategy.html> If set to the sentinel value 9999, no rounding is done. For dates - range, stddev & IQR are always at least 5 decimal places as they are reported in days, and 5 places gives us millisecond precision. | `4` |
-| `--nulls` | flag | Include NULLs in the population size for computing mean and standard deviation. |  |
-| `--weight` | string | Compute weighted statistics using the specified column as weights. The weight column must be numeric. When specified, all statistics (mean, stddev, variance, median, quartiles, mode, etc.) will be computed using weighted algorithms. The weight column is automatically excluded from statistics computation. Missing or non-numeric weights default to 1.0. Zero and negative weights are ignored and do not contribute to the statistics. The output filename will be <FILESTEM>.stats.weighted.csv to distinguish from unweighted statistics. |  |
+| &nbsp;`--median`&nbsp; | flag | Compute the median. Loads & sorts all the selected columns' data in memory. <https://en.wikipedia.org/wiki/Median> |  |
+| &nbsp;`--mad`&nbsp; | flag | Compute the median absolute deviation (MAD). <https://en.wikipedia.org/wiki/Median_absolute_deviation> |  |
+| &nbsp;`--quartiles`&nbsp; | flag | Compute the quartiles (using method 3), the IQR, the lower/upper, inner/outer fences and skewness. <https://en.wikipedia.org/wiki/Quartile#Method_3> |  |
+| &nbsp;`--percentiles`&nbsp; | flag | Compute custom percentiles using the nearest rank method. <https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method> |  |
+| &nbsp;`--percentile-list`&nbsp; | string | Comma-separated list of percentiles to compute. For example, "5,10,40,60,90,95" will compute percentiles 5th, 10th, 40th, 60th, 90th, and 95th. Multiple percentiles are separated by the QSV_STATS_SEPARATOR environment variable. If not set, the default separator is "\|". It is ignored if --percentiles is not set. Special values "deciles" and "quintiles" are automatically expanded to "10,20,30,40,50,60,70,80,90" and "20,40,60,80" respectively. | `5,10,40,60,90,95` |
+| &nbsp;`--round`&nbsp; | string | Round statistics to <decimal_places>. Rounding is done following Midpoint Nearest Even (aka "Bankers Rounding") rule. <https://docs.rs/rust_decimal/latest/rust_decimal/enum.RoundingStrategy.html> If set to the sentinel value 9999, no rounding is done. For dates - range, stddev & IQR are always at least 5 decimal places as they are reported in days, and 5 places gives us millisecond precision. | `4` |
+| &nbsp;`--nulls`&nbsp; | flag | Include NULLs in the population size for computing mean and standard deviation. |  |
+| &nbsp;`--weight`&nbsp; | string | Compute weighted statistics using the specified column as weights. The weight column must be numeric. When specified, all statistics (mean, stddev, variance, median, quartiles, mode, etc.) will be computed using weighted algorithms. The weight column is automatically excluded from statistics computation. Missing or non-numeric weights default to 1.0. Zero and negative weights are ignored and do not contribute to the statistics. The output filename will be <FILESTEM>.stats.weighted.csv to distinguish from unweighted statistics. |  |
 
 <a name="date-inferencing-options"></a>
 
@@ -264,14 +264,14 @@ qsv stats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--infer-dates` | flag | Infer date/datetime data types. This is an expensive option and should only be used when you know there are date/datetime fields. Also, if timezone is not specified in the data, it'll be set to UTC. |  |
-| `--dates-whitelist` | string | The comma-separated, case-insensitive patterns to look for when shortlisting fields for date inferencing. i.e. if the field's name has any of these patterns, it is shortlisted for date inferencing. | `sniff` |
-| `--prefer-dmy` | flag | Parse dates in dmy format. Otherwise, use mdy format. Ignored if --infer-dates is false. |  |
-| `--force` | flag | Force recomputing stats even if valid precomputed stats cache exists. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `--stats-jsonl` | flag | Also write the stats in JSONL format. If set, the stats will be written to <FILESTEM>.stats.csv.data.jsonl. Note that this option used internally by other qsv "smart" commands (see <https://github.com/dathere/qsv/blob/master/docs/PERFORMANCE.md#stats-cache>) to load cached stats to make them work smarter & faster. You can preemptively create the stats-jsonl file by using this option BEFORE running "smart" commands and they will automatically use it. |  |
-| `-c,`<br>`--cache-threshold` | string | Controls the creation of stats cache files. * when greater than 1, the threshold in milliseconds before caching stats results. If a stats run takes longer than this threshold, the stats results will be cached. * 0 to suppress caching. * 1 to force caching. * a negative number to automatically create an index when the input file size is greater than abs(arg) in bytes. If the negative number ends with 5, it will delete the index file and the stats cache file after the stats run. Otherwise, the index file and the cache files are kept. | `5000` |
-| `--vis-whitespace` | flag | Visualize whitespace characters in the output. See <https://github.com/dathere/qsv/wiki/Supplemental#whitespace-markers> for the list of whitespace markers. |  |
+| &nbsp;`--infer-dates`&nbsp; | flag | Infer date/datetime data types. This is an expensive option and should only be used when you know there are date/datetime fields. Also, if timezone is not specified in the data, it'll be set to UTC. |  |
+| &nbsp;`--dates-whitelist`&nbsp; | string | The comma-separated, case-insensitive patterns to look for when shortlisting fields for date inferencing. i.e. if the field's name has any of these patterns, it is shortlisted for date inferencing. | `sniff` |
+| &nbsp;`--prefer-dmy`&nbsp; | flag | Parse dates in dmy format. Otherwise, use mdy format. Ignored if --infer-dates is false. |  |
+| &nbsp;`--force`&nbsp; | flag | Force recomputing stats even if valid precomputed stats cache exists. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. This works only when the given CSV has an index. Note that a file handle is opened for each job. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`--stats-jsonl`&nbsp; | flag | Also write the stats in JSONL format. If set, the stats will be written to <FILESTEM>.stats.csv.data.jsonl. Note that this option used internally by other qsv "smart" commands (see <https://github.com/dathere/qsv/blob/master/docs/PERFORMANCE.md#stats-cache>) to load cached stats to make them work smarter & faster. You can preemptively create the stats-jsonl file by using this option BEFORE running "smart" commands and they will automatically use it. |  |
+| &nbsp;`-c,`<br>`--cache-threshold`&nbsp; | string | Controls the creation of stats cache files. * when greater than 1, the threshold in milliseconds before caching stats results. If a stats run takes longer than this threshold, the stats results will be cached. * 0 to suppress caching. * 1 to force caching. * a negative number to automatically create an index when the input file size is greater than abs(arg) in bytes. If the negative number ends with 5, it will delete the index file and the stats cache file after the stats run. Otherwise, the index file and the cache files are kept. | `5000` |
+| &nbsp;`--vis-whitespace`&nbsp; | flag | Visualize whitespace characters in the output. See <https://github.com/dathere/qsv/wiki/Supplemental#whitespace-markers> for the list of whitespace markers. |  |
 
 <a name="common-options"></a>
 
@@ -279,11 +279,11 @@ qsv stats --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will NOT be interpreted as column names. i.e., They will be included in statistics. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for READING CSV data. Must be a single character. (default: ,) |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. This option is ignored when computing default, streaming statistics, as it is not needed. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will NOT be interpreted as column names. i.e., They will be included in statistics. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for READING CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. This option is ignored when computing default, streaming statistics, as it is not needed. |  |
 
 ---
 **Source:** [`src/cmd/stats.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/stats.rs)

--- a/docs/help/table.md
+++ b/docs/help/table.md
@@ -43,10 +43,10 @@ qsv table --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-w,`<br>`--width` | string | The minimum width of each column. | `2` |
-| `-p,`<br>`--pad` | string | The minimum number of spaces between each column. | `2` |
-| `-a,`<br>`--align` | string | How entries should be aligned in a column. Options: "left", "right", "center". "leftendtab" & "leftfwf" "leftendtab" is a special alignment that similar to "left" but with whitespace padding ending with a tab character. The resulting output still validates as a valid TSV file, while also being more human-readable (aka "aligned" TSV). "leftfwf" is similar to "left" with Fixed Width Format allgnment. The first line is a comment (prefixed with "#") that enumerates the position (1-based, comma-separated) of each column. | `left` |
-| `-c,`<br>`--condense` | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
+| &nbsp;`-w,`<br>`--width`&nbsp; | string | The minimum width of each column. | `2` |
+| &nbsp;`-p,`<br>`--pad`&nbsp; | string | The minimum number of spaces between each column. | `2` |
+| &nbsp;`-a,`<br>`--align`&nbsp; | string | How entries should be aligned in a column. Options: "left", "right", "center". "leftendtab" & "leftfwf" "leftendtab" is a special alignment that similar to "left" but with whitespace padding ending with a tab character. The resulting output still validates as a valid TSV file, while also being more human-readable (aka "aligned" TSV). "leftfwf" is similar to "left" with Fixed Width Format allgnment. The first line is a comment (prefixed with "#") that enumerates the position (1-based, comma-separated) of each column. | `left` |
+| &nbsp;`-c,`<br>`--condense`&nbsp; | string | Limits the length of each field to the value specified. If the field is UTF-8 encoded, then <arg> refers to the number of code points. Otherwise, it refers to the number of bytes. |  |
 
 <a name="common-options"></a>
 
@@ -54,10 +54,10 @@ qsv table --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
 
 ---
 **Source:** [`src/cmd/table.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/table.rs)

--- a/docs/help/template.md
+++ b/docs/help/template.md
@@ -85,8 +85,8 @@ qsv template --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | The CSV file to read. If not given, input is read from STDIN. |
-| `<outdir>` | The directory where the output files will be written. If it does not exist, it will be created. If not set, output will be sent to stdout or the specified --output. When writing to <outdir>, files are organized into subdirectories of --outsubdir-size (default: 1000) files each to avoid filesystem navigation & performance issues. |
+| &nbsp;`<input>`&nbsp; | The CSV file to read. If not given, input is read from STDIN. |
+| &nbsp;`<outdir>`&nbsp; | The directory where the output files will be written. If it does not exist, it will be created. If not set, output will be sent to stdout or the specified --output. When writing to <outdir>, files are organized into subdirectories of --outsubdir-size (default: 1000) files each to avoid filesystem navigation & performance issues. |
 
 <a name="template-options"></a>
 
@@ -94,18 +94,18 @@ qsv template --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--template` | string | MiniJinja template string to use (alternative to --template-file) |  |
-| `-t,`<br>`--template-file` | string | MiniJinja template file to use |  |
-| `-j,`<br>`--globals-json` | string | A JSON file containing global variables to make available in templates. The JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.school_name}}, {{qsv_g.year}}). This allows sharing common values across all template renders. |  |
-| `--outfilename` | string | MiniJinja template string to use to create the filename of the output files to write to <outdir>. If set to just QSV_ROWNO, the filestem is set to the current rowno of the record, padded with leading zeroes, with the ".txt" extension (e.g. 001.txt, 002.txt, etc.) Note that all the fields, including QSV_ROWNO, are available when defining the filename template. | `QSV_ROWNO` |
-| `--outsubdir-size` | string | The number of files per subdirectory in <outdir>. | `1000` |
-| `--customfilter-error` | string | The value to return when a custom filter returns an error. Use "<empty string>" to return an empty string. | `<FILTER_ERROR>` |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
-| `--timeout` | string | Timeout for downloading lookups on URLs. | `30` |
-| `--cache-dir` | string | The directory to use for caching downloaded lookup resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
-| `--ckan-api` | string | The URL of the CKAN API to use for downloading lookup resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
-| `--ckan-token` | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. |  |
+| &nbsp;`--template`&nbsp; | string | MiniJinja template string to use (alternative to --template-file) |  |
+| &nbsp;`-t,`<br>`--template-file`&nbsp; | string | MiniJinja template file to use |  |
+| &nbsp;`-j,`<br>`--globals-json`&nbsp; | string | A JSON file containing global variables to make available in templates. The JSON properties can be accessed in templates using the "qsv_g" namespace (e.g. {{qsv_g.school_name}}, {{qsv_g.year}}). This allows sharing common values across all template renders. |  |
+| &nbsp;`--outfilename`&nbsp; | string | MiniJinja template string to use to create the filename of the output files to write to <outdir>. If set to just QSV_ROWNO, the filestem is set to the current rowno of the record, padded with leading zeroes, with the ".txt" extension (e.g. 001.txt, 002.txt, etc.) Note that all the fields, including QSV_ROWNO, are available when defining the filename template. | `QSV_ROWNO` |
+| &nbsp;`--outsubdir-size`&nbsp; | string | The number of files per subdirectory in <outdir>. | `1000` |
+| &nbsp;`--customfilter-error`&nbsp; | string | The value to return when a custom filter returns an error. Use "<empty string>" to return an empty string. | `<FILTER_ERROR>` |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for downloading lookups on URLs. | `30` |
+| &nbsp;`--cache-dir`&nbsp; | string | The directory to use for caching downloaded lookup resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
+| &nbsp;`--ckan-api`&nbsp; | string | The URL of the CKAN API to use for downloading lookup resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. | `https://data.dathere.com/api/3/action` |
+| &nbsp;`--ckan-token`&nbsp; | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. |  |
 
 <a name="common-options"></a>
 
@@ -113,11 +113,11 @@ qsv template --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. Templates must use numeric 1-based indices with the "_c" prefix.(e.g. col1: {{_c1}} col2: {{_c2}}) |  |
-| `--delimiter` | string | Field separator for reading CSV | `,` |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. Templates must use numeric 1-based indices with the "_c" prefix.(e.g. col1: {{_c1}} col2: {{_c2}}) |  |
+| &nbsp;`--delimiter`&nbsp; | string | Field separator for reading CSV | `,` |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
 
 ---
 **Source:** [`src/cmd/template.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/template.rs)

--- a/docs/help/to.md
+++ b/docs/help/to.md
@@ -206,18 +206,18 @@ qsv to --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-k,`<br>`--print-package` | flag | Print statistics as datapackage, by default will print field summary. |  |
-| `-u,`<br>`--dump` | flag | Create database dump file for use with `psql` or `sqlite3` command line tools (postgres/sqlite only). |  |
-| `-a,`<br>`--stats` | flag | Produce extra statistics about the data beyond just type guessing. |  |
-| `-c,`<br>`--stats-csv` | string | Output stats as CSV to specified file. |  |
-| `-q,`<br>`--quiet` | flag | Do not print out field summary. |  |
-| `-s,`<br>`--schema` | string | The schema to load the data into. (postgres only). |  |
-| `-d,`<br>`--drop` | flag | Drop tables before loading new data into them (postgres/sqlite only). |  |
-| `-e,`<br>`--evolve` | flag | If loading into existing db, alter existing tables so that new data will load. (postgres/sqlite only). |  |
-| `-i,`<br>`--pipe` | flag | Adjust output format for piped data (omits row counts and field format columns). |  |
-| `-p,`<br>`--separator` | string | For xlsx, use this character to help truncate xlsx sheet names. Defaults to space. |  |
-| `-A,`<br>`--all-strings` | flag | Convert all fields to strings. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-k,`<br>`--print-package`&nbsp; | flag | Print statistics as datapackage, by default will print field summary. |  |
+| &nbsp;`-u,`<br>`--dump`&nbsp; | flag | Create database dump file for use with `psql` or `sqlite3` command line tools (postgres/sqlite only). |  |
+| &nbsp;`-a,`<br>`--stats`&nbsp; | flag | Produce extra statistics about the data beyond just type guessing. |  |
+| &nbsp;`-c,`<br>`--stats-csv`&nbsp; | string | Output stats as CSV to specified file. |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not print out field summary. |  |
+| &nbsp;`-s,`<br>`--schema`&nbsp; | string | The schema to load the data into. (postgres only). |  |
+| &nbsp;`-d,`<br>`--drop`&nbsp; | flag | Drop tables before loading new data into them (postgres/sqlite only). |  |
+| &nbsp;`-e,`<br>`--evolve`&nbsp; | flag | If loading into existing db, alter existing tables so that new data will load. (postgres/sqlite only). |  |
+| &nbsp;`-i,`<br>`--pipe`&nbsp; | flag | Adjust output format for piped data (omits row counts and field format columns). |  |
+| &nbsp;`-p,`<br>`--separator`&nbsp; | string | For xlsx, use this character to help truncate xlsx sheet names. Defaults to space. |  |
+| &nbsp;`-A,`<br>`--all-strings`&nbsp; | flag | Convert all fields to strings. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="common-options"></a>
 
@@ -225,8 +225,8 @@ qsv to --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 
 ---
 **Source:** [`src/cmd/to.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/to.rs)

--- a/docs/help/tojsonl.md
+++ b/docs/help/tojsonl.md
@@ -42,10 +42,10 @@ qsv tojsonl --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--trim` | flag | Trim leading and trailing whitespace from fields before converting to JSON. |  |
-| `--no-boolean` | flag | Do not infer boolean fields. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| &nbsp;`--trim`&nbsp; | flag | Trim leading and trailing whitespace from fields before converting to JSON. |  |
+| &nbsp;`--no-boolean`&nbsp; | flag | Do not infer boolean fields. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="common-options"></a>
 
@@ -53,11 +53,11 @@ qsv tojsonl --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
-| `-q,`<br>`--quiet` | flag | Do not display enum/const list inferencing messages. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not display enum/const list inferencing messages. |  |
 
 ---
 **Source:** [`src/cmd/tojsonl.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/tojsonl.rs)

--- a/docs/help/transpose.md
+++ b/docs/help/transpose.md
@@ -77,9 +77,9 @@ qsv transpose --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-m,`<br>`--multipass` | flag | Process the transpose by making multiple passes over the dataset. Consumes memory relative to the number of rows. Note that in general it is faster to process the transpose in memory. Useful for really big datasets as the default is to read the entire dataset into memory. |  |
-| `-s,`<br>`--select` | string | Select a subset of columns to transpose. When used with --long, this filters which columns become attribute rows (the field columns are unaffected). See 'qsv select --help' for the full selection syntax. |  |
-| `--long` | string | Convert wide-format CSV to "long" format. |  |
+| &nbsp;`-m,`<br>`--multipass`&nbsp; | flag | Process the transpose by making multiple passes over the dataset. Consumes memory relative to the number of rows. Note that in general it is faster to process the transpose in memory. Useful for really big datasets as the default is to read the entire dataset into memory. |  |
+| &nbsp;`-s,`<br>`--select`&nbsp; | string | Select a subset of columns to transpose. When used with --long, this filters which columns become attribute rows (the field columns are unaffected). See 'qsv select --help' for the full selection syntax. |  |
+| &nbsp;`--long`&nbsp; | string | Convert wide-format CSV to "long" format. |  |
 
 <a name="common-options"></a>
 
@@ -87,10 +87,10 @@ qsv transpose --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-o,`<br>`--output` | string | Write output to <file> instead of stdout. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| `--memcheck` | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. Ignored when --multipass or --long option is enabled. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-o,`<br>`--output`&nbsp; | string | Write output to <file> instead of stdout. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`--memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. Ignored when --multipass or --long option is enabled. |  |
 
 ---
 **Source:** [`src/cmd/transpose.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/transpose.rs)

--- a/docs/help/validate.md
+++ b/docs/help/validate.md
@@ -228,8 +228,8 @@ qsv validate --help
 
 | Argument | Description |
 |----------|-------------|
-| `<input>` | ...                 Input CSV file(s) to validate. If not provided, will read from stdin. If input is a directory, all files in the directory will be validated. If the input is a file with a '.infile-list' extension, the file will be read as a list of input files. If the input are snappy-compressed files(s), it will be decompressed automatically. Extended Input Support is only available for RFC 4180 validation mode. |
-| `<json-schema>` | JSON Schema file to validate against. If not provided, `validate` will run in RFC 4180 validation mode. The file can be a local file or a URL (http and https schemes supported). |
+| &nbsp;`<input>`&nbsp; | ...                 Input CSV file(s) to validate. If not provided, will read from stdin. If input is a directory, all files in the directory will be validated. If the input is a file with a '.infile-list' extension, the file will be read as a list of input files. If the input are snappy-compressed files(s), it will be decompressed automatically. Extended Input Support is only available for RFC 4180 validation mode. |
+| &nbsp;`<json-schema>`&nbsp; | JSON Schema file to validate against. If not provided, `validate` will run in RFC 4180 validation mode. The file can be a local file or a URL (http and https schemes supported). |
 
 <a name="validate-options"></a>
 
@@ -237,16 +237,16 @@ qsv validate --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--trim` | flag | Trim leading and trailing whitespace from fields before validating. |  |
-| `--no-format-validation` | flag | Disable JSON Schema format validation. Ignores all JSON Schema "format" keywords (e.g. date,email, uri, currency, etc.). This is useful when you want to validate the structure of the CSV file w/o worrying about the data types and domain/range of the fields. |  |
-| `--fail-fast` | flag | Stops on first error. |  |
-| `--valid` | string | Valid record output file suffix. | `valid` |
-| `--invalid` | string | Invalid record output file suffix. | `invalid` |
-| `--json` | flag | When validating without a JSON Schema, return the RFC 4180 check as a JSON file instead of a message. |  |
-| `--pretty-json` | flag | Same as --json, but pretty printed. |  |
-| `--valid-output` | string | Change validation mode behavior so if ALL rows are valid, to pass it to output, return exit code 1, and set stderr to the number of valid rows. Setting this will override the default behavior of creating a valid file only when there are invalid records. To send valid records to stdout, use `-` as the filename. |  |
-| `-j,`<br>`--jobs` | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
-| `-b,`<br>`--batch` | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
+| &nbsp;`--trim`&nbsp; | flag | Trim leading and trailing whitespace from fields before validating. |  |
+| &nbsp;`--no-format-validation`&nbsp; | flag | Disable JSON Schema format validation. Ignores all JSON Schema "format" keywords (e.g. date,email, uri, currency, etc.). This is useful when you want to validate the structure of the CSV file w/o worrying about the data types and domain/range of the fields. |  |
+| &nbsp;`--fail-fast`&nbsp; | flag | Stops on first error. |  |
+| &nbsp;`--valid`&nbsp; | string | Valid record output file suffix. | `valid` |
+| &nbsp;`--invalid`&nbsp; | string | Invalid record output file suffix. | `invalid` |
+| &nbsp;`--json`&nbsp; | flag | When validating without a JSON Schema, return the RFC 4180 check as a JSON file instead of a message. |  |
+| &nbsp;`--pretty-json`&nbsp; | flag | Same as --json, but pretty printed. |  |
+| &nbsp;`--valid-output`&nbsp; | string | Change validation mode behavior so if ALL rows are valid, to pass it to output, return exit code 1, and set stderr to the number of valid rows. Setting this will override the default behavior of creating a valid file only when there are invalid records. To send valid records to stdout, use `-` as the filename. |  |
+| &nbsp;`-j,`<br>`--jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
+| &nbsp;`-b,`<br>`--batch`&nbsp; | string | The number of rows per batch to load into memory, before running in parallel. Automatically determined for CSV files with more than 50000 rows. Set to 0 to load all rows in one batch. Set to 1 to force batch optimization even for files with less than 50000 rows. | `50000` |
 
 <a name="fancy-regex-options"></a>
 
@@ -254,8 +254,8 @@ qsv validate --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--fancy-regex` | flag | Use the fancy regex engine instead of the default regex engine for validation. The fancy engine supports advanced regex features such as lookaround and backreferences, but is not as performant as the default regex engine which guarantees linear-time matching, prevents DoS attacks, and is more efficient for simple patterns. |  |
-| `--backtrack-limit` | string | Set the approximate number of backtracking steps allowed. This is only used when --fancy-regex is set. | `1000000` |
+| &nbsp;`--fancy-regex`&nbsp; | flag | Use the fancy regex engine instead of the default regex engine for validation. The fancy engine supports advanced regex features such as lookaround and backreferences, but is not as performant as the default regex engine which guarantees linear-time matching, prevents DoS attacks, and is more efficient for simple patterns. |  |
+| &nbsp;`--backtrack-limit`&nbsp; | string | Set the approximate number of backtracking steps allowed. This is only used when --fancy-regex is set. | `1000000` |
 
 <a name="options-for-both-regex-engines"></a>
 
@@ -263,12 +263,12 @@ qsv validate --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--size-limit` | string | Set the approximate size limit, in megabytes, of a compiled regex. | `50` |
-| `--dfa-size-limit` | string | Set the approximate capacity, in megabytes, of the cache of transitions used by the engine's lazy Discrete Finite Automata. | `10` |
-| `--timeout` | string | Timeout for downloading json-schemas on URLs and for 'dynamicEnum' lookups on URLs. If 0, no timeout is used. | `30` |
-| `--cache-dir` | string | The directory to use for caching downloaded dynamicEnum resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. Not available on qsvlite. | `~/.qsv-cache` |
-| `--ckan-api` | string | The URL of the CKAN API to use for downloading dynamicEnum resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. Not available on qsvlite. | `https://data.dathere.com/api/3/action` |
-| `--ckan-token` | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. Not available on qsvlite. |  |
+| &nbsp;`--size-limit`&nbsp; | string | Set the approximate size limit, in megabytes, of a compiled regex. | `50` |
+| &nbsp;`--dfa-size-limit`&nbsp; | string | Set the approximate capacity, in megabytes, of the cache of transitions used by the engine's lazy Discrete Finite Automata. | `10` |
+| &nbsp;`--timeout`&nbsp; | string | Timeout for downloading json-schemas on URLs and for 'dynamicEnum' lookups on URLs. If 0, no timeout is used. | `30` |
+| &nbsp;`--cache-dir`&nbsp; | string | The directory to use for caching downloaded dynamicEnum resources. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. Not available on qsvlite. | `~/.qsv-cache` |
+| &nbsp;`--ckan-api`&nbsp; | string | The URL of the CKAN API to use for downloading dynamicEnum resources with the "ckan://" scheme. If the QSV_CKAN_API envvar is set, it will be used instead. Not available on qsvlite. | `https://data.dathere.com/api/3/action` |
+| &nbsp;`--ckan-token`&nbsp; | string | The CKAN API token to use. Only required if downloading private resources. If the QSV_CKAN_TOKEN envvar is set, it will be used instead. Not available on qsvlite. |  |
 
 <a name="email-validation-options"></a>
 
@@ -276,10 +276,10 @@ qsv validate --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `--email-required-tld` | flag | Require the email to have a valid Top-Level Domain (TLD) (e.g. .com, .org, .net, etc.). e.g. "john.doe@example" is VALID if this option is NOT set. |  |
-| `--email-display-text` | flag | Allow display text in emails. e.g. "John Doe <john.doe@example.com>" is INVALID if this option is NOT set. |  |
-| `--email-min-subdomains` | string | Minimum number of subdomains required in the email. e.g. "jdoe@example.com" is INVALID if this option is set to 3, but "jdoe@sub.example.com" is VALID. | `2` |
-| `--email-domain-literal` | flag | Allow domain literals in emails. e.g. "john.doe@[127.0.0.1]" is VALID if this option is set. |  |
+| &nbsp;`--email-required-tld`&nbsp; | flag | Require the email to have a valid Top-Level Domain (TLD) (e.g. .com, .org, .net, etc.). e.g. "john.doe@example" is VALID if this option is NOT set. |  |
+| &nbsp;`--email-display-text`&nbsp; | flag | Allow display text in emails. e.g. "John Doe <john.doe@example.com>" is INVALID if this option is NOT set. |  |
+| &nbsp;`--email-min-subdomains`&nbsp; | string | Minimum number of subdomains required in the email. e.g. "jdoe@example.com" is INVALID if this option is set to 3, but "jdoe@sub.example.com" is VALID. | `2` |
+| &nbsp;`--email-domain-literal`&nbsp; | flag | Allow domain literals in emails. e.g. "john.doe@[127.0.0.1]" is VALID if this option is set. |  |
 
 <a name="common-options"></a>
 
@@ -287,11 +287,11 @@ qsv validate --help
 
 | Option | Type | Description | Default |
 |--------|------|-------------|--------|
-| `-h,`<br>`--help` | flag | Display this message |  |
-| `-n,`<br>`--no-headers` | flag | When set, the first row will not be interpreted as headers. It will be validated with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. Note that this option is only valid when running in RFC 4180 validation mode as JSON Schema validation requires headers. |  |
-| `-d,`<br>`--delimiter` | string | The field delimiter for reading CSV data. Must be a single character. |  |
-| `-p,`<br>`--progressbar` | flag | Show progress bars. Not valid for stdin. |  |
-| `-q,`<br>`--quiet` | flag | Do not display validation summary message. |  |
+| &nbsp;`-h,`<br>`--help`&nbsp; | flag | Display this message |  |
+| &nbsp;`-n,`<br>`--no-headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. It will be validated with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. Note that this option is only valid when running in RFC 4180 validation mode as JSON Schema validation requires headers. |  |
+| &nbsp;`-d,`<br>`--delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. |  |
+| &nbsp;`-p,`<br>`--progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
+| &nbsp;`-q,`<br>`--quiet`&nbsp; | flag | Do not display validation summary message. |  |
 
 ---
 **Source:** [`src/cmd/validate.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/validate.rs)

--- a/src/help_markdown_gen.rs
+++ b/src/help_markdown_gen.rs
@@ -337,7 +337,7 @@ fn generate_command_markdown(
         for arg in &parsed_args {
             let _ = writeln!(
                 md,
-                "| `{}` | {} |",
+                "| &nbsp;`{}`&nbsp; | {} |",
                 arg.name,
                 escape_table_cell(&linkify_bare_urls(&arg.description))
             );
@@ -355,9 +355,9 @@ fn generate_command_markdown(
         md.push_str("|--------|------|-------------|--------|\n");
         for opt in options {
             let option_display = if let Some(short) = &opt.short {
-                format!("`{short},`<br>`{}`", opt.flag)
+                format!("&nbsp;`{short},`<br>`{}`&nbsp;", opt.flag)
             } else {
-                format!("`{}`", opt.flag)
+                format!("&nbsp;`{}`&nbsp;", opt.flag)
             };
             let default_str = opt
                 .default


### PR DESCRIPTION
Prevents word-wrapping on hyphens and equal signs in rendered markdown by surrounding code spans with non-breaking spaces.