### PR TITLE
feat(pivotp): expand smart aggregation with 7 more statistics

### DIFF
--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -824,10 +824,7 @@ fn suggest_numeric_after_bimodality(
 
 /// Log message for the mixed-sign cancellation guard.
 fn log_mixed_sign(stats: &StatsData) {
-    let (n_neg, n_pos) = (
-        stats.n_negative.unwrap_or(0),
-        stats.n_positive.unwrap_or(0),
-    );
+    let (n_neg, n_pos) = (stats.n_negative.unwrap_or(0), stats.n_positive.unwrap_or(0));
     let total = n_neg + stats.n_zero.unwrap_or(0) + n_pos;
     let neg_pct = (n_neg.saturating_mul(100) + (total / 2)) / total;
     let pos_pct = (n_pos.saturating_mul(100) + (total / 2)) / total;

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -533,7 +533,8 @@ fn suggest_agg_function(
                 } else if stats.sparsity.unwrap_or(0.0) > 0.5 {
                     if !quiet {
                         eprintln!(
-                            "Info: \"{value_col}\" contains >50% NULL values, using Len"
+                            "Info: \"{value_col}\" is a sparse {} column (>50% NULL), using Len",
+                            stats.r#type
                         );
                     }
                     Expr::Element.len()
@@ -795,8 +796,8 @@ fn suggest_numeric_after_bimodality(
             if neg_frac > 0.2 && pos_frac > 0.2 {
                 if !quiet {
                     eprintln!(
-                        "Info: Mixed-sign data ({:.0}% negative, {:.0}% positive), using Mean \
-                         to avoid Sum cancellation",
+                        "Info: Mixed-sign data ({:.0}% negative, {:.0}% positive), using Mean to \
+                         avoid Sum cancellation",
                         neg_frac * 100.0,
                         pos_frac * 100.0
                     );

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -54,11 +54,12 @@ pivotp options:
                               len - Count of values
                               item - Get single value from group. Raises error if there are multiple values.
                               smart - use value column data type & statistics to pick an aggregation.
-                                      Always uses type, cardinality, sparsity, CV, and sign
-                                      distribution (n_negative/n_positive) from streaming stats.
+                                      Always uses type, cardinality, sparsity, CV, sign
+                                      distribution (n_negative/n_positive), and sort_order
+                                      from streaming stats.
                                       When the stats cache includes non-streaming stats (from a
                                       prior `stats --everything` or `stats --mode --quartiles`),
-                                      also uses skewness, mode_count, and sort_order.
+                                      also uses skewness and mode_count.
                                       When moarstats has been run, also leverages outlier profile,
                                       Pearson skewness, MAD/stddev ratio, median/mean ratio, and
                                       quartile coefficient of dispersion for smarter selection.
@@ -559,7 +560,7 @@ fn suggest_agg_function(
                         Expr::Element.first()
                     }
                 } else if let Some(sort_order) = &stats.sort_order
-                    && sort_order == "Ascending"
+                    && sort_order.starts_with("Ascending")
                 {
                     // Value column itself is sorted ascending — most recent entry
                     // is typically most useful for temporal data

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -54,8 +54,11 @@ pivotp options:
                               len - Count of values
                               item - Get single value from group. Raises error if there are multiple values.
                               smart - use value column data type & statistics to pick an aggregation.
-                                      From base stats, uses type, cardinality, sparsity, CV, skewness,
-                                      sort_order, mode_count and sign distribution (n_negative/n_positive).
+                                      Always uses type, cardinality, sparsity, CV, and sign
+                                      distribution (n_negative/n_positive) from streaming stats.
+                                      When the stats cache includes non-streaming stats (from a
+                                      prior `stats --everything` or `stats --mode --quartiles`),
+                                      also uses skewness, mode_count, and sort_order.
                                       When moarstats has been run, also leverages outlier profile,
                                       Pearson skewness, MAD/stddev ratio, median/mean ratio, and
                                       quartile coefficient of dispersion for smarter selection.
@@ -637,7 +640,6 @@ fn suggest_agg_function(
 /// Contains the remaining moarstats-aware checks (outliers, kurtosis, Gini,
 /// MAD/stddev divergence, mean/median divergence, quartile dispersion)
 /// followed by the original CV, cardinality, and skewness logic.
-#[allow(clippy::cast_precision_loss)]
 #[allow(clippy::fn_params_excessive_bools)]
 fn suggest_numeric_after_bimodality(
     stats: &StatsData,
@@ -738,6 +740,17 @@ fn suggest_numeric_after_bimodality(
         return Expr::Element.median();
     }
 
+    // Mixed-sign cancellation guard — Sum cancels out with substantial
+    // negative and positive values, Mean is more informative.
+    // Uses integer arithmetic (n * 5 > total ≡ n/total > 20%) to avoid
+    // f64 casts.
+    let is_mixed_sign = if let (Some(n_neg), Some(n_pos)) = (stats.n_negative, stats.n_positive) {
+        let total = n_neg + stats.n_zero.unwrap_or(0) + n_pos;
+        total > 0 && n_neg.saturating_mul(5) > total && n_pos.saturating_mul(5) > total
+    } else {
+        false
+    };
+
     // Original: high cardinality pivot + index
     if high_cardinality_pivot && high_cardinality_index {
         // moarstats: near-uniform distribution makes aggregation uninformative
@@ -750,6 +763,14 @@ fn suggest_numeric_after_bimodality(
                 );
             }
             return Expr::Element.len();
+        }
+
+        // Mixed-sign guard applies here too — Sum would cancel out
+        if is_mixed_sign {
+            if !quiet {
+                log_mixed_sign(stats);
+            }
+            return Expr::Element.mean();
         }
 
         if ordered_pivot && ordered_index {
@@ -786,25 +807,12 @@ fn suggest_numeric_after_bimodality(
         return Expr::Element.median();
     }
 
-    // Mixed-sign cancellation guard — Sum cancels out with substantial
-    // negative and positive values, Mean is more informative
-    if let (Some(n_neg), Some(n_pos)) = (stats.n_negative, stats.n_positive) {
-        let total = n_neg + stats.n_zero.unwrap_or(0) + n_pos;
-        if total > 0 {
-            let neg_frac = n_neg as f64 / total as f64;
-            let pos_frac = n_pos as f64 / total as f64;
-            if neg_frac > 0.2 && pos_frac > 0.2 {
-                if !quiet {
-                    eprintln!(
-                        "Info: Mixed-sign data ({:.0}% negative, {:.0}% positive), using Mean to \
-                         avoid Sum cancellation",
-                        neg_frac * 100.0,
-                        pos_frac * 100.0
-                    );
-                }
-                return Expr::Element.mean();
-            }
+    // Mixed-sign guard for the default path
+    if is_mixed_sign {
+        if !quiet {
+            log_mixed_sign(stats);
         }
+        return Expr::Element.mean();
     }
 
     // Default for numeric
@@ -812,6 +820,21 @@ fn suggest_numeric_after_bimodality(
         eprintln!("Info: Using Sum for \"{value_col}\"");
     }
     Expr::Element.sum()
+}
+
+/// Log message for the mixed-sign cancellation guard.
+fn log_mixed_sign(stats: &StatsData) {
+    let (n_neg, n_pos) = (
+        stats.n_negative.unwrap_or(0),
+        stats.n_positive.unwrap_or(0),
+    );
+    let total = n_neg + stats.n_zero.unwrap_or(0) + n_pos;
+    let neg_pct = (n_neg.saturating_mul(100) + (total / 2)) / total;
+    let pos_pct = (n_pos.saturating_mul(100) + (total / 2)) / total;
+    eprintln!(
+        "Info: Mixed-sign data ({neg_pct}% negative, {pos_pct}% positive), using Mean to avoid \
+         Sum cancellation"
+    );
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -54,9 +54,14 @@ pivotp options:
                               len - Count of values
                               item - Get single value from group. Raises error if there are multiple values.
                               smart - use value column data type & statistics to pick an aggregation.
-                                      When moarstats has been run, leverages outlier profile and
-                                      Pearson skewness for smarter selection. With moarstats --advanced,
-                                      also uses kurtosis, bimodality, entropy and Gini coefficient.
+                                      From base stats, uses type, cardinality, sparsity, CV, skewness,
+                                      sort_order, mode_count and sign distribution (n_negative/n_positive).
+                                      When moarstats has been run, also leverages outlier profile,
+                                      Pearson skewness, MAD/stddev ratio, median/mean ratio, and
+                                      quartile coefficient of dispersion for smarter selection.
+                                      With moarstats --advanced, also uses kurtosis, bimodality,
+                                      entropy and Gini coefficient.
+                                      For Date/DateTime values, checks sparsity and sort order.
                                       Will only work if there is one value column, otherwise
                                       it falls back to `first`
                             [default: smart]
@@ -475,6 +480,17 @@ fn suggest_agg_function(
                         eprintln!("Info: \"{value_col}\" contains >50% NULL values, using Len");
                     }
                     Expr::Element.len()
+                } else if let Some(mc) = stats.mode_count
+                    && mc > 10
+                {
+                    // Complex multimodal — more than 10 tied modes means
+                    // central tendency is especially misleading
+                    if !quiet {
+                        eprintln!(
+                            "Info: Complex multimodal distribution ({mc} modes > 10), using Len"
+                        );
+                    }
+                    Expr::Element.len()
                 } else if let Some(bc) = stats.bimodality_coefficient {
                     if bc >= 0.555 {
                         // Bimodal distribution — central tendency is misleading
@@ -514,6 +530,13 @@ fn suggest_agg_function(
                         eprintln!("Info: \"{value_col}\" contains only one value, using Item");
                     }
                     Expr::Element.item(true)
+                } else if stats.sparsity.unwrap_or(0.0) > 0.5 {
+                    if !quiet {
+                        eprintln!(
+                            "Info: \"{value_col}\" contains >50% NULL values, using Len"
+                        );
+                    }
+                    Expr::Element.len()
                 } else if high_cardinality_pivot || high_cardinality_index {
                     if ordered_pivot && ordered_index {
                         if !quiet {
@@ -531,6 +554,18 @@ fn suggest_agg_function(
                         }
                         Expr::Element.first()
                     }
+                } else if let Some(sort_order) = &stats.sort_order
+                    && sort_order == "Ascending"
+                {
+                    // Value column itself is sorted ascending — most recent entry
+                    // is typically most useful for temporal data
+                    if !quiet {
+                        eprintln!(
+                            "Info: Ascending {} values detected, using Last for most recent",
+                            stats.r#type
+                        );
+                    }
+                    Expr::Element.last()
                 } else {
                     if !quiet {
                         eprintln!("Info: Using Len for {} column", stats.r#type);
@@ -598,8 +633,10 @@ fn suggest_agg_function(
 }
 
 /// Helper for numeric aggregation decisions after the bimodality check.
-/// Contains the remaining moarstats-aware checks (outliers, kurtosis, Gini)
+/// Contains the remaining moarstats-aware checks (outliers, kurtosis, Gini,
+/// MAD/stddev divergence, mean/median divergence, quartile dispersion)
 /// followed by the original CV, cardinality, and skewness logic.
+#[allow(clippy::cast_precision_loss)]
 #[allow(clippy::fn_params_excessive_bools)]
 fn suggest_numeric_after_bimodality(
     stats: &StatsData,
@@ -646,6 +683,45 @@ fn suggest_numeric_after_bimodality(
     {
         if !quiet {
             eprintln!("Info: High inequality (Gini coefficient {gc:.3} > 0.6), using Median");
+        }
+        return Expr::Element.median();
+    }
+
+    // moarstats: robust vs non-robust spread divergence — outliers inflate stddev
+    if let Some(msr) = stats.mad_stddev_ratio
+        && msr < 0.5
+    {
+        if !quiet {
+            eprintln!(
+                "Info: Robust/non-robust spread divergence (MAD/stddev ratio {msr:.3} < 0.5), \
+                 using Median"
+            );
+        }
+        return Expr::Element.median();
+    }
+
+    // moarstats: direct mean/median divergence
+    if let Some(mmr) = stats.median_mean_ratio
+        && !(0.7..=1.3).contains(&mmr)
+    {
+        if !quiet {
+            eprintln!(
+                "Info: Mean/median divergence (ratio {mmr:.3}, outside 0.7\u{2013}1.3), using \
+                 Median"
+            );
+        }
+        return Expr::Element.median();
+    }
+
+    // moarstats: robust quartile-based variability
+    if let Some(qcd) = stats.quartile_coefficient_dispersion
+        && qcd > 0.5
+    {
+        if !quiet {
+            eprintln!(
+                "Info: High robust variability (quartile coefficient of dispersion {qcd:.3} > \
+                 0.5), using Median"
+            );
         }
         return Expr::Element.median();
     }
@@ -707,6 +783,27 @@ fn suggest_numeric_after_bimodality(
             );
         }
         return Expr::Element.median();
+    }
+
+    // Mixed-sign cancellation guard — Sum cancels out with substantial
+    // negative and positive values, Mean is more informative
+    if let (Some(n_neg), Some(n_pos)) = (stats.n_negative, stats.n_positive) {
+        let total = n_neg + stats.n_zero.unwrap_or(0) + n_pos;
+        if total > 0 {
+            let neg_frac = n_neg as f64 / total as f64;
+            let pos_frac = n_pos as f64 / total as f64;
+            if neg_frac > 0.2 && pos_frac > 0.2 {
+                if !quiet {
+                    eprintln!(
+                        "Info: Mixed-sign data ({:.0}% negative, {:.0}% positive), using Mean \
+                         to avoid Sum cancellation",
+                        neg_frac * 100.0,
+                        pos_frac * 100.0
+                    );
+                }
+                return Expr::Element.mean();
+            }
+        }
     }
 
     // Default for numeric

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -1110,7 +1110,10 @@ fn pivotp_smart_mixed_sign() {
 }
 
 // Test smart aggregation — complex multimodal (>10 modes) should pick Len
-// Requires moarstats to preserve the stats cache with mode_count
+// mode_count comes from `stats --everything` (or `--mode`). We also run
+// moarstats so that pivotp reads the existing cache rather than re-running
+// stats with FrequencyForceStats (which only produces streaming stats and
+// would not include mode_count).
 #[test]
 fn pivotp_smart_multimodal() {
     let wrk = Workdir::new("pivotp_smart_multimodal");
@@ -1128,7 +1131,8 @@ fn pivotp_smart_multimodal() {
         .join("\n");
     wrk.create_from_string("multimodal.csv", &csv_content);
 
-    // stats --everything + moarstats so pivotp reads the full cache with mode_count
+    // stats --everything produces mode_count; moarstats prevents pivotp
+    // from overwriting the cache with a streaming-only re-run
     let mut stats_cmd = wrk.command("stats");
     stats_cmd.args(["--everything", "multimodal.csv"]);
     wrk.assert_success(&mut stats_cmd);

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -915,6 +915,322 @@ fn pivotp_smart_moarstats_outliers() {
     );
 }
 
+// Test smart aggregation with moarstats — MAD/stddev ratio < 0.5 should pick Median
+#[test]
+fn pivotp_smart_moarstats_mad_stddev_ratio() {
+    let wrk = Workdir::new("pivotp_smart_mad_stddev");
+    // Data where a few large outliers inflate stddev far beyond MAD.
+    // Most values cluster near 50, but a few extreme values push stddev up
+    // while MAD stays low because the median neighborhood is tight.
+    let csv_content = std::iter::once("category,group,value".to_string())
+        .chain((0..50).map(|i| {
+            let cat = if i % 2 == 0 { "A" } else { "B" };
+            let grp = if i % 2 == 0 { "X" } else { "Y" };
+            let val = match i {
+                0 => 5000,
+                1 => 4000,
+                2 => 3000,
+                _ => 50 + (i % 5),
+            };
+            format!("{cat},{grp},{val}")
+        }))
+        .collect::<Vec<_>>()
+        .join("\n");
+    wrk.create_from_string("mad_stddev.csv", &csv_content);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd.args(["--everything", "mad_stddev.csv"]);
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut moar_cmd = wrk.command("moarstats");
+    moar_cmd.args(["mad_stddev.csv"]);
+    wrk.assert_success(&mut moar_cmd);
+
+    let mut cmd = wrk.command("pivotp");
+    cmd.args([
+        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "mad_stddev.csv",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    // Should use Median — outliers inflate stddev but MAD stays robust
+    assert!(
+        stderr.contains("Median"),
+        "Expected Median for data with low MAD/stddev ratio, got: {stderr}"
+    );
+}
+
+// Test smart aggregation with moarstats — median/mean ratio far from 1.0 should pick Median
+#[test]
+fn pivotp_smart_moarstats_median_mean_divergence() {
+    let wrk = Workdir::new("pivotp_smart_median_mean");
+    // Right-skewed data: many small values, a few large ones.
+    // Mean gets pulled up by the large values while median stays low,
+    // producing a median/mean ratio well below 0.7.
+    let csv_content = std::iter::once("category,group,value".to_string())
+        .chain((0..60).map(|i| {
+            let cat = if i % 3 == 0 {
+                "A"
+            } else if i % 3 == 1 {
+                "B"
+            } else {
+                "C"
+            };
+            let grp = if i % 2 == 0 { "X" } else { "Y" };
+            // 50 values at 10-15, 10 values at 500-600
+            let val = if i < 50 { 10 + (i % 6) } else { 500 + i * 10 };
+            format!("{cat},{grp},{val}")
+        }))
+        .collect::<Vec<_>>()
+        .join("\n");
+    wrk.create_from_string("median_mean.csv", &csv_content);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd.args(["--everything", "median_mean.csv"]);
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut moar_cmd = wrk.command("moarstats");
+    moar_cmd.args(["median_mean.csv"]);
+    wrk.assert_success(&mut moar_cmd);
+
+    let mut cmd = wrk.command("pivotp");
+    cmd.args([
+        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "median_mean.csv",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    // Should use Median — mean and median diverge significantly
+    assert!(
+        stderr.contains("Median"),
+        "Expected Median for data with divergent mean/median, got: {stderr}"
+    );
+}
+
+// Test smart aggregation with moarstats — high quartile coefficient of dispersion
+#[test]
+fn pivotp_smart_moarstats_quartile_dispersion() {
+    let wrk = Workdir::new("pivotp_smart_qcd");
+    // Data with wide IQR relative to the quartile sum.
+    // Spread values broadly so Q3-Q1 is large relative to Q3+Q1 (QCD > 0.5).
+    let csv_content = std::iter::once("category,group,value".to_string())
+        .chain((0..50).map(|i| {
+            let cat = if i % 2 == 0 { "A" } else { "B" };
+            let grp = if i % 2 == 0 { "X" } else { "Y" };
+            // Uniform-ish distribution from 1 to 1000
+            let val = 1 + i * 20;
+            format!("{cat},{grp},{val}")
+        }))
+        .collect::<Vec<_>>()
+        .join("\n");
+    wrk.create_from_string("qcd.csv", &csv_content);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd.args(["--everything", "qcd.csv"]);
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut moar_cmd = wrk.command("moarstats");
+    moar_cmd.args(["qcd.csv"]);
+    wrk.assert_success(&mut moar_cmd);
+
+    let mut cmd = wrk.command("pivotp");
+    cmd.args([
+        "group", "--index", "category", "--values", "value", "--agg", "smart", "qcd.csv",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    // Should use Median — high quartile-based dispersion
+    assert!(
+        stderr.contains("Median"),
+        "Expected Median for data with high quartile coefficient of dispersion, got: {stderr}"
+    );
+}
+
+// Test smart aggregation — mixed-sign data should pick Mean (avoid Sum cancellation)
+#[test]
+fn pivotp_smart_mixed_sign() {
+    let wrk = Workdir::new("pivotp_smart_mixed_sign");
+    // Data with substantial negative and positive values (both >20%).
+    // Sum would cancel out and be misleading.
+    let csv_content = std::iter::once("category,group,value".to_string())
+        .chain((0..40).map(|i| {
+            let cat = if i % 2 == 0 { "A" } else { "B" };
+            let grp = if i % 2 == 0 { "X" } else { "Y" };
+            // ~50% negative, ~50% positive, low variability so CV < 1
+            let val = if i < 20 {
+                -(10 + (i % 5))
+            } else {
+                10 + (i % 5)
+            };
+            format!("{cat},{grp},{val}")
+        }))
+        .collect::<Vec<_>>()
+        .join("\n");
+    wrk.create_from_string("mixed_sign.csv", &csv_content);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd.args(["--everything", "mixed_sign.csv"]);
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("pivotp");
+    cmd.args([
+        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "mixed_sign.csv",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    // Should use Mean — mixed-sign data makes Sum cancel out
+    assert!(
+        stderr.contains("Mean") || stderr.contains("Mixed-sign"),
+        "Expected Mean for mixed-sign data, got: {stderr}"
+    );
+}
+
+// Test smart aggregation — complex multimodal (>10 modes) should pick Len
+// Requires moarstats to preserve the stats cache with mode_count
+#[test]
+fn pivotp_smart_multimodal() {
+    let wrk = Workdir::new("pivotp_smart_multimodal");
+    // Data where many values appear with equal frequency, creating >10 modes.
+    // Each value appears exactly twice so all are tied as modes (mode_count = 20).
+    let csv_content = std::iter::once("category,group,value".to_string())
+        .chain((0..40).map(|i| {
+            let cat = if i % 2 == 0 { "A" } else { "B" };
+            let grp = if i % 2 == 0 { "X" } else { "Y" };
+            // 20 distinct values, each appearing twice -> mode_count = 20
+            let val = (i % 20) * 100;
+            format!("{cat},{grp},{val}")
+        }))
+        .collect::<Vec<_>>()
+        .join("\n");
+    wrk.create_from_string("multimodal.csv", &csv_content);
+
+    // stats --everything + moarstats so pivotp reads the full cache with mode_count
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd.args(["--everything", "multimodal.csv"]);
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut moar_cmd = wrk.command("moarstats");
+    moar_cmd.args(["multimodal.csv"]);
+    wrk.assert_success(&mut moar_cmd);
+
+    let mut cmd = wrk.command("pivotp");
+    cmd.args([
+        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "multimodal.csv",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    // Should use Len — too many modes means central tendency is misleading
+    assert!(
+        stderr.contains("Len") || stderr.contains("modes"),
+        "Expected Len for complex multimodal data, got: {stderr}"
+    );
+}
+
+// Test smart aggregation — Date/DateTime with >50% NULLs should pick Len
+// Requires stats --infer-dates + moarstats to preserve Date type in cache
+#[test]
+fn pivotp_smart_date_sparse() {
+    let wrk = Workdir::new("pivotp_smart_date_sparse");
+    // Date column with >50% NULL values
+    let csv_content = "category,group,date_val\n\
+                        A,X,2024-01-01\n\
+                        A,Y,\n\
+                        B,X,\n\
+                        B,Y,2024-02-15\n\
+                        C,X,\n\
+                        C,Y,\n\
+                        A,X,\n\
+                        B,X,\n\
+                        C,X,\n\
+                        A,Y,2024-03-10\n";
+    wrk.create_from_string("date_sparse.csv", csv_content);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd.args(["--everything", "--infer-dates", "date_sparse.csv"]);
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut moar_cmd = wrk.command("moarstats");
+    moar_cmd.args(["date_sparse.csv"]);
+    wrk.assert_success(&mut moar_cmd);
+
+    let mut cmd = wrk.command("pivotp");
+    cmd.args([
+        "group",
+        "--index",
+        "category",
+        "--values",
+        "date_val",
+        "--agg",
+        "smart",
+        "--try-parsedates",
+        "date_sparse.csv",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    // Should use Len — >50% NULLs in date column
+    assert!(
+        stderr.contains("Len") || stderr.contains("NULL"),
+        "Expected Len for sparse date column, got: {stderr}"
+    );
+}
+
+// Test smart aggregation — ascending Date values should pick Last
+// Requires stats --infer-dates + moarstats to preserve Date type in cache
+#[test]
+fn pivotp_smart_date_ascending() {
+    let wrk = Workdir::new("pivotp_smart_date_ascending");
+    // Ascending date values — Last gives the most recent entry
+    let csv_content = "category,group,date_val\n\
+                        A,X,2024-01-01\n\
+                        A,Y,2024-01-15\n\
+                        B,X,2024-02-01\n\
+                        B,Y,2024-02-15\n\
+                        C,X,2024-03-01\n\
+                        C,Y,2024-03-15\n\
+                        A,X,2024-04-01\n\
+                        B,X,2024-04-15\n\
+                        C,X,2024-05-01\n\
+                        A,Y,2024-05-15\n";
+    wrk.create_from_string("date_ascending.csv", csv_content);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd.args(["--everything", "--infer-dates", "date_ascending.csv"]);
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut moar_cmd = wrk.command("moarstats");
+    moar_cmd.args(["date_ascending.csv"]);
+    wrk.assert_success(&mut moar_cmd);
+
+    let mut cmd = wrk.command("pivotp");
+    cmd.args([
+        "group",
+        "--index",
+        "category",
+        "--values",
+        "date_val",
+        "--agg",
+        "smart",
+        "--try-parsedates",
+        "date_ascending.csv",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    // Should use Last — ascending date values, most recent is most useful
+    assert!(
+        stderr.contains("Last") || stderr.contains("Ascending"),
+        "Expected Last for ascending date column, got: {stderr}"
+    );
+}
+
 // Test pivot with custom infer length
 pivotp_test!(
     pivotp_infer_len,

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -948,7 +948,13 @@ fn pivotp_smart_moarstats_mad_stddev_ratio() {
 
     let mut cmd = wrk.command("pivotp");
     cmd.args([
-        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "group",
+        "--index",
+        "category",
+        "--values",
+        "value",
+        "--agg",
+        "smart",
         "mad_stddev.csv",
     ]);
     wrk.assert_success(&mut cmd);
@@ -996,7 +1002,13 @@ fn pivotp_smart_moarstats_median_mean_divergence() {
 
     let mut cmd = wrk.command("pivotp");
     cmd.args([
-        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "group",
+        "--index",
+        "category",
+        "--values",
+        "value",
+        "--agg",
+        "smart",
         "median_mean.csv",
     ]);
     wrk.assert_success(&mut cmd);
@@ -1059,7 +1071,8 @@ fn pivotp_smart_mixed_sign() {
         .chain((0..40).map(|i| {
             let cat = if i % 2 == 0 { "A" } else { "B" };
             let grp = if i % 2 == 0 { "X" } else { "Y" };
-            // ~50% negative, ~50% positive, low variability so CV < 1
+            // ~50% negative, ~50% positive; mean ≈ 0 so CV is NaN,
+            // which won't preempt the mixed-sign check
             let val = if i < 20 {
                 -(10 + (i % 5))
             } else {
@@ -1077,7 +1090,13 @@ fn pivotp_smart_mixed_sign() {
 
     let mut cmd = wrk.command("pivotp");
     cmd.args([
-        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "group",
+        "--index",
+        "category",
+        "--values",
+        "value",
+        "--agg",
+        "smart",
         "mixed_sign.csv",
     ]);
     wrk.assert_success(&mut cmd);
@@ -1120,7 +1139,13 @@ fn pivotp_smart_multimodal() {
 
     let mut cmd = wrk.command("pivotp");
     cmd.args([
-        "group", "--index", "category", "--values", "value", "--agg", "smart",
+        "group",
+        "--index",
+        "category",
+        "--values",
+        "value",
+        "--agg",
+        "smart",
         "multimodal.csv",
     ]);
     wrk.assert_success(&mut cmd);
@@ -1139,18 +1164,21 @@ fn pivotp_smart_multimodal() {
 fn pivotp_smart_date_sparse() {
     let wrk = Workdir::new("pivotp_smart_date_sparse");
     // Date column with >50% NULL values
-    let csv_content = "category,group,date_val\n\
-                        A,X,2024-01-01\n\
-                        A,Y,\n\
-                        B,X,\n\
-                        B,Y,2024-02-15\n\
-                        C,X,\n\
-                        C,Y,\n\
-                        A,X,\n\
-                        B,X,\n\
-                        C,X,\n\
-                        A,Y,2024-03-10\n";
-    wrk.create_from_string("date_sparse.csv", csv_content);
+    let csv_content = vec![
+        "category,group,date_val",
+        "A,X,2024-01-01",
+        "A,Y,",
+        "B,X,",
+        "B,Y,2024-02-15",
+        "C,X,",
+        "C,Y,",
+        "A,X,",
+        "B,X,",
+        "C,X,",
+        "A,Y,2024-03-10",
+    ]
+    .join("\n");
+    wrk.create_from_string("date_sparse.csv", &csv_content);
 
     let mut stats_cmd = wrk.command("stats");
     stats_cmd.args(["--everything", "--infer-dates", "date_sparse.csv"]);
@@ -1188,18 +1216,21 @@ fn pivotp_smart_date_sparse() {
 fn pivotp_smart_date_ascending() {
     let wrk = Workdir::new("pivotp_smart_date_ascending");
     // Ascending date values — Last gives the most recent entry
-    let csv_content = "category,group,date_val\n\
-                        A,X,2024-01-01\n\
-                        A,Y,2024-01-15\n\
-                        B,X,2024-02-01\n\
-                        B,Y,2024-02-15\n\
-                        C,X,2024-03-01\n\
-                        C,Y,2024-03-15\n\
-                        A,X,2024-04-01\n\
-                        B,X,2024-04-15\n\
-                        C,X,2024-05-01\n\
-                        A,Y,2024-05-15\n";
-    wrk.create_from_string("date_ascending.csv", csv_content);
+    let csv_content = vec![
+        "category,group,date_val",
+        "A,X,2024-01-01",
+        "A,Y,2024-01-15",
+        "B,X,2024-02-01",
+        "B,Y,2024-02-15",
+        "C,X,2024-03-01",
+        "C,Y,2024-03-15",
+        "A,X,2024-04-01",
+        "B,X,2024-04-15",
+        "C,X,2024-05-01",
+        "A,Y,2024-05-15",
+    ]
+    .join("\n");
+    wrk.create_from_string("date_ascending.csv", &csv_content);
 
     let mut stats_cmd = wrk.command("stats");
     stats_cmd.args(["--everything", "--infer-dates", "date_ascending.csv"]);


### PR DESCRIPTION
## Summary

- Expand `--agg smart` to consult 7 additional statistics from `StatsData` for better aggregation decisions
- **Numeric:** `mad_stddev_ratio`, `median_mean_ratio`, `quartile_coefficient_dispersion` → Median; `n_negative`/`n_positive` mixed-sign guard → Mean; `mode_count > 10` multimodal → Len
- **Date/DateTime:** sparsity > 50% → Len; ascending sort order → Last
- Add 7 tests covering each new signal path
- Update `--agg smart` help text to document all signals

## Test plan

- [x] `cargo test pivotp -F all_features` — all 56 tests pass (49 existing + 7 new)
- [x] `cargo clippy --bin qsv -F all_features -- -W clippy::pedantic` — zero warnings
- [x] Manual verification with crafted CSVs for each new signal (MAD/stddev divergence, median/mean divergence, QCD, mixed-sign, multimodal, sparse dates, ascending dates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)