### PR TITLE
refactor(mcp): extract spawnWithTimeout, gate debug logging

### DIFF
--- a/.claude/skills/src/config.ts
+++ b/.claude/skills/src/config.ts
@@ -890,15 +890,16 @@ export const config = {
    * - "info" (default): Log all tool invocations (start/end with timing)
    * - "off": Disable MCP audit logging entirely
    * - "error": Log only failed tool invocations
+   * - "debug": Like "info" but also enables verbose executor/process logging to stderr
    */
   mcpLogLevel: (() => {
     const val = getStringEnv("QSV_MCP_LOG_LEVEL", "info").toLowerCase();
-    const valid = ["off", "error", "info"];
+    const valid = ["off", "error", "info", "debug"];
     if (!valid.includes(val)) {
       console.error(`[Config] Invalid QSV_MCP_LOG_LEVEL: "${val}", using default: "info"`);
       return "info" as const;
     }
-    return val as "off" | "error" | "info";
+    return val as "off" | "error" | "info" | "debug";
   })(),
 
   /**

--- a/.claude/skills/src/duckdb.ts
+++ b/.claude/skills/src/duckdb.ts
@@ -477,9 +477,13 @@ export async function executeDuckDbQuery(
     onExit: options?.onExit,
   });
 
-  // Surface spawn errors (e.g. ENOENT) as exceptions
+  // Surface spawn errors or signal kills as exceptions
   if (result.exitCode === null && !result.timedOut) {
-    throw new Error(result.stderr || "DuckDB process failed to start");
+    throw new Error(
+      result.signal
+        ? `DuckDB query failed (killed by signal ${result.signal}): ${result.stderr}`
+        : (result.stderr || "DuckDB process failed to start"),
+    );
   }
 
   if (result.timedOut) {

--- a/.claude/skills/src/duckdb.ts
+++ b/.claude/skills/src/duckdb.ts
@@ -6,11 +6,12 @@
  * for better PostgreSQL compatibility and performance.
  */
 
-import { execFileSync, spawn, type ChildProcess } from "child_process";
+import { execFileSync, type ChildProcess } from "child_process";
 import { statSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { config } from "./config.js";
+import { spawnWithTimeout } from "./spawn-utils.js";
 
 /**
  * Timeout for DuckDB binary validation in milliseconds (5 seconds)
@@ -464,82 +465,36 @@ export async function executeDuckDbQuery(
   // For parquet format, no output flag needed (COPY handles it)
   args.push("-c", fullSql);
 
-  return new Promise((resolve, reject) => {
-    const proc = spawn(binPath, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    options?.onSpawn?.(proc);
-
-    let stdout = "";
-    let stderr = "";
-    let stdoutTruncated = false;
-    let timedOut = false;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    let killTimer: ReturnType<typeof setTimeout> | null = null;
-
-    timer = setTimeout(() => {
-      timedOut = true;
-      proc.kill("SIGTERM");
-      killTimer = setTimeout(() => {
-        if (proc.exitCode === null) {
-          try { proc.kill("SIGKILL"); } catch { /* ignore */ }
-          proc.unref();
-        }
-      }, 1000);
-    }, timeoutMs);
-
-    proc.stdout!.on("data", (chunk) => {
-      const data = chunk.toString();
-      if (stdout.length + data.length > maxOutputSize) {
-        if (!stdoutTruncated) {
-          stdoutTruncated = true;
-          stdout += "\n\n[OUTPUT TRUNCATED - Result too large. Use --format parquet with --output to write to file.]\n";
-        }
-        return;
-      }
-      stdout += data;
-    });
-
-    proc.stderr!.on("data", (chunk) => {
-      if (stderr.length < MAX_STDERR_SIZE) {
-        stderr += chunk.toString();
-        if (stderr.length > MAX_STDERR_SIZE) {
-          stderr = stderr.slice(0, MAX_STDERR_SIZE) + "\n[STDERR TRUNCATED]";
-        }
-      }
-    });
-
-    proc.on("close", (exitCode) => {
-      if (timer) clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
-      options?.onExit?.(proc);
-
-      if (timedOut) {
-        resolve({
-          output: stdout,
-          version,
-          exitCode: 124,
-          stderr: stderr + `\n[TIMEOUT] DuckDB query exceeded ${timeoutMs}ms timeout.`,
-        });
-        return;
-      }
-
-      resolve({
-        output: format === "parquet" ? `Parquet file written to: ${options?.outputFile}` : stdout,
-        version,
-        exitCode: exitCode ?? 0,
-        stderr,
-      });
-    });
-
-    proc.on("error", (err) => {
-      if (timer) clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
-      options?.onExit?.(proc);
-
-      // Binary-level failure (e.g., ENOENT)
-      reject(err);
-    });
+  const result = await spawnWithTimeout({
+    binary: binPath,
+    args,
+    timeoutMs,
+    maxStdoutSize: maxOutputSize,
+    stdoutTruncationMsg:
+      "\n\n[OUTPUT TRUNCATED - Result too large. Use --format parquet with --output to write to file.]\n",
+    maxStderrSize: MAX_STDERR_SIZE,
+    onSpawn: options?.onSpawn,
+    onExit: options?.onExit,
   });
+
+  // Surface spawn errors (e.g. ENOENT) as exceptions
+  if (result.exitCode === null && !result.timedOut) {
+    throw new Error(result.stderr || "DuckDB process failed to start");
+  }
+
+  if (result.timedOut) {
+    return {
+      output: result.stdout,
+      version,
+      exitCode: 124,
+      stderr: result.stderr + `\n[TIMEOUT] DuckDB query exceeded ${timeoutMs}ms timeout.`,
+    };
+  }
+
+  return {
+    output: format === "parquet" ? `Parquet file written to: ${options?.outputFile}` : result.stdout,
+    version,
+    exitCode: result.exitCode ?? 0,
+    stderr: result.stderr,
+  };
 }

--- a/.claude/skills/src/executor.ts
+++ b/.claude/skills/src/executor.ts
@@ -7,6 +7,7 @@ import { spawn, type ChildProcess } from "child_process";
 import type { QsvSkill, Option, SkillParams, SkillResult } from "./types.js";
 import { config } from "./config.js";
 import { compareVersions } from "./utils.js";
+import { spawnWithTimeout } from "./spawn-utils.js";
 
 /** Minimum qsv binary version that supports --frequency-jsonl */
 const FREQUENCY_JSONL_MIN_VERSION = "16.1.0";
@@ -358,9 +359,21 @@ export class SkillExecutor {
   }
 
   /**
+   * Signal-to-exit-code mapping (128 + signal number).
+   * SIGTERM=15 → 143, SIGKILL=9 → 137, SIGINT=2 → 130
+   */
+  private static readonly SIGNAL_EXIT_CODES: Record<string, number> = {
+    SIGTERM: 143,
+    SIGKILL: 137,
+    SIGINT: 130,
+    SIGHUP: 129,
+    SIGQUIT: 131,
+  };
+
+  /**
    * Run qsv command with timeout handling
    */
-  private runQsv(
+  private async runQsv(
     args: string[],
     params: SkillParams,
     timeoutMs: number,
@@ -369,172 +382,51 @@ export class SkillExecutor {
     stdout: string;
     stderr: string;
   }> {
-    return new Promise((resolve, reject) => {
-      // Log the full command for debugging
-      const fullCommand = `${this.qsvBinary} ${args.join(" ")}`;
-      console.error(`[Executor] Running command: ${fullCommand}`);
-      console.error(`[Executor] Binary path: ${this.qsvBinary}`);
+    const debug = config.mcpLogLevel === "debug";
+    if (debug) {
+      console.error(`[Executor] Running command: ${this.qsvBinary} ${args.join(" ")}`);
       console.error(`[Executor] Working directory: ${this.workingDirectory}`);
-      console.error(`[Executor] Args:`, JSON.stringify(args));
       console.error(`[Executor] Timeout: ${timeoutMs}ms`);
+    }
 
-      const proc = spawn(this.qsvBinary, args, {
-        stdio: ["pipe", "pipe", "pipe"],
-        cwd: this.workingDirectory,
-      });
-
-      let stdout = "";
-      let stderr = "";
-      let stdoutTruncated = false;
-      let timedOut = false;
-      let processExited = false;
-      let timer: ReturnType<typeof setTimeout> | null = null;
-      let killTimer: ReturnType<typeof setTimeout> | null = null;
-      const MAX_OUTPUT_SIZE = 50 * 1024 * 1024; // 50MB limit to prevent memory issues (stdout and stderr)
-
-      // Cleanup helper to clear both timers and mark process as exited
-      const clearTimers = () => {
-        processExited = true;
-        if (timer) { clearTimeout(timer); timer = null; }
-        if (killTimer) { clearTimeout(killTimer); killTimer = null; }
-      };
-
-      // Set up timeout handler
-      timer = setTimeout(() => {
-        timedOut = true;
-        console.error(
-          `[Executor] Process timed out after ${timeoutMs}ms, sending SIGTERM`,
-        );
-        proc.kill("SIGTERM");
-
-        // Give process a moment to terminate gracefully, then send SIGKILL
-        killTimer = setTimeout(() => {
-          // Only send SIGKILL if process hasn't exited yet
-          // Check both our flag (set on 'close') and proc.exitCode (set on 'exit')
-          // since 'exit' fires before 'close' when process terminates
-          if (!processExited && proc.exitCode === null) {
-            console.error(`[Executor] Process did not terminate, sending SIGKILL`);
-            try {
-              proc.kill("SIGKILL");
-            } catch {
-              // Process may have already exited between the check and kill
-              console.error(`[Executor] SIGKILL failed (process may have already exited)`);
-            }
-            // Ensure parent process won't wait for this child
-            proc.unref();
-          }
-        }, 1000);
-      }, timeoutMs);
-
-      // Handle input
-      if (params.stdin) {
-        proc.stdin.write(params.stdin);
-        proc.stdin.end();
-      } else {
-        proc.stdin.end();
-      }
-
-      // Collect output with size limit
-      proc.stdout.on("data", (chunk) => {
-        const chunkStr = chunk.toString();
-
-        // Check if adding this chunk would exceed the limit
-        if (stdout.length + chunkStr.length > MAX_OUTPUT_SIZE) {
-          if (!stdoutTruncated) {
-            stdoutTruncated = true;
-            console.error(
-              `[Executor] WARNING: stdout exceeded ${MAX_OUTPUT_SIZE / 1024 / 1024}MB limit, truncating output. Consider using --output to write to a file instead.`,
-            );
-            stdout +=
-              "\n\n[OUTPUT TRUNCATED - Result too large for display. Use --output option to write to a file.]\n";
-          }
-          // Stop accumulating to prevent memory issues
-          return;
-        }
-
-        stdout += chunkStr;
-      });
-
-      let stderrTruncated = false;
-      proc.stderr.on("data", (chunk) => {
-        const data = chunk.toString();
-        if (stderr.length + data.length > MAX_OUTPUT_SIZE) {
-          if (!stderrTruncated) {
-            stderrTruncated = true;
-            console.error(
-              `[Executor] WARNING: stderr exceeded ${MAX_OUTPUT_SIZE / 1024 / 1024}MB limit, truncating.`,
-            );
-            stderr +=
-              "\n\n[STDERR TRUNCATED - Too much diagnostic output.]\n";
-          }
-          return;
-        }
-        stderr += data;
-        console.error(`[Executor] stderr: ${data}`);
-      });
-
-      proc.on("close", (exitCode, signal) => {
-        clearTimers();
-
-        console.error(`[Executor] Process exited with code: ${exitCode}, signal: ${signal}`);
-        console.error(`[Executor] stdout length: ${stdout.length}`);
-        console.error(`[Executor] stderr length: ${stderr.length}`);
-
-        // If process was terminated due to timeout, return exit code 124
-        if (timedOut) {
-          resolve({
-            exitCode: 124, // Standard timeout exit code (like GNU timeout)
-            stdout,
-            stderr:
-              stderr +
-              `\n[TIMEOUT] Process exceeded ${timeoutMs}ms timeout and was terminated.`,
-          });
-          return;
-        }
-
-        // Handle signal termination: if exitCode is null but signal is present,
-        // the process was killed by a signal (external SIGTERM/SIGKILL, etc.)
-        // Treat this as a failure rather than coercing to success (exit code 0)
-        if (exitCode === null && signal) {
-          // Map common signals to conventional exit codes (128 + signal number)
-          // SIGTERM=15 -> 143, SIGKILL=9 -> 137, SIGINT=2 -> 130
-          const signalExitCodes: Record<string, number> = {
-            SIGTERM: 143,
-            SIGKILL: 137,
-            SIGINT: 130,
-            SIGHUP: 129,
-            SIGQUIT: 131,
-          };
-          const signalExitCode = signalExitCodes[signal] ?? 128;
-          resolve({
-            exitCode: signalExitCode,
-            stdout,
-            stderr: stderr + `\n[SIGNAL] Process was terminated by signal: ${signal}`,
-          });
-          return;
-        }
-
-        resolve({
-          exitCode: exitCode ?? 0,
-          stdout,
-          stderr,
-        });
-      });
-
-      proc.on("error", (err) => {
-        clearTimers();
-
-        // If we already handled timeout, log the error but don't reject
-        // (the timeout handler already resolved the promise)
-        if (timedOut) {
-          console.error(`[Executor] Process error after timeout (suppressed):`, err.message);
-          return;
-        }
-
-        console.error(`[Executor] Process error:`, err);
-        reject(err);
-      });
+    const result = await spawnWithTimeout({
+      binary: this.qsvBinary,
+      args,
+      cwd: this.workingDirectory,
+      timeoutMs,
+      stdin: params.stdin,
+      stdoutTruncationMsg:
+        "\n\n[OUTPUT TRUNCATED - Result too large for display. Use --output option to write to a file.]\n",
     });
+
+    if (debug) {
+      console.error(`[Executor] Process exited: code=${result.exitCode}, signal=${result.signal}`);
+      console.error(`[Executor] stdout length: ${result.stdout.length}, stderr length: ${result.stderr.length}`);
+    }
+
+    if (result.timedOut) {
+      return {
+        exitCode: 124, // Standard timeout exit code (like GNU timeout)
+        stdout: result.stdout,
+        stderr: result.stderr + `\n[TIMEOUT] Process exceeded ${timeoutMs}ms timeout and was terminated.`,
+      };
+    }
+
+    // Handle signal termination: map signals to conventional exit codes
+    if (result.exitCode === null && result.signal) {
+      const signalExitCode = SkillExecutor.SIGNAL_EXIT_CODES[result.signal] ?? 128;
+      return {
+        exitCode: signalExitCode,
+        stdout: result.stdout,
+        stderr: result.stderr + `\n[SIGNAL] Process was terminated by signal: ${result.signal}`,
+      };
+    }
+
+    return {
+      exitCode: result.exitCode ?? 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
   }
 
   /**

--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -681,7 +681,7 @@ class QsvMcpServer {
       const auditLogEnabled = config.mcpLogLevel !== "off";
       // Skip automatic audit logging for qsv_log to avoid recursive noise
       const skipAuditLog = name === "qsv_log";
-      if (config.mcpLogLevel === "info" && !skipAuditLog) {
+      if ((config.mcpLogLevel === "info" || config.mcpLogLevel === "debug") && !skipAuditLog) {
         runQsvSimple(config.qsvBinPath, ["log", name, `s-${invocationId}`, startMsg], {
           timeoutMs: 5_000,
           cwd: this.filesystemProvider.getWorkingDirectory(),
@@ -776,7 +776,7 @@ class QsvMcpServer {
         const elapsedMs = Date.now() - startTime;
         const elapsedSecs = (elapsedMs / 1000).toFixed(2);
         const isError = "isError" in result && result.isError === true;
-        if (auditLogEnabled && !skipAuditLog && (config.mcpLogLevel === "info" || isError)) {
+        if (auditLogEnabled && !skipAuditLog && (config.mcpLogLevel === "info" || config.mcpLogLevel === "debug" || isError)) {
           const endMsg = isError
             ? `error(${elapsedSecs}s): tool returned error`
             : `ok(${elapsedSecs}s)`;

--- a/.claude/skills/src/parquet-bridge.ts
+++ b/.claude/skills/src/parquet-bridge.ts
@@ -2,7 +2,6 @@
  * Parquet/DuckDB conversion, schema management, and stats cache utilities.
  */
 
-import { spawn } from "child_process";
 import { readFile, writeFile, open, stat, unlink, mkdir } from "fs/promises";
 import { basename, dirname, join, parse } from "path";
 import { isShuttingDown, activeProcesses } from "./concurrency.js";
@@ -16,6 +15,7 @@ import {
 } from "./duckdb.js";
 import { config } from "./config.js";
 import { getErrorMessage, errorResult, successResult } from "./utils.js";
+import { spawnWithTimeout } from "./spawn-utils.js";
 
 /**
  * Map a qsv stats `type` + min/max range to the tightest DuckDB SQL type.
@@ -204,65 +204,30 @@ async function spawnDuckDbCommands(
   // Ensure working directory exists before spawning
   await mkdir(workDir, { recursive: true });
 
-  return new Promise((resolve, reject) => {
-    const proc = spawn(binPath, [dbPath, "-c", sql], {
-      // stdout ignored: COPY ... TO produces no result set; prevents backpressure hangs.
-      // If future SQL returns rows, change to "pipe" and consume the stream.
-      stdio: ["ignore", "ignore", "pipe"],
-      cwd: workDir,
-    });
-
-    activeProcesses.add(proc);
-
-    let stderr = "";
-    let timedOut = false;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    let killTimer: ReturnType<typeof setTimeout> | null = null;
-
-    timer = setTimeout(() => {
-      timedOut = true;
-      proc.kill("SIGTERM");
-      killTimer = setTimeout(() => {
-        if (proc.exitCode === null) {
-          try { proc.kill("SIGKILL"); } catch { /* ignore */ }
-          proc.unref();
-        }
-      }, 1000);
-    }, timeoutMs);
-
-    proc.stderr!.on("data", (chunk) => {
-      if (stderr.length < MAX_STDERR_SIZE) {
-        stderr += chunk.toString();
-        if (stderr.length > MAX_STDERR_SIZE) {
-          stderr = stderr.slice(0, MAX_STDERR_SIZE) + "\n[STDERR TRUNCATED]";
-        }
-      }
-    });
-
-    proc.on("close", (exitCode, signal) => {
-      if (timer) clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
-      activeProcesses.delete(proc);
-
-      if (timedOut) {
-        reject(new Error(`DuckDB Parquet conversion timed out after ${timeoutMs}ms`));
-        return;
-      }
-      if (exitCode !== 0) {
-        const exitInfo = exitCode !== null ? `exit ${exitCode}` : `killed by signal ${signal ?? "unknown"}`;
-        reject(new Error(`DuckDB Parquet conversion failed (${exitInfo}): ${stderr}`));
-        return;
-      }
-      resolve();
-    });
-
-    proc.on("error", (err) => {
-      if (timer) clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
-      activeProcesses.delete(proc);
-      reject(err);
-    });
+  const result = await spawnWithTimeout({
+    binary: binPath,
+    args: [dbPath, "-c", sql],
+    cwd: workDir,
+    timeoutMs,
+    // stdout ignored: COPY ... TO produces no result set; prevents backpressure hangs.
+    captureStdout: false,
+    maxStderrSize: MAX_STDERR_SIZE,
+    onSpawn: (proc) => activeProcesses.add(proc),
+    onExit: (proc) => activeProcesses.delete(proc),
   });
+
+  if (result.timedOut) {
+    throw new Error(`DuckDB Parquet conversion timed out after ${timeoutMs}ms`);
+  }
+
+  // Surface spawn errors (e.g. ENOENT)
+  if (result.exitCode === null) {
+    throw new Error(result.stderr || "DuckDB process failed to start");
+  }
+
+  if (result.exitCode !== 0) {
+    throw new Error(`DuckDB Parquet conversion failed (exit ${result.exitCode}): ${result.stderr}`);
+  }
 }
 
 /**

--- a/.claude/skills/src/parquet-bridge.ts
+++ b/.claude/skills/src/parquet-bridge.ts
@@ -220,9 +220,13 @@ async function spawnDuckDbCommands(
     throw new Error(`DuckDB Parquet conversion timed out after ${timeoutMs}ms`);
   }
 
-  // Surface spawn errors (e.g. ENOENT)
+  // Surface spawn errors or signal kills
   if (result.exitCode === null) {
-    throw new Error(result.stderr || "DuckDB process failed to start");
+    throw new Error(
+      result.signal
+        ? `DuckDB Parquet conversion failed (killed by signal ${result.signal}): ${result.stderr}`
+        : (result.stderr || "DuckDB process failed to start"),
+    );
   }
 
   if (result.exitCode !== 0) {

--- a/.claude/skills/src/spawn-utils.ts
+++ b/.claude/skills/src/spawn-utils.ts
@@ -1,0 +1,156 @@
+/**
+ * Common process spawning utility with timeout and output collection.
+ *
+ * Consolidates the SIGTERM → SIGKILL cascade, output truncation,
+ * and timer cleanup shared by executor.ts, duckdb.ts, and parquet-bridge.ts.
+ */
+
+import { spawn, type ChildProcess, type StdioOptions } from "child_process";
+import { KILL_GRACE_PERIOD_MS } from "./tool-constants.js";
+
+/** Default max output size per stream (50 MB). */
+const DEFAULT_MAX_OUTPUT_SIZE = 50 * 1024 * 1024;
+
+/** Options for {@link spawnWithTimeout}. */
+export interface SpawnWithTimeoutOptions {
+  /** Binary to execute. */
+  binary: string;
+  /** Command-line arguments. */
+  args: string[];
+  /** Working directory for the child process. */
+  cwd?: string;
+  /** Timeout in milliseconds. */
+  timeoutMs: number;
+  /** Data to write to stdin. If undefined stdin is set to "ignore". */
+  stdin?: string | Buffer;
+  /** Whether to capture stdout (default: true). When false, stdout is "ignore". */
+  captureStdout?: boolean;
+  /** Max bytes to collect from stdout before truncating (default: 50 MB). */
+  maxStdoutSize?: number;
+  /** Message appended to stdout when truncated. */
+  stdoutTruncationMsg?: string;
+  /** Max bytes to collect from stderr before truncating (default: 50 MB). */
+  maxStderrSize?: number;
+  /** Called immediately after spawn (e.g. to add to activeProcesses). */
+  onSpawn?: (proc: ChildProcess) => void;
+  /** Called when the process closes or errors (e.g. to remove from activeProcesses). */
+  onExit?: (proc: ChildProcess) => void;
+}
+
+/** Raw result from {@link spawnWithTimeout}. Callers map this to their own types. */
+export interface SpawnResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/**
+ * Spawn a child process with a timeout and SIGTERM → SIGKILL cascade.
+ *
+ * Returns a raw result; callers decide whether to resolve/reject, map exit
+ * codes, or attach metadata based on their needs.
+ */
+export function spawnWithTimeout(options: SpawnWithTimeoutOptions): Promise<SpawnResult> {
+  const {
+    binary,
+    args,
+    cwd,
+    timeoutMs,
+    stdin,
+    captureStdout = true,
+    maxStdoutSize = DEFAULT_MAX_OUTPUT_SIZE,
+    stdoutTruncationMsg = "\n\n[OUTPUT TRUNCATED - Result too large.]\n",
+    maxStderrSize = DEFAULT_MAX_OUTPUT_SIZE,
+    onSpawn,
+    onExit,
+  } = options;
+
+  const stdinMode = stdin !== undefined ? "pipe" : "ignore";
+  const stdoutMode = captureStdout ? "pipe" : "ignore";
+  const stdio: StdioOptions = [stdinMode, stdoutMode, "pipe"];
+
+  return new Promise((resolve) => {
+    const proc = spawn(binary, args, { stdio, cwd });
+
+    onSpawn?.(proc);
+
+    let stdout = "";
+    let stderr = "";
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+    let timedOut = false;
+    let processExited = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimers = () => {
+      processExited = true;
+      if (timer) { clearTimeout(timer); timer = null; }
+      if (killTimer) { clearTimeout(killTimer); killTimer = null; }
+    };
+
+    // ── Timeout: SIGTERM → grace period → SIGKILL ──────────────────────
+    timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill("SIGTERM");
+      killTimer = setTimeout(() => {
+        if (!processExited && proc.exitCode === null) {
+          try { proc.kill("SIGKILL"); } catch { /* may have exited between check and kill */ }
+          proc.unref();
+        }
+      }, KILL_GRACE_PERIOD_MS);
+    }, timeoutMs);
+
+    // ── stdin ───────────────────────────────────────────────────────────
+    if (stdin !== undefined) {
+      proc.stdin!.write(stdin);
+      proc.stdin!.end();
+    }
+
+    // ── stdout collection ──────────────────────────────────────────────
+    if (captureStdout) {
+      proc.stdout!.on("data", (chunk) => {
+        const data = chunk.toString();
+        if (stdout.length + data.length > maxStdoutSize) {
+          if (!stdoutTruncated) {
+            stdoutTruncated = true;
+            stdout += stdoutTruncationMsg;
+          }
+          return;
+        }
+        stdout += data;
+      });
+    }
+
+    // ── stderr collection ──────────────────────────────────────────────
+    proc.stderr!.on("data", (chunk) => {
+      const data = chunk.toString();
+      if (stderr.length + data.length > maxStderrSize) {
+        if (!stderrTruncated) {
+          stderrTruncated = true;
+          stderr = stderr.slice(0, maxStderrSize) + "\n[STDERR TRUNCATED]";
+        }
+        return;
+      }
+      stderr += data;
+    });
+
+    // ── close ──────────────────────────────────────────────────────────
+    proc.on("close", (exitCode, signal) => {
+      clearTimers();
+      onExit?.(proc);
+      resolve({ exitCode, signal, stdout, stderr, timedOut });
+    });
+
+    // ── spawn error (e.g. ENOENT) ──────────────────────────────────────
+    proc.on("error", (err) => {
+      clearTimers();
+      onExit?.(proc);
+      // Surface the error in stderr so callers can inspect it uniformly.
+      const msg = err?.message ?? String(err);
+      resolve({ exitCode: null, signal: null, stdout, stderr: stderr + `\n[SPAWN ERROR] ${msg}`, timedOut: false });
+    });
+  });
+}

--- a/.claude/skills/src/spawn-utils.ts
+++ b/.claude/skills/src/spawn-utils.ts
@@ -137,20 +137,23 @@ export function spawnWithTimeout(options: SpawnWithTimeoutOptions): Promise<Spaw
       stderr += data;
     });
 
+    // Shared finalizer: clears timers, calls onExit exactly once, resolves.
+    const finish = (result: SpawnResult) => {
+      clearTimers();
+      if (!processExited) { processExited = true; onExit?.(proc); }
+      resolve(result);
+    };
+
     // ── close ──────────────────────────────────────────────────────────
     proc.on("close", (exitCode, signal) => {
-      clearTimers();
-      onExit?.(proc);
-      resolve({ exitCode, signal, stdout, stderr, timedOut });
+      finish({ exitCode, signal, stdout, stderr, timedOut });
     });
 
     // ── spawn error (e.g. ENOENT) ──────────────────────────────────────
     proc.on("error", (err) => {
-      clearTimers();
-      onExit?.(proc);
       // Surface the error in stderr so callers can inspect it uniformly.
       const msg = err?.message ?? String(err);
-      resolve({ exitCode: null, signal: null, stdout, stderr: stderr + `\n[SPAWN ERROR] ${msg}`, timedOut: false });
+      finish({ exitCode: null, signal: null, stdout, stderr: stderr + `\n[SPAWN ERROR] ${msg}`, timedOut: false });
     });
   });
 }

--- a/.claude/skills/src/spawn-utils.ts
+++ b/.claude/skills/src/spawn-utils.ts
@@ -81,12 +81,12 @@ export function spawnWithTimeout(options: SpawnWithTimeoutOptions): Promise<Spaw
     let stdoutTruncated = false;
     let stderrTruncated = false;
     let timedOut = false;
-    let processExited = false;
+    let processExited = false;  // guards SIGKILL after SIGTERM
+    let finalized = false;      // ensures finish() runs exactly once
     let timer: ReturnType<typeof setTimeout> | null = null;
     let killTimer: ReturnType<typeof setTimeout> | null = null;
 
     const clearTimers = () => {
-      processExited = true;
       if (timer) { clearTimeout(timer); timer = null; }
       if (killTimer) { clearTimeout(killTimer); killTimer = null; }
     };
@@ -105,6 +105,11 @@ export function spawnWithTimeout(options: SpawnWithTimeoutOptions): Promise<Spaw
 
     // ── stdin ───────────────────────────────────────────────────────────
     if (stdin !== undefined) {
+      proc.stdin!.on("error", (err) => {
+        // EPIPE is expected if the child exits before consuming all input.
+        const msg = err?.message ?? String(err);
+        stderr += `\n[STDIN ERROR] ${msg}`;
+      });
       proc.stdin!.write(stdin);
       proc.stdin!.end();
     }
@@ -137,10 +142,13 @@ export function spawnWithTimeout(options: SpawnWithTimeoutOptions): Promise<Spaw
       stderr += data;
     });
 
-    // Shared finalizer: clears timers, calls onExit exactly once, resolves.
+    // Shared finalizer: clears timers, calls onExit exactly once, resolves once.
     const finish = (result: SpawnResult) => {
+      if (finalized) return;
+      finalized = true;
+      processExited = true;
       clearTimers();
-      if (!processExited) { processExited = true; onExit?.(proc); }
+      onExit?.(proc);
       resolve(result);
     };
 

--- a/.claude/skills/src/tool-constants.ts
+++ b/.claude/skills/src/tool-constants.ts
@@ -172,3 +172,8 @@ export const LOG_ENTRY_TYPES = new Set([
  * Auto-indexing threshold in MB
  */
 export const AUTO_INDEX_SIZE_MB = 10;
+
+/**
+ * Grace period (ms) between SIGTERM and SIGKILL when killing timed-out processes.
+ */
+export const KILL_GRACE_PERIOD_MS = 1000;


### PR DESCRIPTION
## Summary

- Extract duplicated SIGTERM→SIGKILL cascade + output truncation pattern from `executor.ts`, `duckdb.ts`, and `parquet-bridge.ts` into a shared `spawnWithTimeout()` utility in `spawn-utils.ts` (net -15 LOC across 7 files)
- Extend `QSV_MCP_LOG_LEVEL` to accept `"debug"` so verbose executor logging is no longer always-on in production
- Replace magic `1000` ms kill grace period literal with named `KILL_GRACE_PERIOD_MS` constant in `tool-constants.ts`

## Test plan

- [x] `npm test` — 569 pass, 0 fail, 5 skipped
- [x] `npm run build` — clean compile
- [x] Verified signal-kill error messages correctly report signal name (not "failed to start")
- [x] Verified `onExit` callback fires exactly once even when both `close` and `error` events fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)