### PR TITLE
fix(deps): update ort dependency to include tls-rustls feature and add new dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4547,6 +4547,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
@@ -6687,6 +6688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -8213,9 +8215,12 @@ dependencies = [
  "base64",
  "log",
  "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
  "socks",
  "ureq-proto",
  "utf-8",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ mlua = { version = "0.11", features = [
 num_cpus = "1"
 odht = "0.3"
 # ort is needed by magika for ONNX runtime; download-binaries fetches prebuilt binaries
-ort = { version = "2.0.0-rc.10", default-features = false, features = ["download-binaries"], optional = true }
+ort = { version = "2.0.0-rc.10", default-features = false, features = ["download-binaries", "tls-rustls"], optional = true }
 phf = { version = "0.13", features = ["macros"] }
 pragmastat = "10.0"
 polars = { version = "0.53", features = [


### PR DESCRIPTION
Had to make this change to address issues below while compiling the release version.
===========

  Compiling qsv v16.1.0 (/Users/pascal/git-hub/qsv)
error: When using `download-binaries`, a TLS feature must be configured. Enable exactly one of: `tls-rustls` (uses `ring` as provider), `tls-rustls-no-provider`, `tls-native`, or `tls-native-vendored`.
 --> /Users/pascal/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ort-sys-2.0.0-rc.11/build/download/mod.rs:2:1
  |
2 | / compile_error!(
3 | |     "When using `download-binaries`, a TLS feature must be configured. Enable exactly one of: \
4 | |     `tls-rustls` (uses `ring` as provider), `tls-rustls-no-provider`, `tls-native`, or `tls-native-vendored`."
5 | | );
  | |_^

error[E0432]: unresolved import `ureq::tls`
   --> /Users/pascal/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ort-sys-2.0.0-rc.11/build/download/mod.rs:12:2
    |
 12 |     tls::{RootCerts, TlsConfig, TlsProvider}
    |     ^^^ could not find `tls` in `ureq`
    |
note: found an item that was configured out
   --> /Users/pascal/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ureq-3.2.0/src/lib.rs:574:9
    |
573 | #[cfg(feature = "_tls")]
    |       ---------------- the item is gated behind the `_tls` feature
574 | pub mod tls;
    |         ^^^

error[E0599]: no method named `tls_config` found for struct `ConfigBuilder<Scope>` in the current scope
  --> /Users/pascal/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ort-sys-2.0.0-rc.11/build/download/mod.rs:45:5
   |
41 | /         UreqConfig::builder()
42 | |             .proxy(Proxy::try_from_env())
43 | |             .max_redirects(1)
44 | |             .https_only(true)
45 | |             .tls_config(TlsConfig::builder().provider(tls_provider).root_certs(root_certs).build())
   | |             -^^^^^^^^^^ method not found in `ConfigBuilder<AgentScope>`
   | |_____________|
   |
