### PR TITLE
feat(mcp): add Windows native folder picker via PowerShell FolderBrow…

### DIFF
--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -1097,6 +1097,7 @@ class QsvMcpServer {
         // Escape single quotes for PowerShell string embedding
         const escapedDir = currentDir.replace(/'/g, "''");
         const psScript = [
+          "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
           "Add-Type -AssemblyName System.Windows.Forms",
           "$dlg = New-Object System.Windows.Forms.FolderBrowserDialog",
           "$dlg.Description = 'Select qsv working directory'",


### PR DESCRIPTION
…serDialog

Extends showNativeFolderPicker() to support Windows alongside macOS, using System.Windows.Forms.FolderBrowserDialog for a native directory selection experience on Windows.