### PR TITLE
fix(mcp): Make output processing more Cowork friendly

### DIFF
--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -411,6 +411,8 @@ The 📊 emoji marks stats-related guidance in tool descriptions.
 5. Update tests to cover new parameters
 6. Update guidance hints if behavior changes
 
+**Parameter alias handling**: `buildSkillExecParams` skips `"input"` and `"output"` keys by default (they are aliases for `input_file`/`output_file` via `resolveParamAliases`). However, if a skill declares `--input` or `--output` as a distinct CLI option (flag), the key is allowed through automatically. Note: this check only matches long-form options (`--input`/`--output`), not short flags (`-i`/`-o`); a positional arg named `input` is always consumed as the input file path.
+
 ### Testing Conventions
 
 - Each module has a corresponding test file: `tests/<module>.test.ts`

--- a/.claude/skills/src/mcp-tools.ts
+++ b/.claude/skills/src/mcp-tools.ts
@@ -1205,13 +1205,24 @@ function buildSkillExecParams(
     console.error(`[MCP Tools] Added input arg: ${inputFile}`);
   }
 
+  // Check whether a skill declares a distinct --input or --output CLI option.
+  // If so, allow the key through instead of treating it as a file alias.
+  // Note: only checks long-form options (--input/--output), not short flags (-i/-o).
+  // A positional arg named "input" is already consumed above as the input file.
+  const skillHasOption = (name: string) =>
+    skill.command.options.some((o) => o.flag === `--${name}`);
+
   for (const [key, value] of Object.entries(params)) {
+    // Skip meta-parameters that are handled separately (not passed as CLI flags).
+    // "input" and "output" are aliases for input_file/output_file resolved by
+    // resolveParamAliases, so skip them unless the skill declares them as
+    // distinct CLI flags (i.e. the skill has an arg or option named "input"/"output").
     if (
       key === "input_file" ||
       key === "output_file" ||
-      key === "output" ||
-      key === "help" ||
-      (key === "input" && args.input)
+      (key === "input" && !skillHasOption("input")) ||
+      (key === "output" && !skillHasOption("output")) ||
+      key === "help"
     ) {
       continue;
     }
@@ -1607,6 +1618,37 @@ async function tryDuckDbExecution(
 }
 
 /**
+ * Resolve LLM-friendly parameter aliases to their canonical names.
+ * LLMs sometimes send "input"/"output" instead of "input_file"/"output_file".
+ * Canonical names take precedence when both are present.
+ */
+function resolveParamAliases(params: Record<string, unknown>): {
+  inputFile: string | undefined;
+  outputFile: string | undefined;
+} {
+  // Only accept string values; reject numbers, booleans, objects, etc.
+  // A numeric value (e.g. { input: 42 }) is almost certainly an LLM mistake,
+  // not a valid file path, so we return undefined rather than coercing to "42".
+  const coerce = (v: unknown, paramName: string): string | undefined => {
+    if (typeof v === "string") return v.trim() || undefined;
+    if (v != null) {
+      console.error(
+        `[MCP Tools] Ignoring non-string ${paramName} value: ${typeof v} (${JSON.stringify(v)})`,
+      );
+    }
+    return undefined;
+  };
+
+  const inputFile =
+    coerce(params.input_file, "input_file") ??
+    coerce(params.input, "input");
+  const outputFile =
+    coerce(params.output_file, "output_file") ??
+    coerce(params.output, "output");
+  return { inputFile, outputFile };
+}
+
+/**
  * Handle execution of a qsv tool
  */
 export async function handleToolCall(
@@ -1642,16 +1684,10 @@ export async function handleToolCall(
       );
     }
 
-    // Extract input_file and output_file
-    // Accept "input"/"output" as aliases (LLMs sometimes use shorter parameter names)
-    let inputFile = params.input_file as string | undefined;
-    if (!inputFile && typeof params.input === "string") {
-      inputFile = params.input;
-    }
-    let outputFile = params.output_file as string | undefined;
-    if (!outputFile && typeof params.output === "string") {
-      outputFile = params.output;
-    }
+    // Extract input_file and output_file (with LLM alias resolution)
+    const { inputFile: rawInputFile, outputFile: rawOutputFile } = resolveParamAliases(params);
+    let inputFile = rawInputFile;
+    let outputFile = rawOutputFile;
     const isHelpRequest = params.help === true;
 
     if (!inputFile && !isHelpRequest) {
@@ -2527,15 +2563,10 @@ export async function handleToParquetCall(
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
 }> {
-  // Accept "input"/"output" as aliases (LLMs sometimes use shorter parameter names)
-  let inputFile = params.input_file as string | undefined;
-  if (!inputFile && typeof params.input === "string") {
-    inputFile = params.input;
-  }
-  let outputFile = params.output_file as string | undefined;
-  if (!outputFile && typeof params.output === "string") {
-    outputFile = params.output;
-  }
+  // Extract input_file and output_file (with LLM alias resolution)
+  const { inputFile: rawInputFile, outputFile: rawOutputFile } = resolveParamAliases(params);
+  let inputFile = rawInputFile;
+  let outputFile = rawOutputFile;
 
   if (!inputFile) {
     return errorResult("Error: input_file parameter is required");

--- a/.claude/skills/tests/qsv-integration.test.ts
+++ b/.claude/skills/tests/qsv-integration.test.ts
@@ -789,8 +789,9 @@ test('handleToParquetCall prefers "input_file" over "input" when both present', 
       loader,
     );
     assert.ok(!headersResult.isError, `Should read parquet headers: ${headersResult.content[0].text}`);
+    const headersText = headersResult.content[0].text ?? '';
     assert.ok(
-      headersResult.content[0].text?.includes('id') && headersResult.content[0].text?.includes('name'),
+      /\bid\b/.test(headersText) && /\bname\b/.test(headersText),
       'Parquet file should contain id,name schema from the preferred input',
     );
   } finally {


### PR DESCRIPTION
Because Cowork spins up a VM for safety, it sometimes has problems accessing the output of qsv.

The Agent often works around the problem, but let's make it more Cowork friendly so the Agent doesn't waste tokens getting the output.