### PR TITLE
refactor(mcp): load command guidance from YAML

### DIFF
--- a/.claude/skills/data/command-guidance.yaml
+++ b/.claude/skills/data/command-guidance.yaml
@@ -1,0 +1,280 @@
+# Command guidance for qsv MCP tool selection and usage.
+# Each top-level key is a qsv subcommand name.
+#
+# Fields (all optional):
+#   whenToUse          — when to select this command (string)
+#   commonPattern      — typical workflow patterns (string)
+#   errorPrevention    — common mistakes and pitfalls (string)
+#   needsMemoryWarning — flag: memory-intensive (boolean, only when true)
+#   needsIndexHint     — flag: benefits from indexing (boolean, only when true)
+#   hasCommonMistakes  — flag: shown with errorPrevention (boolean, only when true)
+
+select:
+  whenToUse: 'Choose columns. Syntax: "1,3,5" (specific), "1-10" (range), "!SSN" (exclude), "/<regex>/" (pattern), "_" (last).'
+  commonPattern: "First step: select columns → filter → sort → output. Speeds up downstream ops."
+
+slice:
+  whenToUse: "Select rows by position: first N, last N, skip N, range."
+
+search:
+  whenToUse: "Filter rows matching pattern/regex. Search applied to selected fields. For complex conditions, use qsv_sqlp."
+  commonPattern: "Combine with select: search (filter rows) → select (pick columns)."
+  needsIndexHint: true
+
+stats:
+  whenToUse: "Quick numeric stats (mean, min/max, stddev). Creates cache for other commands. Run 2nd after index."
+  commonPattern: "Run 2nd (after index). Creates cache used by frequency, schema, tojsonl, sqlp, joinp, pivotp, describegpt, moarstats, sample. Moarstats is auto-run after stats to enrich the cache with ~25 additional columns."
+  errorPrevention: "Works with CSV/TSV/SSV files only. For SQL queries, use sqlp. Run qsv_index first for files >10MB."
+  needsIndexHint: true
+
+moarstats:
+  whenToUse: "Basic moarstats is auto-run after stats. Only invoke manually for --advanced (kurtosis, entropy, gini, etc.) or --bivariate (pairwise correlations)."
+  commonPattern: >-
+    Basic moarstats runs automatically after stats to enrich the .stats.csv cache.
+    Invoke manually only for --advanced or --bivariate.
+    When running manually, use the CLI --output flag if you need to control where the main stats output is written;
+    MCP output_file only saves stdout and does not set moarstats --output.
+    Enriches .stats.csv with ~25 additional columns (including trimean, midhinge, robust_cv, jarque_bera,
+    theil_index, mean_ad, simpsons_diversity_index) for richer LLM analysis —
+    moarstats enriches .stats.csv only, not .data.jsonl; smart commands still use .data.jsonl.
+    With --bivariate: main stats go to --output (or stdout if omitted),
+    while bivariate stats are written to <FILESTEM>.stats.bivariate.csv (a separate file next to the input).
+  errorPrevention: >-
+    Run stats first to create cache. IMPORTANT: Only run --bivariate when requested as it's expensive.
+    Bivariate results are written to a SEPARATE file: <FILESTEM>.stats.bivariate.csv
+    (located next to the input file, not controlled by MCP output_file/stdout capture).
+    Always read this file to get bivariate results.
+    With --join-inputs, the file is <FILESTEM>.stats.bivariate.joined.csv.
+  needsMemoryWarning: true
+  hasCommonMistakes: true
+
+pragmastat:
+  whenToUse: "Robust outlier-resistant statistics (Hodges-Lehmann center, Shamos spread). Use when data is messy, heavy-tailed, or outlier-prone. Use --twosample to compare column pairs (shift, ratio, disparity)."
+  commonPattern: "Index → Pragmastat for single-sample analysis. For comparisons: --twosample --select col1,col2. Use --misrate 1e-6 for critical decisions (default 1e-3)."
+  errorPrevention: "Only processes numeric columns (non-numeric appear with n=0). All numeric values loaded into memory. Blank cells in output mean insufficient data or positivity requirement not met."
+  needsMemoryWarning: true
+
+frequency:
+  whenToUse: "Count unique values. Best for low-cardinality categorical columns. Run qsv_stats --cardinality first to identify high-cardinality columns to exclude."
+  commonPattern: "Stats → Frequency: Use qsv_stats --cardinality first to identify high-cardinality columns (IDs) to exclude. The frequency cache (--frequency-jsonl) is auto-created on first run for faster subsequent analysis."
+  errorPrevention: >-
+    High-cardinality columns (IDs, timestamps) can produce huge output. Use qsv_stats --cardinality to inspect
+    column cardinality before running frequency. Do NOT set a client-side timeout shorter than the server's
+    operation timeout (default 10 min) — let frequency run to completion. If the server timeout is exceeded
+    on very large files, fall back to qsv_sqlp:
+    'SELECT col, COUNT(*) FROM _t_1 GROUP BY col ORDER BY COUNT(*) DESC LIMIT 20'.
+    Use --select to target specific columns instead of computing frequency on all columns.
+  needsMemoryWarning: true
+  hasCommonMistakes: true
+
+join:
+  whenToUse: "Join CSV files (<50MB). For large/complex joins, use qsv_joinp."
+  commonPattern: "Run qsv_index first on both files for speed."
+  errorPrevention: "Both files need join column(s). Column names case-sensitive. Check with qsv_headers."
+  hasCommonMistakes: true
+
+joinp:
+  whenToUse: "Fast Polars-powered joins for large files (>50MB) or SQL-like joins (inner/left/right/outer/cross/asof). Asof joins match on the nearest key rather than exact equality — ideal for time-series data. Use stats cache (qsv_stats --cardinality) to determine optimal table order (smaller cardinality on right)."
+  commonPattern: "Stats → Join: Use qsv_stats --cardinality on both files, put lower-cardinality join column on right for efficiency. Check nullcount on join columns — nulls never match in joins and high null rates explain missing rows. For time-series joins, use --asof to match on nearest key rather than exact equality; both datasets are auto-sorted on join columns unless --no-sort is set."
+  errorPrevention: "Use --try-parsedates for date joins. Check column types with qsv_stats — mismatched types (String vs Integer) cause silent join failures."
+  hasCommonMistakes: true
+
+dedup:
+  whenToUse: "Remove duplicates. Loads entire CSV. For large files (>1GB), use qsv_extdedup. Use qsv_stats --cardinality to check column cardinality - if key column has unique values only, dedup will be a no-op."
+  commonPattern: "Often followed by stats: dedup → stats for distribution."
+  errorPrevention: "May OOM on files >1GB. Use qsv_extdedup for large files."
+  needsMemoryWarning: true
+  hasCommonMistakes: true
+
+sort:
+  whenToUse: "Sort by columns. Loads entire file. For large files (>1GB), use qsv_extsort. Use stats cache to check if data is already sorted."
+  commonPattern: "Before joins or top-N: sort DESC → slice --end 10."
+  errorPrevention: "May OOM on files >1GB. Use qsv_extsort for large files."
+  needsMemoryWarning: true
+  hasCommonMistakes: true
+
+count:
+  whenToUse: "Count rows. Very fast with index. Run qsv_index first for files >10MB."
+  errorPrevention: "Works with CSV/TSV/SSV files only. Very fast with index file (.idx)."
+
+headers:
+  whenToUse: "View/rename column names. Quick CSV structure discovery."
+  errorPrevention: "Works with CSV/TSV/SSV files only. For Parquet schema, use sqlp with DESCRIBE."
+
+sample:
+  whenToUse: "Random sampling. Fast, memory-efficient. Good for previews or test datasets."
+  commonPattern: "Quick preview (100 rows) or test data (1000 rows). Faster than qsv_slice for random."
+  needsIndexHint: true
+
+schema:
+  whenToUse: "Infer data types, generate Polars Schema & JSON Schema."
+  commonPattern: "Iterate: qsv_schema → validate → fix → validate until clean. Use --polars to generate Polars schema for qsv_to_parquet."
+  errorPrevention: "Run qsv_stats first for best type inference. Use --polars for Parquet conversion workflows."
+  hasCommonMistakes: true
+
+validate:
+  whenToUse: "Validate against JSON Schema. Check data quality, type correctness. Also use this without a JSON Schema to check if a CSV is well-formed."
+  commonPattern: "Iterate: qsv_schema → validate → fix → validate until clean."
+  needsIndexHint: true
+
+sqlp:
+  whenToUse: "Run SQL queries on tabular data. Auto-converts CSV to Parquet for performance, then routes to DuckDB when available (faster, PostgreSQL-compatible). Falls back to Polars SQL (sqlp) otherwise."
+  commonPattern: >-
+    Stats → SQL: Read qsv_stats output before writing queries.
+    Use type for correct casts (don't quote integers, use date functions for Date/DateTime).
+    Use min/max/range for precise WHERE clauses.
+    Use cardinality to optimize GROUP BY (low = fast, high = consider LIMIT).
+    Use sort_order to skip redundant ORDER BY.
+    For value distributions, run qsv_frequency on relevant columns.
+    For multi-file queries, convert all files to Parquet first with qsv_to_parquet, then use read_parquet() in SQL.
+    For complex queries on large files, use EXPLAIN to review the query plan before execution.
+  errorPrevention: "Column names are case-sensitive in Polars SQL but case-insensitive in DuckDB. For unsupported output formats (Arrow, Avro), sqlp is used automatically. Use nullcount from qsv_stats to add COALESCE/IS NOT NULL only where nulls actually exist — skip null handling for columns with nullcount=0. In Claude Cowork, ensure DuckDB runs on the host, not the Linux container."
+  hasCommonMistakes: true
+
+rename:
+  whenToUse: "Rename columns. Supports bulk/regex."
+
+template:
+  whenToUse: "Generate formatted output from CSV using Mini Jinja templates. For reports, markdown, HTML."
+  needsIndexHint: true
+
+index:
+  whenToUse: "Create .idx index. Run FIRST for files >10MB queried multiple times. Enables instant counts, fast slicing."
+  commonPattern: "Run 1st for files >10MB. Makes count instant, slice 100x faster."
+  errorPrevention: "Creates .idx index for CSV/TSV/SSV files only. Parquet files don't need indexing."
+
+diff:
+  whenToUse: "Compare CSV files (added/deleted/modified rows). Requires same schema."
+
+cat:
+  whenToUse: "Concatenate CSV files. Subcommands: rows (stack vertically), rowskey (different schemas), columns (side-by-side). Specify via subcommand parameter."
+  commonPattern: "Combine files: cat rows → headers from first file only. cat rowskey → handles different schemas. cat columns → side-by-side merge."
+  errorPrevention: "rows mode requires same column order. Use rowskey for different schemas."
+  hasCommonMistakes: true
+
+geocode:
+  whenToUse: "Geocode locations using Geonames/MaxMind. Subcommands: suggest, reverse, countryinfo, iplookup. Specify via subcommand parameter."
+  commonPattern: "Common: suggest for city lookup, reverse for lat/lon → city, iplookup for IP → location."
+  errorPrevention: "Needs Geonames index (auto-downloads on first use). iplookup needs MaxMind GeoLite2 DB."
+  needsIndexHint: true
+
+pivotp:
+  whenToUse: "Polars-powered pivot tables and group-by aggregations. PIVOT MODE: provide <on-cols> with --agg (sum/mean/count/first/last/min/max/smart). GROUP-BY MODE: omit <on-cols> and use --index to aggregate without pivoting. Use qsv_stats --cardinality to check pivot column cardinality."
+  commonPattern: "Stats → Pivot: Use qsv_stats --cardinality to estimate pivot output width (pivot column cardinality × value columns) and keep estimated columns below ~1000. Group-by: omit on-cols, e.g. qsv_pivotp(input_file='data.csv', index='group-col', values='val-col', agg='sum'). Use stats type column to pick the right --agg: sum/mean for numeric, count for categorical."
+  errorPrevention: "High-cardinality pivot columns create wide output. Use qsv_stats --cardinality to check cardinality of potential pivot columns. In group-by mode, --index is required, --agg smart resolves to len (count), and none is not supported."
+  hasCommonMistakes: true
+
+excel:
+  whenToUse: "Convert spreadsheets (Excel and OpenDocument) to CSV. Also can be used to get workbook metadata. Supports multi-sheet workbooks."
+
+searchset:
+  whenToUse: "Filter rows matching any pattern from a regex file. For multiple patterns at once. Use qsv_search for single patterns."
+  errorPrevention: "Needs regex file. qsv_search easier for simple patterns."
+  needsIndexHint: true
+  hasCommonMistakes: true
+
+datefmt:
+  whenToUse: "Parse and reformat date/time columns. Supports diverse input formats and strftime output patterns."
+  needsIndexHint: true
+
+luau:
+  whenToUse: "Run Luau scripts per row. Use map to create new columns, filter to select rows. For complex custom logic beyond apply."
+  needsIndexHint: true
+
+replace:
+  whenToUse: "Find and replace text in columns using regex. For bulk text substitution across the dataset."
+  needsIndexHint: true
+
+split:
+  whenToUse: "Split CSV into chunks of N rows each, writing separate files. For breaking large files into manageable pieces."
+  needsIndexHint: true
+
+tojsonl:
+  whenToUse: "Convert CSV to JSONL/NDJSON with smart type inference. Uses stats cache for accurate types."
+  commonPattern: "Run qsv_stats first for best type inference. Output uses correct JSON types (numbers, booleans, nulls)."
+  needsIndexHint: true
+
+transpose:
+  whenToUse: "Swap rows and columns. Best for small datasets or creating wide-format summaries."
+  needsMemoryWarning: true
+  needsIndexHint: true
+
+reverse:
+  whenToUse: "Reverse row order preserving relative order (stable). With index: constant memory. Without index: loads entire CSV."
+  errorPrevention: "Without an index file, loads entire CSV into memory. Run qsv_index first, or use qsv_sort --reverse for sorted reversal."
+  needsMemoryWarning: true
+  needsIndexHint: true
+
+safenames:
+  whenToUse: "Make headers database-ready/CKAN-ready. Removes special chars, spaces, ensures unique names."
+
+sniff:
+  whenToUse: "Detect CSV metadata (delimiter, header, preamble, quote char, encoding, field types). Also a general mime type detector. Supports URLs."
+  commonPattern: "First step for unknown files: sniff → headers → stats → frequency. Use --json for parseable output."
+  errorPrevention: "For remote URLs, use --quick for faster detection. Use --sample to control inference depth."
+
+extdedup:
+  whenToUse: "Remove duplicates from arbitrarily large files (>1GB) using on-disk hash table. Constant memory. Use instead of qsv_dedup for large files."
+  errorPrevention: "Does not sort output (unlike dedup). Requires explicit output file argument. Use --dupes-output to capture removed rows."
+
+extsort:
+  whenToUse: "Sort arbitrarily large files (>1GB) using external merge sort. Use instead of qsv_sort for large files."
+  errorPrevention: "Sorts entire rows as text (no column-specific sorting). For column-specific sorting of large files, use qsv_sqlp."
+  needsIndexHint: true
+
+partition:
+  whenToUse: "Split CSV into separate files by column value. One output file per unique value in the partition column."
+  errorPrevention: "High-cardinality columns create many files. Use qsv_stats --cardinality to check column cardinality first."
+  hasCommonMistakes: true
+
+explode:
+  whenToUse: "Unnest multi-value cells into separate rows. Splits a column on a separator, creating one row per value."
+
+pseudo:
+  whenToUse: "Pseudonymize column values with incremental IDs. For de-identification or anonymization before sharing data."
+
+describegpt:
+  whenToUse: "Generate data dictionaries, descriptions, and tags for CSV data using LLM inference."
+  commonPattern: "Through MCP: no API key needed — uses the connected LLM automatically. Use --dictionary, --description, --tags, or --all. May require two tool calls (first returns prompts, second processes your responses via _llm_responses). For natural language questions, use sqlp or other qsv tools directly instead of --prompt."
+  errorPrevention: "In MCP mode: do NOT use --prompt (SQL RAG mode) — ask the LLM directly instead. Do NOT pass --base-url or --api-key. LLM results may be inaccurate. Run stats first for best results."
+
+fixlengths:
+  whenToUse: "Fix ragged CSVs where rows have inconsistent field counts. Pads short rows, truncates long rows to match the longest row."
+  commonPattern: "Early in cleaning: safenames → fixlengths → trim → dedup. Run count before/after to detect how many rows were ragged."
+
+fmt:
+  whenToUse: "Reformat CSV: change delimiter, quoting style, line endings. Use --out-delimiter to convert between CSV/TSV/SSV."
+  commonPattern: "CSV ↔ TSV: fmt --out-delimiter '\\t'. Also useful for normalizing quoting before downstream tools."
+
+input:
+  whenToUse: "Normalize encoding to UTF-8, strip BOM, and handle non-UTF-8 CSV files. First step for files with encoding issues."
+
+table:
+  whenToUse: "Pretty-print CSV as an aligned text table. For small files or terminal display only."
+  needsMemoryWarning: true
+
+fill:
+  whenToUse: "Fill empty fields with values from previous rows or a specified groupby column. Useful for sparse data with repeated group headers."
+
+sortcheck:
+  whenToUse: "Check if CSV is already sorted on specified columns. Avoids unnecessary sort operations."
+
+enum:
+  whenToUse: "Add a row number, UUID, or constant column. Useful for creating IDs or tracking row provenance."
+
+exclude:
+  whenToUse: "Remove rows from one CSV that match rows in another. Inverse of join — keeps only non-matching rows. For anti-join semantics, joinp --anti is faster for large files."
+
+flatten:
+  whenToUse: "Display each row vertically (one field per line). For inspecting wide CSVs with many columns in the terminal."
+
+blake3:
+  whenToUse: "Compute BLAKE3 cryptographic hashes of files for integrity verification. Fast, parallel hashing with optional keyed hashing and key derivation."
+  commonPattern: "Hash files: blake3 file.csv > checksums.b3. Verify: blake3 --check checksums.b3. Use --no-names for just the hash value."
+  errorPrevention: "This is a FILE hashing command — hashes entire files, not individual CSV rows or columns. For per-row hashing, use luau."
+
+to:
+  whenToUse: "Convert CSV to Parquet, PostgreSQL, SQLite, XLSX, ODS, or Data Package. Supports batch conversion of multiple files. For single-file CSV-to-Parquet, prefer qsv_to_parquet (core tool) which auto-runs stats and generates Polars schema."
+  commonPattern: "Parquet: to parquet output_dir file.csv. Database: to postgres 'connection_string' file.csv. Spreadsheet: to xlsx output.xlsx file.csv. Batch: pass a directory or .infile-list as input to convert multiple files (e.g. to parquet output_dir my_csvs_dir)."
+  errorPrevention: "For single-file Parquet, prefer qsv_to_parquet core tool (auto-generates stats + schema for optimal type inference). Use 'to parquet' for batch conversion or when you need explicit control. For batch conversion with multiple explicit files, use qsv_command instead of qsv_to (the skill accepts a single input). For PostgreSQL, a connection string is required unless --dump is set (dump mode writes SQL to a file or stdout instead of loading into a database)."
+  hasCommonMistakes: true

--- a/.claude/skills/package-lock.json
+++ b/.claude/skills/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@qsv/agent-skills",
-  "version": "19.0.0",
+  "version": "19.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qsv/agent-skills",
-      "version": "19.0.0",
+      "version": "19.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "wink-bm25-text-search": "^3.0.0",
-        "wink-nlp-utils": "^2.1.0"
+        "wink-nlp-utils": "^2.1.0",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "qsv-mcp-server": "dist/mcp-server.js"
@@ -2604,6 +2605,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/.claude/skills/package.json
+++ b/.claude/skills/package.json
@@ -42,7 +42,8 @@
     "@modelcontextprotocol/ext-apps": "^1.2.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "wink-bm25-text-search": "^3.0.0",
-    "wink-nlp-utils": "^2.1.0"
+    "wink-nlp-utils": "^2.1.0",
+    "yaml": "^2.8.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/.claude/skills/scripts/package-mcpb.js
+++ b/.claude/skills/scripts/package-mcpb.js
@@ -173,6 +173,13 @@ async function createArchive() {
     console.log('   Adding skill definitions (qsv/)...');
     archive.directory(join(rootDir, 'qsv'), 'qsv');
 
+    // Add runtime data files (YAML guidance loaded by command-guidance.ts)
+    const dataDir = join(rootDir, 'data');
+    if (existsSync(dataDir)) {
+      console.log('   Adding runtime data (data/)...');
+      archive.directory(dataDir, 'data');
+    }
+
     // Add Claude Plugin files
     const pluginDir = join(rootDir, '.claude-plugin');
     if (existsSync(pluginDir)) {

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -1,9 +1,19 @@
 /**
  * Command guidance system — provides contextual hints for tool selection and usage.
+ *
+ * Guidance data is loaded at runtime from data/command-guidance.yaml.
+ * Call loadCommandGuidance() once at server startup before using getCommandGuidance().
  */
 
+import { readFile } from "fs/promises";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { existsSync } from "fs";
+import { parse as parseYaml } from "yaml";
 import type { QsvSkill } from "./types.js";
 import { config } from "./config.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Consolidated guidance for each command.
@@ -19,298 +29,103 @@ export interface CommandGuidance {
   hasCommonMistakes?: boolean;
 }
 
-export const COMMAND_GUIDANCE: Record<string, CommandGuidance> = {
-  select: {
-    whenToUse: 'Choose columns. Syntax: "1,3,5" (specific), "1-10" (range), "!SSN" (exclude), "/<regex>/" (pattern), "_" (last).',
-    commonPattern: "First step: select columns → filter → sort → output. Speeds up downstream ops.",
-  },
-  slice: {
-    whenToUse: "Select rows by position: first N, last N, skip N, range.",
-  },
-  search: {
-    whenToUse: "Filter rows matching pattern/regex. Search applied to selected fields. For complex conditions, use qsv_sqlp.",
-    commonPattern: "Combine with select: search (filter rows) → select (pick columns).",
-    needsIndexHint: true,
-  },
-  stats: {
-    whenToUse: "Quick numeric stats (mean, min/max, stddev). Creates cache for other commands. Run 2nd after index.",
-    commonPattern: `Run 2nd (after index). Creates cache used by frequency, schema, tojsonl, sqlp, joinp, pivotp, describegpt, moarstats, sample. Moarstats is auto-run after stats to enrich the cache with ~25 additional columns.`,
-    errorPrevention: "Works with CSV/TSV/SSV files only. For SQL queries, use sqlp. Run qsv_index first for files >10MB.",
-    needsIndexHint: true,
-  },
-  moarstats: {
-    whenToUse: "Basic moarstats is auto-run after stats. Only invoke manually for --advanced (kurtosis, entropy, gini, etc.) or --bivariate (pairwise correlations).",
-    commonPattern: "Basic moarstats runs automatically after stats to enrich the .stats.csv cache. Invoke manually only for --advanced or --bivariate. When running manually, use the CLI --output flag if you need to control where the main stats output is written; MCP output_file only saves stdout and does not set moarstats --output. Enriches .stats.csv with ~25 additional columns (including trimean, midhinge, robust_cv, jarque_bera, theil_index, mean_ad, simpsons_diversity_index) for richer LLM analysis — moarstats enriches .stats.csv only, not .data.jsonl; smart commands still use .data.jsonl. With --bivariate: main stats go to --output (or stdout if omitted), while bivariate stats are written to <FILESTEM>.stats.bivariate.csv (a separate file next to the input).",
-    errorPrevention: "Run stats first to create cache. IMPORTANT: Only run --bivariate when requested as it's expensive. Bivariate results are written to a SEPARATE file: <FILESTEM>.stats.bivariate.csv (located next to the input file, not controlled by MCP output_file/stdout capture). Always read this file to get bivariate results. With --join-inputs, the file is <FILESTEM>.stats.bivariate.joined.csv.",
-    needsMemoryWarning: true,
-    hasCommonMistakes: true,
-  },
-  pragmastat: {
-    whenToUse:
-      "Robust outlier-resistant statistics (Hodges-Lehmann center, Shamos spread). Use when data is messy, heavy-tailed, or outlier-prone. Use --twosample to compare column pairs (shift, ratio, disparity).",
-    commonPattern:
-      "Index → Pragmastat for single-sample analysis. For comparisons: --twosample --select col1,col2. Use --misrate 1e-6 for critical decisions (default 1e-3).",
-    errorPrevention:
-      "Only processes numeric columns (non-numeric appear with n=0). All numeric values loaded into memory. Blank cells in output mean insufficient data or positivity requirement not met.",
-    needsMemoryWarning: true,
-  },
-  frequency: {
-    whenToUse: "Count unique values. Best for low-cardinality categorical columns. Run qsv_stats --cardinality first to identify high-cardinality columns to exclude.",
-    commonPattern: "Stats → Frequency: Use qsv_stats --cardinality first to identify high-cardinality columns (IDs) to exclude. The frequency cache (--frequency-jsonl) is auto-created on first run for faster subsequent analysis.",
-    errorPrevention: "High-cardinality columns (IDs, timestamps) can produce huge output. Use qsv_stats --cardinality to inspect column cardinality before running frequency. Do NOT set a client-side timeout shorter than the server's operation timeout (default 10 min) — let frequency run to completion. If the server timeout is exceeded on very large files, fall back to qsv_sqlp: 'SELECT col, COUNT(*) FROM _t_1 GROUP BY col ORDER BY COUNT(*) DESC LIMIT 20'. Use --select to target specific columns instead of computing frequency on all columns.",
-    needsMemoryWarning: true,
-    hasCommonMistakes: true,
-  },
-  join: {
-    whenToUse: "Join CSV files (<50MB). For large/complex joins, use qsv_joinp.",
-    commonPattern: "Run qsv_index first on both files for speed.",
-    errorPrevention: "Both files need join column(s). Column names case-sensitive. Check with qsv_headers.",
-    hasCommonMistakes: true,
-  },
-  joinp: {
-    whenToUse: "Fast Polars-powered joins for large files (>50MB) or SQL-like joins (inner/left/right/outer/cross/asof). Asof joins match on the nearest key rather than exact equality — ideal for time-series data. Use stats cache (qsv_stats --cardinality) to determine optimal table order (smaller cardinality on right).",
-    commonPattern: "Stats → Join: Use qsv_stats --cardinality on both files, put lower-cardinality join column on right for efficiency. Check nullcount on join columns — nulls never match in joins and high null rates explain missing rows. For time-series joins, use --asof to match on nearest key rather than exact equality; both datasets are auto-sorted on join columns unless --no-sort is set.",
-    errorPrevention: "Use --try-parsedates for date joins. Check column types with qsv_stats — mismatched types (String vs Integer) cause silent join failures.",
-    hasCommonMistakes: true,
-  },
-  dedup: {
-    whenToUse: "Remove duplicates. Loads entire CSV. For large files (>1GB), use qsv_extdedup. Use qsv_stats --cardinality to check column cardinality - if key column has unique values only, dedup will be a no-op.",
-    commonPattern: "Often followed by stats: dedup → stats for distribution.",
-    errorPrevention: "May OOM on files >1GB. Use qsv_extdedup for large files.",
-    needsMemoryWarning: true,
-    hasCommonMistakes: true,
-  },
-  sort: {
-    whenToUse: "Sort by columns. Loads entire file. For large files (>1GB), use qsv_extsort. Use stats cache to check if data is already sorted.",
-    commonPattern: "Before joins or top-N: sort DESC → slice --end 10.",
-    errorPrevention: "May OOM on files >1GB. Use qsv_extsort for large files.",
-    needsMemoryWarning: true,
-    hasCommonMistakes: true,
-  },
-  count: {
-    whenToUse: "Count rows. Very fast with index. Run qsv_index first for files >10MB.",
-    errorPrevention: "Works with CSV/TSV/SSV files only. Very fast with index file (.idx).",
-  },
-  headers: {
-    whenToUse: "View/rename column names. Quick CSV structure discovery.",
-    errorPrevention: "Works with CSV/TSV/SSV files only. For Parquet schema, use sqlp with DESCRIBE.",
-  },
-  sample: {
-    whenToUse: "Random sampling. Fast, memory-efficient. Good for previews or test datasets.",
-    commonPattern: "Quick preview (100 rows) or test data (1000 rows). Faster than qsv_slice for random.",
-    needsIndexHint: true,
-  },
-  schema: {
-    whenToUse: "Infer data types, generate Polars Schema & JSON Schema.",
-    commonPattern:
-      "Iterate: qsv_schema → validate → fix → validate until clean. Use --polars to generate Polars schema for qsv_to_parquet.",
-    errorPrevention:
-      "Run qsv_stats first for best type inference. Use --polars for Parquet conversion workflows.",
-    hasCommonMistakes: true,
-  },
-  validate: {
-    whenToUse: "Validate against JSON Schema. Check data quality, type correctness. Also use this without a JSON Schema to check if a CSV is well-formed.",
-    commonPattern: "Iterate: qsv_schema → validate → fix → validate until clean.",
-    needsIndexHint: true,
-  },
-  sqlp: {
-    whenToUse:
-      "Run SQL queries on tabular data. Auto-converts CSV to Parquet for performance, then routes to DuckDB when available (faster, PostgreSQL-compatible). Falls back to Polars SQL (sqlp) otherwise.",
-    commonPattern:
-      "Stats → SQL: Read qsv_stats output before writing queries. Use type for correct casts (don't quote integers, use date functions for Date/DateTime). Use min/max/range for precise WHERE clauses. Use cardinality to optimize GROUP BY (low = fast, high = consider LIMIT). Use sort_order to skip redundant ORDER BY. For value distributions, run qsv_frequency on relevant columns. For multi-file queries, convert all files to Parquet first with qsv_to_parquet, then use read_parquet() in SQL. For complex queries on large files, use EXPLAIN to review the query plan before execution.",
-    errorPrevention:
-      "Column names are case-sensitive in Polars SQL but case-insensitive in DuckDB. For unsupported output formats (Arrow, Avro), sqlp is used automatically. Use nullcount from qsv_stats to add COALESCE/IS NOT NULL only where nulls actually exist — skip null handling for columns with nullcount=0. In Claude Cowork, ensure DuckDB runs on the host, not the Linux container.",
-    hasCommonMistakes: true,
-  },
-  rename: {
-    whenToUse: "Rename columns. Supports bulk/regex.",
-  },
-  template: {
-    whenToUse: "Generate formatted output from CSV using Mini Jinja templates. For reports, markdown, HTML.",
-    needsIndexHint: true,
-  },
-  index: {
-    whenToUse: "Create .idx index. Run FIRST for files >10MB queried multiple times. Enables instant counts, fast slicing.",
-    commonPattern: "Run 1st for files >10MB. Makes count instant, slice 100x faster.",
-    errorPrevention: "Creates .idx index for CSV/TSV/SSV files only. Parquet files don't need indexing.",
-  },
-  diff: {
-    whenToUse: "Compare CSV files (added/deleted/modified rows). Requires same schema.",
-  },
-  cat: {
-    whenToUse: "Concatenate CSV files. Subcommands: rows (stack vertically), rowskey (different schemas), columns (side-by-side). Specify via subcommand parameter.",
-    commonPattern: "Combine files: cat rows → headers from first file only. cat rowskey → handles different schemas. cat columns → side-by-side merge.",
-    errorPrevention: "rows mode requires same column order. Use rowskey for different schemas.",
-    hasCommonMistakes: true,
-  },
-  geocode: {
-    whenToUse: "Geocode locations using Geonames/MaxMind. Subcommands: suggest, reverse, countryinfo, iplookup. Specify via subcommand parameter.",
-    commonPattern: "Common: suggest for city lookup, reverse for lat/lon → city, iplookup for IP → location.",
-    errorPrevention: "Needs Geonames index (auto-downloads on first use). iplookup needs MaxMind GeoLite2 DB.",
-    needsIndexHint: true,
-  },
-  pivotp: {
-    whenToUse: "Polars-powered pivot tables and group-by aggregations. PIVOT MODE: provide <on-cols> with --agg (sum/mean/count/first/last/min/max/smart). GROUP-BY MODE: omit <on-cols> and use --index to aggregate without pivoting. Use qsv_stats --cardinality to check pivot column cardinality.",
-    commonPattern: "Stats → Pivot: Use qsv_stats --cardinality to estimate pivot output width (pivot column cardinality × value columns) and keep estimated columns below ~1000. Group-by: omit on-cols, e.g. qsv_pivotp(input_file='data.csv', index='group-col', values='val-col', agg='sum'). Use stats type column to pick the right --agg: sum/mean for numeric, count for categorical.",
-    errorPrevention: "High-cardinality pivot columns create wide output. Use qsv_stats --cardinality to check cardinality of potential pivot columns. In group-by mode, --index is required, --agg smart resolves to len (count), and none is not supported.",
-    hasCommonMistakes: true,
-  },
-  excel: {
-    whenToUse: "Convert spreadsheets (Excel and OpenDocument) to CSV. Also can be used to get workbook metadata. Supports multi-sheet workbooks.",
-  },
-  searchset: {
-    whenToUse:
-      "Filter rows matching any pattern from a regex file. For multiple patterns at once. Use qsv_search for single patterns.",
-    errorPrevention: "Needs regex file. qsv_search easier for simple patterns.",
-    needsIndexHint: true,
-    hasCommonMistakes: true,
-  },
-  datefmt: {
-    whenToUse:
-      "Parse and reformat date/time columns. Supports diverse input formats and strftime output patterns.",
-    needsIndexHint: true,
-  },
-  luau: {
-    whenToUse:
-      "Run Luau scripts per row. Use map to create new columns, filter to select rows. For complex custom logic beyond apply.",
-    needsIndexHint: true,
-  },
-  replace: {
-    whenToUse:
-      "Find and replace text in columns using regex. For bulk text substitution across the dataset.",
-    needsIndexHint: true,
-  },
-  split: {
-    whenToUse:
-      "Split CSV into chunks of N rows each, writing separate files. For breaking large files into manageable pieces.",
-    needsIndexHint: true,
-  },
-  tojsonl: {
-    whenToUse:
-      "Convert CSV to JSONL/NDJSON with smart type inference. Uses stats cache for accurate types.",
-    commonPattern:
-      "Run qsv_stats first for best type inference. Output uses correct JSON types (numbers, booleans, nulls).",
-    needsIndexHint: true,
-  },
-  transpose: {
-    whenToUse:
-      "Swap rows and columns. Best for small datasets or creating wide-format summaries.",
-    needsMemoryWarning: true,
-    needsIndexHint: true,
-  },
-  // Commands added for guidance coverage
-  reverse: {
-    whenToUse:
-      "Reverse row order preserving relative order (stable). With index: constant memory. Without index: loads entire CSV.",
-    errorPrevention:
-      "Without an index file, loads entire CSV into memory. Run qsv_index first, or use qsv_sort --reverse for sorted reversal.",
-    needsMemoryWarning: true,
-    needsIndexHint: true,
-  },
-  safenames: {
-    whenToUse:
-      "Make headers database-ready/CKAN-ready. Removes special chars, spaces, ensures unique names.",
-  },
-  sniff: {
-    whenToUse:
-      "Detect CSV metadata (delimiter, header, preamble, quote char, encoding, field types). Also a general mime type detector. Supports URLs.",
-    commonPattern:
-      "First step for unknown files: sniff → headers → stats → frequency. Use --json for parseable output.",
-    errorPrevention:
-      "For remote URLs, use --quick for faster detection. Use --sample to control inference depth.",
-  },
-  extdedup: {
-    whenToUse:
-      "Remove duplicates from arbitrarily large files (>1GB) using on-disk hash table. Constant memory. Use instead of qsv_dedup for large files.",
-    errorPrevention:
-      "Does not sort output (unlike dedup). Requires explicit output file argument. Use --dupes-output to capture removed rows.",
-  },
-  extsort: {
-    whenToUse:
-      "Sort arbitrarily large files (>1GB) using external merge sort. Use instead of qsv_sort for large files.",
-    errorPrevention:
-      "Sorts entire rows as text (no column-specific sorting). For column-specific sorting of large files, use qsv_sqlp.",
-    needsIndexHint: true,
-  },
-  partition: {
-    whenToUse:
-      "Split CSV into separate files by column value. One output file per unique value in the partition column.",
-    errorPrevention:
-      "High-cardinality columns create many files. Use qsv_stats --cardinality to check column cardinality first.",
-    hasCommonMistakes: true,
-  },
-  explode: {
-    whenToUse:
-      "Unnest multi-value cells into separate rows. Splits a column on a separator, creating one row per value.",
-  },
-  pseudo: {
-    whenToUse:
-      "Pseudonymize column values with incremental IDs. For de-identification or anonymization before sharing data.",
-  },
-  describegpt: {
-    whenToUse: "Generate data dictionaries, descriptions, and tags for CSV data using LLM inference.",
-    commonPattern: "Through MCP: no API key needed — uses the connected LLM automatically. Use --dictionary, --description, --tags, or --all. May require two tool calls (first returns prompts, second processes your responses via _llm_responses). For natural language questions, use sqlp or other qsv tools directly instead of --prompt.",
-    errorPrevention: "In MCP mode: do NOT use --prompt (SQL RAG mode) — ask the LLM directly instead. Do NOT pass --base-url or --api-key. LLM results may be inaccurate. Run stats first for best results.",
-  },
-  fixlengths: {
-    whenToUse:
-      "Fix ragged CSVs where rows have inconsistent field counts. Pads short rows, truncates long rows to match the longest row.",
-    commonPattern:
-      "Early in cleaning: safenames → fixlengths → trim → dedup. Run count before/after to detect how many rows were ragged.",
-  },
-  fmt: {
-    whenToUse:
-      "Reformat CSV: change delimiter, quoting style, line endings. Use --out-delimiter to convert between CSV/TSV/SSV.",
-    commonPattern:
-      "CSV ↔ TSV: fmt --out-delimiter '\\t'. Also useful for normalizing quoting before downstream tools.",
-  },
-  input: {
-    whenToUse:
-      "Normalize encoding to UTF-8, strip BOM, and handle non-UTF-8 CSV files. First step for files with encoding issues.",
-  },
-  table: {
-    whenToUse:
-      "Pretty-print CSV as an aligned text table. For small files or terminal display only.",
-    needsMemoryWarning: true,
-  },
-  fill: {
-    whenToUse:
-      "Fill empty fields with values from previous rows or a specified groupby column. Useful for sparse data with repeated group headers.",
-  },
-  sortcheck: {
-    whenToUse:
-      "Check if CSV is already sorted on specified columns. Avoids unnecessary sort operations.",
-  },
-  enum: {
-    whenToUse:
-      "Add a row number, UUID, or constant column. Useful for creating IDs or tracking row provenance.",
-  },
-  exclude: {
-    whenToUse:
-      "Remove rows from one CSV that match rows in another. Inverse of join — keeps only non-matching rows. For anti-join semantics, joinp --anti is faster for large files.",
-  },
-  flatten: {
-    whenToUse:
-      "Display each row vertically (one field per line). For inspecting wide CSVs with many columns in the terminal.",
-  },
-  blake3: {
-    whenToUse:
-      "Compute BLAKE3 cryptographic hashes of files for integrity verification. Fast, parallel hashing with optional keyed hashing and key derivation.",
-    commonPattern:
-      "Hash files: blake3 file.csv > checksums.b3. Verify: blake3 --check checksums.b3. Use --no-names for just the hash value.",
-    errorPrevention:
-      "This is a FILE hashing command — hashes entire files, not individual CSV rows or columns. For per-row hashing, use luau.",
-  },
-  to: {
-    whenToUse:
-      "Convert CSV to Parquet, PostgreSQL, SQLite, XLSX, ODS, or Data Package. Supports batch conversion of multiple files. For single-file CSV-to-Parquet, prefer qsv_to_parquet (core tool) which auto-runs stats and generates Polars schema.",
-    commonPattern:
-      "Parquet: to parquet output_dir file.csv. Database: to postgres 'connection_string' file.csv. Spreadsheet: to xlsx output.xlsx file.csv. Batch: pass a directory or .infile-list as input to convert multiple files (e.g. to parquet output_dir my_csvs_dir).",
-    errorPrevention:
-      "For single-file Parquet, prefer qsv_to_parquet core tool (auto-generates stats + schema for optimal type inference). Use 'to parquet' for batch conversion or when you need explicit control. For batch conversion with multiple explicit files, use qsv_command instead of qsv_to (the skill accepts a single input). For PostgreSQL, a connection string is required unless --dump is set (dump mode writes SQL to a file or stdout instead of loading into a database).",
-    hasCommonMistakes: true,
-  },
-};
+// Module-level cache — populated by loadCommandGuidance(), read by getCommandGuidance()
+let commandGuidance: Record<string, CommandGuidance> = {};
+let guidanceLoaded = false;
+
+/**
+ * Resolve the path to command-guidance.yaml.
+ * Handles both production (dist/command-guidance.js → ../data/)
+ * and test (dist/src/command-guidance.js → ../../data/) layouts.
+ */
+function resolveGuidancePath(): string {
+  // Production: dist/command-guidance.js → ../data/
+  const productionPath = join(__dirname, "../data/command-guidance.yaml");
+  // Test build: dist/src/command-guidance.js → ../../data/
+  const testPath = join(__dirname, "../../data/command-guidance.yaml");
+
+  if (existsSync(productionPath)) return productionPath;
+  if (existsSync(testPath)) return testPath;
+  return productionPath; // fallback for clear error message
+}
+
+const VALID_STRING_FIELDS = ["whenToUse", "commonPattern", "errorPrevention"];
+const VALID_BOOLEAN_FIELDS = [
+  "needsMemoryWarning",
+  "needsIndexHint",
+  "hasCommonMistakes",
+];
+
+/** Type guard for a single guidance entry. */
+function isValidGuidanceEntry(entry: unknown): entry is CommandGuidance {
+  if (typeof entry !== "object" || entry === null) return false;
+  const obj = entry as Record<string, unknown>;
+
+  for (const key of VALID_STRING_FIELDS) {
+    if (key in obj && typeof obj[key] !== "string") return false;
+  }
+  for (const key of VALID_BOOLEAN_FIELDS) {
+    if (key in obj && typeof obj[key] !== "boolean") return false;
+  }
+  return true;
+}
+
+/**
+ * Load command guidance from YAML file.
+ * Caches result after first successful load; subsequent calls return the cache.
+ */
+export async function loadCommandGuidance(): Promise<
+  Record<string, CommandGuidance>
+> {
+  if (guidanceLoaded) return commandGuidance;
+
+  const yamlPath = resolveGuidancePath();
+  try {
+    const content = await readFile(yamlPath, "utf-8");
+    const parsed = parseYaml(content) as Record<string, unknown>;
+
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new Error("YAML root must be a mapping");
+    }
+
+    const result: Record<string, CommandGuidance> = {};
+    for (const [cmd, entry] of Object.entries(parsed)) {
+      if (isValidGuidanceEntry(entry)) {
+        result[cmd] = entry;
+      } else {
+        console.error(`[Guidance] Skipping invalid entry for "${cmd}"`);
+      }
+    }
+
+    commandGuidance = result;
+    guidanceLoaded = true;
+    console.error(
+      `[Guidance] Loaded ${Object.keys(result).length} command guidance entries`,
+    );
+    return commandGuidance;
+  } catch (error) {
+    console.error(`[Guidance] Failed to load ${yamlPath}:`, error);
+    // Graceful degradation — the server still works, just without guidance hints
+    guidanceLoaded = true;
+    return commandGuidance;
+  }
+}
+
+/**
+ * Get already-loaded guidance (synchronous).
+ * Returns empty object if loadCommandGuidance() hasn't been called yet.
+ */
+export function getCommandGuidance(): Record<string, CommandGuidance> {
+  return commandGuidance;
+}
+
+/**
+ * Reset guidance state (for testing only).
+ */
+export function _resetGuidance(): void {
+  commandGuidance = {};
+  guidanceLoaded = false;
+}
 
 /**
  * Enhance parameter descriptions with examples and common values
@@ -347,7 +162,6 @@ export function enhanceParameterDescription(
   return enhanced;
 }
 
-
 /**
  * Enhance tool description with contextual guidance
  *
@@ -357,7 +171,7 @@ export function enhanceParameterDescription(
  */
 export function enhanceDescription(skill: QsvSkill): string {
   const commandName = skill.command.subcommand;
-  const guidance = COMMAND_GUIDANCE[commandName];
+  const guidance = getCommandGuidance()[commandName];
 
   // Use concise description from README.md
   let description = skill.description;

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -30,7 +30,10 @@ export interface CommandGuidance {
 }
 
 // Module-level cache — populated by loadCommandGuidance(), read by getCommandGuidance()
-let commandGuidance: Record<string, CommandGuidance> = {};
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+let commandGuidance: Record<string, CommandGuidance> =
+  Object.create(null) as Record<string, CommandGuidance>;
 let guidanceLoaded = false;
 
 /**
@@ -109,8 +112,13 @@ export async function loadCommandGuidance(): Promise<
       throw new Error("YAML root must be a mapping, not a sequence or scalar");
     }
 
-    const result: Record<string, CommandGuidance> = {};
+    const result: Record<string, CommandGuidance> =
+      Object.create(null) as Record<string, CommandGuidance>;
     for (const [cmd, entry] of Object.entries(parsed)) {
+      if (DANGEROUS_KEYS.has(cmd)) {
+        console.error(`[Guidance] Rejecting dangerous key "${cmd}"`);
+        continue;
+      }
       if (isValidGuidanceEntry(entry, cmd)) {
         result[cmd] = entry;
       } else {
@@ -148,7 +156,7 @@ export function getCommandGuidance(): Record<string, CommandGuidance> {
  * Reset guidance state (for testing only).
  */
 export function _resetGuidance(): void {
-  commandGuidance = {};
+  commandGuidance = Object.create(null) as Record<string, CommandGuidance>;
   guidanceLoaded = false;
 }
 

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -105,8 +105,8 @@ export async function loadCommandGuidance(): Promise<
     const content = await readFile(yamlPath, "utf-8");
     const parsed = parseYaml(content) as Record<string, unknown>;
 
-    if (typeof parsed !== "object" || parsed === null) {
-      throw new Error("YAML root must be a mapping");
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("YAML root must be a mapping, not a sequence or scalar");
     }
 
     const result: Record<string, CommandGuidance> = {};
@@ -116,6 +116,10 @@ export async function loadCommandGuidance(): Promise<
       } else {
         console.error(`[Guidance] Skipping invalid entry for "${cmd}"`);
       }
+    }
+
+    if (Object.keys(result).length === 0) {
+      throw new Error("YAML parsed but produced 0 valid entries");
     }
 
     commandGuidance = result;

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -115,19 +115,7 @@ export async function loadCommandGuidance(): Promise<
       throw new Error("YAML root must be a mapping, not a sequence or scalar");
     }
 
-    const result: Record<string, CommandGuidance> =
-      Object.create(null) as Record<string, CommandGuidance>;
-    for (const [cmd, entry] of Object.entries(parsed)) {
-      if (DANGEROUS_KEYS.has(cmd)) {
-        console.error(`[Guidance] Rejecting dangerous key "${cmd}"`);
-        continue;
-      }
-      if (isValidGuidanceEntry(entry, cmd)) {
-        result[cmd] = entry;
-      } else {
-        console.error(`[Guidance] Skipping invalid entry for "${cmd}"`);
-      }
-    }
+    const result = _filterGuidanceEntries(parsed);
 
     if (Object.keys(result).length === 0) {
       throw new Error("YAML parsed but produced 0 valid entries");
@@ -153,6 +141,29 @@ export async function loadCommandGuidance(): Promise<
  */
 export function getCommandGuidance(): Record<string, CommandGuidance> {
   return commandGuidance;
+}
+
+/**
+ * Filter and validate parsed YAML entries into a guidance map.
+ * Rejects dangerous keys and invalid entries. Exported for testing.
+ */
+export function _filterGuidanceEntries(
+  parsed: Record<string, unknown>,
+): Record<string, CommandGuidance> {
+  const result: Record<string, CommandGuidance> =
+    Object.create(null) as Record<string, CommandGuidance>;
+  for (const [cmd, entry] of Object.entries(parsed)) {
+    if (DANGEROUS_KEYS.has(cmd)) {
+      console.error(`[Guidance] Rejecting dangerous key "${cmd}"`);
+      continue;
+    }
+    if (isValidGuidanceEntry(entry, cmd)) {
+      result[cmd] = entry;
+    } else {
+      console.error(`[Guidance] Skipping invalid entry for "${cmd}"`);
+    }
+  }
+  return result;
 }
 
 /**

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -75,12 +75,18 @@ function isValidGuidanceEntry(
   }
 
   // Warn on unrecognized keys — catches typos like "wehnToUse"
-  for (const key of Object.keys(obj)) {
-    if (!ALL_VALID_FIELDS.includes(key)) {
-      console.error(
-        `[Guidance] Unknown key "${key}" in entry "${cmd ?? "?"}" — possible typo`,
-      );
-    }
+  const unknownKeys = Object.keys(obj).filter(
+    (k) => !ALL_VALID_FIELDS.includes(k),
+  );
+  for (const key of unknownKeys) {
+    console.error(
+      `[Guidance] Unknown key "${key}" in entry "${cmd ?? "?"}" — possible typo`,
+    );
+  }
+
+  // Reject entries where ALL keys are unrecognized (entirely bogus entry)
+  if (unknownKeys.length > 0 && unknownKeys.length === Object.keys(obj).length) {
+    return false;
   }
   return true;
 }

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -57,7 +57,13 @@ const VALID_BOOLEAN_FIELDS = [
 ];
 
 /** Type guard for a single guidance entry. */
-function isValidGuidanceEntry(entry: unknown): entry is CommandGuidance {
+const ALL_VALID_FIELDS = [...VALID_STRING_FIELDS, ...VALID_BOOLEAN_FIELDS];
+
+/** Type guard for a single guidance entry. Warns on unrecognized keys (likely typos). */
+function isValidGuidanceEntry(
+  entry: unknown,
+  cmd?: string,
+): entry is CommandGuidance {
   if (typeof entry !== "object" || entry === null) return false;
   const obj = entry as Record<string, unknown>;
 
@@ -66,6 +72,15 @@ function isValidGuidanceEntry(entry: unknown): entry is CommandGuidance {
   }
   for (const key of VALID_BOOLEAN_FIELDS) {
     if (key in obj && typeof obj[key] !== "boolean") return false;
+  }
+
+  // Warn on unrecognized keys — catches typos like "wehnToUse"
+  for (const key of Object.keys(obj)) {
+    if (!ALL_VALID_FIELDS.includes(key)) {
+      console.error(
+        `[Guidance] Unknown key "${key}" in entry "${cmd ?? "?"}" — possible typo`,
+      );
+    }
   }
   return true;
 }
@@ -90,7 +105,7 @@ export async function loadCommandGuidance(): Promise<
 
     const result: Record<string, CommandGuidance> = {};
     for (const [cmd, entry] of Object.entries(parsed)) {
-      if (isValidGuidanceEntry(entry)) {
+      if (isValidGuidanceEntry(entry, cmd)) {
         result[cmd] = entry;
       } else {
         console.error(`[Guidance] Skipping invalid entry for "${cmd}"`);
@@ -105,8 +120,8 @@ export async function loadCommandGuidance(): Promise<
     return commandGuidance;
   } catch (error) {
     console.error(`[Guidance] Failed to load ${yamlPath}:`, error);
-    // Graceful degradation — the server still works, just without guidance hints
-    guidanceLoaded = true;
+    // Leave guidanceLoaded = false so a subsequent call can retry
+    // (e.g., transient I/O failure at startup)
     return commandGuidance;
   }
 }

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -106,7 +106,10 @@ export async function loadCommandGuidance(): Promise<
   const yamlPath = resolveGuidancePath();
   try {
     const content = await readFile(yamlPath, "utf-8");
-    const parsed = parseYaml(content) as Record<string, unknown>;
+    const parsed = parseYaml(content, { uniqueKeys: true }) as Record<
+      string,
+      unknown
+    >;
 
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       throw new Error("YAML root must be a mapping, not a sequence or scalar");

--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -51,6 +51,7 @@ import {
   killAllProcesses,
   getActiveProcessCount,
   setToolsWorkingDir,
+  loadCommandGuidance,
 } from "./mcp-tools.js";
 // @ts-ignore — moduleResolution:"node" can't resolve exports-mapped subpath; runtime resolves fine
 import { getUiCapability, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
@@ -1199,6 +1200,9 @@ class QsvMcpServer {
         configurable: true,
       });
     }
+
+    // Load command guidance from YAML before tools are listed
+    await loadCommandGuidance();
 
     console.error("Starting QSV MCP Server...");
 

--- a/.claude/skills/src/mcp-tools.ts
+++ b/.claude/skills/src/mcp-tools.ts
@@ -23,6 +23,13 @@ export {
 } from "./tool-constants.js";
 export type { PipelineMetadata } from "./tool-constants.js";
 
+// ── command-guidance ────────────────────────────────────────────────────────
+export {
+  loadCommandGuidance,
+  getCommandGuidance,
+} from "./command-guidance.js";
+export type { CommandGuidance } from "./command-guidance.js";
+
 // ── concurrency ─────────────────────────────────────────────────────────────
 export {
   initiateShutdown,

--- a/.claude/skills/src/tool-handlers.ts
+++ b/.claude/skills/src/tool-handlers.ts
@@ -57,7 +57,7 @@ import {
   normalizeTableRefs,
   translateSql,
 } from "./duckdb.js";
-import { COMMAND_GUIDANCE } from "./command-guidance.js";
+import { getCommandGuidance } from "./command-guidance.js";
 
 /** Token usage from a describegpt cached response. */
 interface DescribegptTokenUsage {
@@ -1165,7 +1165,7 @@ export async function handleSearchToolsCall(
     }
 
     // Get when-to-use guidance if available
-    const whenToUse = COMMAND_GUIDANCE[skill.command.subcommand]?.whenToUse;
+    const whenToUse = getCommandGuidance()[skill.command.subcommand]?.whenToUse;
 
     resultText += `**${toolName}** [${skill.category}]\n`;
     resultText += `  ${shortDesc}\n`;

--- a/.claude/skills/src/tool-handlers.ts
+++ b/.claude/skills/src/tool-handlers.ts
@@ -1156,6 +1156,7 @@ export async function handleSearchToolsCall(
   }
   resultText += ":\n\n";
 
+  const guidance = getCommandGuidance();
   for (const skill of limitedResults) {
     const toolName = skill.name.replace("qsv-", "qsv_");
     // Truncate description to first sentence for conciseness
@@ -1165,7 +1166,7 @@ export async function handleSearchToolsCall(
     }
 
     // Get when-to-use guidance if available
-    const whenToUse = getCommandGuidance()[skill.command.subcommand]?.whenToUse;
+    const whenToUse = guidance[skill.command.subcommand]?.whenToUse;
 
     resultText += `**${toolName}** [${skill.category}]\n`;
     resultText += `  ${shortDesc}\n`;

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -120,7 +120,7 @@ describe("loadCommandGuidance reset behavior", () => {
   test("getCommandGuidance returns empty object before load", () => {
     _resetGuidance();
     const guidance = getCommandGuidance();
-    assert.deepStrictEqual(guidance, {}, "Should be empty before load");
+    assert.strictEqual(Object.keys(guidance).length, 0, "Should be empty before load");
   });
 
   test("fresh load after reset caches correctly", async () => {

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -148,13 +148,22 @@ describe("prototype pollution safety", () => {
   });
 
   test("_filterGuidanceEntries rejects dangerous keys while preserving valid entries", () => {
-    const input = {
-      select: { whenToUse: "Choose columns" },
-      __proto__: { whenToUse: "Should be rejected" },
-      constructor: { whenToUse: "Should be rejected" },
-      prototype: { whenToUse: "Should be rejected" },
-      stats: { whenToUse: "Quick numeric stats" },
-    };
+    // Use Object.create(null) so __proto__ is stored as a regular own property,
+    // mirroring what the YAML parser produces. In a normal object literal,
+    // __proto__ sets the prototype instead of creating an own property.
+    const input = Object.create(null) as Record<string, unknown>;
+    input["select"] = { whenToUse: "Choose columns" };
+    input["__proto__"] = { whenToUse: "Should be rejected" };
+    input["constructor"] = { whenToUse: "Should be rejected" };
+    input["prototype"] = { whenToUse: "Should be rejected" };
+    input["stats"] = { whenToUse: "Quick numeric stats" };
+
+    // Verify __proto__ is actually an own property in our test input
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(input, "__proto__"),
+      "Test setup: __proto__ must be an own property of input",
+    );
+
     const result = _filterGuidanceEntries(input);
 
     // Valid entries preserved

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -107,6 +107,22 @@ describe("loadCommandGuidance", () => {
     const second = await loadCommandGuidance();
     assert.strictEqual(first, second, "Should return same cached object");
   });
+
+  test("getCommandGuidance returns empty object before load", async () => {
+    _resetGuidance();
+    const guidance = getCommandGuidance();
+    assert.deepStrictEqual(guidance, {}, "Should be empty before load");
+    // Reload for remaining tests
+    await loadCommandGuidance();
+  });
+
+  test("fresh load after reset caches correctly", async () => {
+    _resetGuidance();
+    const first = await loadCommandGuidance();
+    assert.ok(Object.keys(first).length >= 50, "Fresh load should have entries");
+    const second = await loadCommandGuidance();
+    assert.strictEqual(first, second, "Second call should return cached object");
+  });
 });
 
 // ============================================================================

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -5,14 +5,21 @@
  * contextual hints, parameter descriptions, and emoji conventions.
  */
 
-import { test, describe } from "node:test";
+import { test, describe, before } from "node:test";
 import assert from "node:assert";
 import {
-  COMMAND_GUIDANCE,
+  loadCommandGuidance,
+  getCommandGuidance,
+  _resetGuidance,
   enhanceParameterDescription,
   enhanceDescription,
 } from "../src/command-guidance.js";
 import type { QsvSkill } from "../src/types.js";
+
+// Load guidance from YAML before all tests
+before(async () => {
+  await loadCommandGuidance();
+});
 
 // ============================================================================
 // COMMAND_GUIDANCE structure
@@ -20,6 +27,7 @@ import type { QsvSkill } from "../src/types.js";
 
 describe("COMMAND_GUIDANCE map", () => {
   test("contains entries for all critical commands", () => {
+    const guidance = getCommandGuidance();
     const criticalCommands = [
       "select", "stats", "moarstats", "frequency", "sqlp",
       "joinp", "join", "sort", "dedup", "count", "headers",
@@ -27,14 +35,14 @@ describe("COMMAND_GUIDANCE map", () => {
     ];
     for (const cmd of criticalCommands) {
       assert.ok(
-        COMMAND_GUIDANCE[cmd],
+        guidance[cmd],
         `Missing guidance for critical command: ${cmd}`,
       );
     }
   });
 
   test("all entries have at least whenToUse", () => {
-    for (const [cmd, guidance] of Object.entries(COMMAND_GUIDANCE)) {
+    for (const [cmd, guidance] of Object.entries(getCommandGuidance())) {
       assert.ok(
         guidance.whenToUse,
         `Command "${cmd}" is missing whenToUse guidance`,
@@ -43,12 +51,13 @@ describe("COMMAND_GUIDANCE map", () => {
   });
 
   test("memory-warning commands have needsMemoryWarning flag", () => {
+    const guidance = getCommandGuidance();
     const memoryCommands = ["dedup", "sort", "frequency", "transpose", "table", "reverse"];
     for (const cmd of memoryCommands) {
-      const guidance = COMMAND_GUIDANCE[cmd];
-      if (guidance) {
+      const entry = guidance[cmd];
+      if (entry) {
         assert.strictEqual(
-          guidance.needsMemoryWarning,
+          entry.needsMemoryWarning,
           true,
           `Memory-intensive command "${cmd}" should have needsMemoryWarning`,
         );
@@ -57,12 +66,13 @@ describe("COMMAND_GUIDANCE map", () => {
   });
 
   test("index-accelerated commands have needsIndexHint flag", () => {
+    const guidance = getCommandGuidance();
     const indexedCommands = ["search", "sample", "validate", "template", "luau"];
     for (const cmd of indexedCommands) {
-      const guidance = COMMAND_GUIDANCE[cmd];
-      if (guidance) {
+      const entry = guidance[cmd];
+      if (entry) {
         assert.strictEqual(
-          guidance.needsIndexHint,
+          entry.needsIndexHint,
           true,
           `Index-accelerated command "${cmd}" should have needsIndexHint`,
         );
@@ -71,7 +81,7 @@ describe("COMMAND_GUIDANCE map", () => {
   });
 
   test("commands with hasCommonMistakes also have errorPrevention", () => {
-    for (const [cmd, guidance] of Object.entries(COMMAND_GUIDANCE)) {
+    for (const [cmd, guidance] of Object.entries(getCommandGuidance())) {
       if (guidance.hasCommonMistakes) {
         assert.ok(
           guidance.errorPrevention,
@@ -79,6 +89,23 @@ describe("COMMAND_GUIDANCE map", () => {
         );
       }
     }
+  });
+});
+
+// ============================================================================
+// loadCommandGuidance
+// ============================================================================
+
+describe("loadCommandGuidance", () => {
+  test("loads non-empty guidance from YAML", async () => {
+    const guidance = getCommandGuidance();
+    assert.ok(Object.keys(guidance).length >= 50, "Should have at least 50 entries");
+  });
+
+  test("returns cached result on subsequent calls", async () => {
+    const first = await loadCommandGuidance();
+    const second = await loadCommandGuidance();
+    assert.strictEqual(first, second, "Should return same cached object");
   });
 });
 
@@ -208,7 +235,7 @@ describe("enhanceDescription", () => {
   test("skips error prevention when hasCommonMistakes is false", () => {
     const result = enhanceDescription(makeSkill("slice"));
     // slice has no hasCommonMistakes, so no errorPrevention text
-    const guidance = COMMAND_GUIDANCE["slice"];
+    const guidance = getCommandGuidance()["slice"];
     if (guidance?.errorPrevention) {
       assert.ok(!result.includes(guidance.errorPrevention));
     }

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -97,7 +97,7 @@ describe("COMMAND_GUIDANCE map", () => {
 // ============================================================================
 
 describe("loadCommandGuidance", () => {
-  test("loads non-empty guidance from YAML", async () => {
+  test("validates loaded guidance is non-empty", () => {
     const guidance = getCommandGuidance();
     assert.ok(Object.keys(guidance).length >= 50, "Should have at least 50 entries");
   });

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -5,7 +5,7 @@
  * contextual hints, parameter descriptions, and emoji conventions.
  */
 
-import { test, describe, before } from "node:test";
+import { test, describe, before, afterEach } from "node:test";
 import assert from "node:assert";
 import {
   loadCommandGuidance,
@@ -107,13 +107,20 @@ describe("loadCommandGuidance", () => {
     const second = await loadCommandGuidance();
     assert.strictEqual(first, second, "Should return same cached object");
   });
+});
 
-  test("getCommandGuidance returns empty object before load", async () => {
+// Reset-dependent tests in their own describe with independent teardown
+describe("loadCommandGuidance reset behavior", () => {
+  afterEach(async () => {
+    // Always restore guidance so other test suites aren't affected
+    _resetGuidance();
+    await loadCommandGuidance();
+  });
+
+  test("getCommandGuidance returns empty object before load", () => {
     _resetGuidance();
     const guidance = getCommandGuidance();
     assert.deepStrictEqual(guidance, {}, "Should be empty before load");
-    // Reload for remaining tests
-    await loadCommandGuidance();
   });
 
   test("fresh load after reset caches correctly", async () => {

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -133,6 +133,44 @@ describe("loadCommandGuidance reset behavior", () => {
 });
 
 // ============================================================================
+// Prototype pollution safety
+// ============================================================================
+
+describe("prototype pollution safety", () => {
+  test("loaded guidance uses null-prototype object", () => {
+    const guidance = getCommandGuidance();
+    // Object.create(null) objects have no prototype
+    assert.strictEqual(
+      Object.getPrototypeOf(guidance),
+      null,
+      "Guidance map should have null prototype",
+    );
+  });
+
+  test("loaded guidance does not contain dangerous keys", () => {
+    const guidance = getCommandGuidance();
+    const dangerousKeys = ["__proto__", "constructor", "prototype"];
+    for (const key of dangerousKeys) {
+      assert.ok(
+        !(key in guidance),
+        `Guidance should not contain dangerous key "${key}"`,
+      );
+    }
+  });
+
+  test("dangerous keys cannot pollute Object prototype via guidance", () => {
+    const guidance = getCommandGuidance();
+    // Verify that accessing __proto__ on a null-prototype object
+    // returns undefined, not Object.prototype
+    assert.strictEqual(
+      (guidance as Record<string, unknown>)["__proto__"],
+      undefined,
+      "__proto__ should be undefined on null-prototype object",
+    );
+  });
+});
+
+// ============================================================================
 // enhanceParameterDescription
 // ============================================================================
 

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -11,6 +11,7 @@ import {
   loadCommandGuidance,
   getCommandGuidance,
   _resetGuidance,
+  _filterGuidanceEntries,
   enhanceParameterDescription,
   enhanceDescription,
 } from "../src/command-guidance.js";
@@ -139,7 +140,6 @@ describe("loadCommandGuidance reset behavior", () => {
 describe("prototype pollution safety", () => {
   test("loaded guidance uses null-prototype object", () => {
     const guidance = getCommandGuidance();
-    // Object.create(null) objects have no prototype
     assert.strictEqual(
       Object.getPrototypeOf(guidance),
       null,
@@ -147,26 +147,39 @@ describe("prototype pollution safety", () => {
     );
   });
 
-  test("loaded guidance does not contain dangerous keys", () => {
-    const guidance = getCommandGuidance();
-    const dangerousKeys = ["__proto__", "constructor", "prototype"];
-    for (const key of dangerousKeys) {
-      assert.ok(
-        !(key in guidance),
-        `Guidance should not contain dangerous key "${key}"`,
-      );
-    }
+  test("_filterGuidanceEntries rejects dangerous keys while preserving valid entries", () => {
+    const input = {
+      select: { whenToUse: "Choose columns" },
+      __proto__: { whenToUse: "Should be rejected" },
+      constructor: { whenToUse: "Should be rejected" },
+      prototype: { whenToUse: "Should be rejected" },
+      stats: { whenToUse: "Quick numeric stats" },
+    };
+    const result = _filterGuidanceEntries(input);
+
+    // Valid entries preserved
+    assert.ok("select" in result, "Valid key 'select' should be present");
+    assert.ok("stats" in result, "Valid key 'stats' should be present");
+    assert.strictEqual(result["select"]?.whenToUse, "Choose columns");
+    assert.strictEqual(result["stats"]?.whenToUse, "Quick numeric stats");
+
+    // Dangerous keys rejected
+    assert.ok(!("__proto__" in result), "__proto__ should be rejected");
+    assert.ok(!("constructor" in result), "constructor should be rejected");
+    assert.ok(!("prototype" in result), "prototype should be rejected");
+
+    // Result uses null prototype
+    assert.strictEqual(Object.getPrototypeOf(result), null);
   });
 
-  test("dangerous keys cannot pollute Object prototype via guidance", () => {
-    const guidance = getCommandGuidance();
-    // Verify that accessing __proto__ on a null-prototype object
-    // returns undefined, not Object.prototype
-    assert.strictEqual(
-      (guidance as Record<string, unknown>)["__proto__"],
-      undefined,
-      "__proto__ should be undefined on null-prototype object",
-    );
+  test("_filterGuidanceEntries skips entries with only unrecognized keys", () => {
+    const input = {
+      valid: { whenToUse: "Valid entry" },
+      bogus: { typoField: "All keys unrecognized" },
+    };
+    const result = _filterGuidanceEntries(input);
+    assert.ok("valid" in result, "Valid entry should be present");
+    assert.ok(!("bogus" in result), "Entry with only unrecognized keys should be rejected");
   });
 });
 


### PR DESCRIPTION
## Summary
- Move 52 command guidance entries from hardcoded TypeScript constant to `data/command-guidance.yaml`, loaded at runtime via async loader
- Guidance text is now editable without a TypeScript rebuild — only a server restart needed
- Add `yaml` dependency (v2, zero transitive deps, TypeScript types built-in)

## Details
- `loadCommandGuidance()` reads YAML once at startup, `getCommandGuidance()` provides sync access in hot paths
- Graceful degradation on load failure (retryable — doesn't cache empty state permanently)
- Validates entry shapes at load time; warns on unrecognized keys (typo detection); rejects entries with only unrecognized keys
- Reset-dependent tests isolated with `afterEach` teardown for ordering safety

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `npm test` — 649 pass, 0 fail (2 new tests for reset/reload behavior)
- [x] Verify YAML has all 52 entries matching original TypeScript constant
- [ ] Start MCP server, call `qsv_search_tools` to verify guidance appears in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)