### PR TITLE
fix(mcp): Use full MCP-qualified tool names in skill/agent content

### DIFF
--- a/.claude/skills/agents/data-analyst.md
+++ b/.claude/skills/agents/data-analyst.md
@@ -46,17 +46,17 @@ Reference these domain knowledge files for best practices:
 - `../skills/data-quality/SKILL.md` - Quality assessment framework
 - `../skills/qsv-performance/SKILL.md` - Performance optimization
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Standard Workflow
 
-1. **Check ontology**: Check if `ONTOLOGY.md` exists in the working directory (via `qsv_list_files`). If it does, read it to learn entity descriptions, column labels, cross-file relationships, join paths, controlled vocabularies, and data quality flags. Use this context to guide which files to analyze and how columns relate across files. **When an ontology exists**, the stats cache (`.stats.csv`) and frequency cache (`.freq.csv`) should already be populated — skip steps 2-6 and go directly to step 7 (Query). Read the existing `.stats.csv` files for column types, cardinality, and ranges. If no ontology exists, proceed with manual discovery in the following steps.
-2. **Index**: Always run `qsv_index` first for fast access.
-3. **Orient**: Use `qsv_sniff` to detect format, then `qsv_count` and `qsv_headers` to understand structure.
-4. **Profile**: Run `qsv_stats` with `cardinality: true, stats_jsonl: true` for comprehensive column statistics. Basic moarstats auto-runs to enrich the cache.
-5. **Deep profile** (when needed): Run `qsv_moarstats` with `advanced: true` for kurtosis, entropy, Gini coefficient, bimodality, and winsorized/trimmed means. Use when data shows skewness, potential outliers, or you need distribution shape analysis. Omit `output_file` — moarstats updates the stats cache in-place by default.
-6. **Explore**: Use `qsv_frequency` for distributions, `qsv_slice` for row samples, `qsv_search` for filtering, `qsv_command` with `command: "sample"` for random sampling.
-7. **Query**: Use `qsv_sqlp` for SQL-based analysis. **Before writing SQL**, read `.stats.csv` for column types, cardinality, nullcount, min/max ranges, and sort order; run `qsv_frequency` on columns you'll GROUP BY or filter on. Use this data to write precise WHERE clauses, skip unnecessary COALESCE on zero-null columns, and avoid GROUP BY on high-cardinality columns. For repeated queries on large CSV (> 10MB), consider converting to Parquet with `qsv_to_parquet` for faster performance — but `sqlp` can query CSV of any size directly.
+1. **Check ontology**: Check if `ONTOLOGY.md` exists in the working directory (via `mcp__qsv__qsv_list_files`). If it does, read it to learn entity descriptions, column labels, cross-file relationships, join paths, controlled vocabularies, and data quality flags. Use this context to guide which files to analyze and how columns relate across files. **When an ontology exists**, the stats cache (`.stats.csv`) and frequency cache (`.freq.csv`) should already be populated — skip steps 2-6 and go directly to step 7 (Query). Read the existing `.stats.csv` files for column types, cardinality, and ranges. If no ontology exists, proceed with manual discovery in the following steps.
+2. **Index**: Always run `mcp__qsv__qsv_index` first for fast access.
+3. **Orient**: Use `mcp__qsv__qsv_sniff` to detect format, then `mcp__qsv__qsv_count` and `mcp__qsv__qsv_headers` to understand structure.
+4. **Profile**: Run `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` for comprehensive column statistics. Basic moarstats auto-runs to enrich the cache.
+5. **Deep profile** (when needed): Run `mcp__qsv__qsv_moarstats` with `advanced: true` for kurtosis, entropy, Gini coefficient, bimodality, and winsorized/trimmed means. Use when data shows skewness, potential outliers, or you need distribution shape analysis. Omit `output_file` — moarstats updates the stats cache in-place by default.
+6. **Explore**: Use `mcp__qsv__qsv_frequency` for distributions, `mcp__qsv__qsv_slice` for row samples, `mcp__qsv__qsv_search` for filtering, `mcp__qsv__qsv_command` with `command: "sample"` for random sampling.
+7. **Query**: Use `mcp__qsv__qsv_sqlp` for SQL-based analysis. **Before writing SQL**, read `.stats.csv` for column types, cardinality, nullcount, min/max ranges, and sort order; run `mcp__qsv__qsv_frequency` on columns you'll GROUP BY or filter on. Use this data to write precise WHERE clauses, skip unnecessary COALESCE on zero-null columns, and avoid GROUP BY on high-cardinality columns. For repeated queries on large CSV (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet` for faster performance — but `sqlp` can query CSV of any size directly.
 8. **Report**: Summarize findings clearly with tables, key metrics, and observations.
 9. **Document**: Using the statistics (steps 4-5) and frequency distributions (step 6) already collected, generate:
 
@@ -105,6 +105,6 @@ Used by `select`, `search`, `sort`, `dedup`, `frequency`, and other commands:
 - Use `sqlp` for ad-hoc analytical queries (it's the most flexible tool)
 - Present numbers with context (percentages, comparisons, trends)
 - Flag data quality issues when discovered (nulls, outliers, type mismatches)
-- For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `qsv_to_parquet` for faster performance. Note: Parquet works ONLY with `sqlp` and DuckDB; all other qsv commands need CSV/TSV/SSV
+- For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet` for faster performance. Note: Parquet works ONLY with `sqlp` and DuckDB; all other qsv commands need CSV/TSV/SSV
 - For large files (> 100MB), prefer `sqlp` with `LIMIT` for exploratory queries
-- Use `qsv_search_tools` to discover additional analysis tools if needed
+- Use `mcp__qsv__qsv_search_tools` to discover additional analysis tools if needed

--- a/.claude/skills/agents/data-wrangler.md
+++ b/.claude/skills/agents/data-wrangler.md
@@ -47,17 +47,17 @@ Reference these domain knowledge files for best practices:
 - `../skills/data-quality/SKILL.md` - Quality assessment and fix commands
 - `../skills/qsv-performance/SKILL.md` - Performance optimization for large files
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Standard Workflow
 
-1. **Check ontology**: Check if `ONTOLOGY.md` exists in the working directory (via `qsv_list_files`). If it does, read it to learn entity descriptions, column labels, cross-file relationships, join paths, controlled vocabularies, and data quality flags. Use this context to understand how files relate before transforming — especially for joins, dedup key selection, and column renaming. **When an ontology exists**, the stats cache (`.stats.csv`) should already be populated — skip steps 2-4 and go directly to step 5 (Plan). Read the existing `.stats.csv` files for column types, cardinality, and null counts to inform your transformation plan. If no ontology exists, proceed with manual discovery in the following steps.
-2. **Index**: Run `qsv_index` for fast access.
-3. **Assess**: Use `qsv_sniff`, `qsv_count`, `qsv_headers` to understand input.
-4. **Profile**: Run `qsv_stats` with `cardinality: true, stats_jsonl: true` to understand data characteristics before transforming.
+1. **Check ontology**: Check if `ONTOLOGY.md` exists in the working directory (via `mcp__qsv__qsv_list_files`). If it does, read it to learn entity descriptions, column labels, cross-file relationships, join paths, controlled vocabularies, and data quality flags. Use this context to understand how files relate before transforming — especially for joins, dedup key selection, and column renaming. **When an ontology exists**, the stats cache (`.stats.csv`) should already be populated — skip steps 2-4 and go directly to step 5 (Plan). Read the existing `.stats.csv` files for column types, cardinality, and null counts to inform your transformation plan. If no ontology exists, proceed with manual discovery in the following steps.
+2. **Index**: Run `mcp__qsv__qsv_index` for fast access.
+3. **Assess**: Use `mcp__qsv__qsv_sniff`, `mcp__qsv__qsv_count`, `mcp__qsv__qsv_headers` to understand input.
+4. **Profile**: Run `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` to understand data characteristics before transforming.
 5. **Plan**: Determine the sequence of transformations needed.
 6. **Transform**: Execute transforms using individual tools, chaining operations sequentially.
-7. **Verify**: Run `qsv_count` and `qsv_stats` on the output to confirm correctness.
+7. **Verify**: Run `mcp__qsv__qsv_count` and `mcp__qsv__qsv_stats` on the output to confirm correctness.
 
 ## Transformation Capabilities
 
@@ -95,14 +95,14 @@ Used by `select`, `search`, `sort`, `dedup`, `frequency`, and other commands:
 - Always preserve original files - write to new output files
 - Order operations efficiently: select columns first (reduces data), then filter, then transform
 - For large files: prefer Polars commands (sqlp, joinp, pivotp) over memory-intensive ones (sort, dedup)
-- For repeated SQL transforms on large CSV (> 10MB), consider converting to Parquet with `qsv_to_parquet` for faster performance. Use `read_parquet('file.parquet')` as the table source in `sqlp`. Note: Parquet works ONLY with `sqlp` and DuckDB; all other qsv commands need CSV/TSV/SSV
+- For repeated SQL transforms on large CSV (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet` for faster performance. Use `read_parquet('file.parquet')` as the table source in `sqlp`. Note: Parquet works ONLY with `sqlp` and DuckDB; all other qsv commands need CSV/TSV/SSV
 - Index the output file if it will be used by subsequent operations
 
 ## Guidelines
 
-- Always assess data before transforming - read `.stats.csv` for types, nulls, cardinality, min/max ranges; run `qsv_frequency` on columns you'll filter or join on
+- Always assess data before transforming - read `.stats.csv` for types, nulls, cardinality, min/max ranges; run `mcp__qsv__qsv_frequency` on columns you'll filter or join on
 - When writing SQL via `sqlp`, use stats to write precise queries: correct casts from `type`, actual bounds from `min`/`max`, skip COALESCE where `nullcount` = 0, check `cardinality` before GROUP BY
-- Use `qsv_search_tools` to discover specialized tools for uncommon operations
+- Use `mcp__qsv__qsv_search_tools` to discover specialized tools for uncommon operations
 - Verify output after transformation - compare row counts, check statistics
 - When cleaning, follow the order: safenames -> fixlengths -> trim -> dedup -> validate
 - Document what was changed: report rows added/removed, columns modified, formats converted

--- a/.claude/skills/agents/policy-analyst.md
+++ b/.claude/skills/agents/policy-analyst.md
@@ -188,7 +188,7 @@ Use `WebSearch` and `WebFetch` to access public government data for context, ben
    - Run `mcp__qsv__qsv_frequency` with `limit: 10` for value distributions
    Then detect cross-file relationships by comparing column names, cardinality, and value overlap across files. Classify as 1:1, 1:N, or M:N based on cardinality ratios. Synthesize all findings into `ONTOLOGY.md` with entities, attributes, relationships, domain taxonomy, controlled vocabularies, and data quality flags. Use the ontology to identify which files are relevant to the policy questions, how they connect (foreign keys, shared dimensions), and what quality issues to account for.
 3. **Establish baseline**: Compute historical trends using `mcp__qsv__qsv_sqlp`. Calculate year-over-year changes, period averages, and identify the baseline period for comparison.
-4. **Cross-reference**: Pull benchmark data from Census (prefer `mcp-census-api` tools when available), BLS (prefer `bls` MCP tools when available), FBI (prefer `fbi-crime-data` MCP tools when available), or Wikidata (prefer `Wikidata MCP` tools when available). Fall back to `WebSearch`/`WebFetch` for sources without dedicated MCP servers. Join external data with local datasets using `mcp__qsv__qsv_joinp` or `mcp__qsv__qsv_sqlp`. For temporal cross-referencing where dates don't align exactly (e.g., annual budgets to monthly CPI, quarterly QCEW to fiscal years), prefer `mcp__qsv__qsv_joinp --asof` with `strategy: "backward", allow_exact_matches: true` to match each record to the most recent reference value.
+4. **Cross-reference**: Pull benchmark data from Census (prefer `mcp-census-api` tools when available), BLS (prefer `bls` MCP tools when available), FBI (prefer `fbi-crime-data` MCP tools when available), or Wikidata (prefer `Wikidata MCP` tools when available). Fall back to `WebSearch`/`WebFetch` for sources without dedicated MCP servers. Join external data with local datasets using `mcp__qsv__qsv_joinp` or `mcp__qsv__qsv_sqlp`. For temporal cross-referencing where dates don't align exactly (e.g., annual budgets to monthly CPI, quarterly QCEW to fiscal years), prefer `mcp__qsv__qsv_joinp` with `asof: true, strategy: "backward", allow_exact_matches: true` to match each record to the most recent reference value.
 5. **Temporal analysis**: Use `mcp__qsv__qsv_sqlp` window functions for trend decomposition — moving averages, rate-of-change, cumulative totals. Flag inflection points and structural breaks in time series.
 6. **Comparative analysis**: Benchmark against peer jurisdictions, state averages, and national figures. Normalize for population, inflation, or other relevant denominators.
 7. **Synthesize findings**: Summarize the evidence with confidence levels. Include spend-vs-outcomes efficiency findings when budget data is available. Identify causal factors where supported, and flag where evidence is correlational only.
@@ -207,7 +207,7 @@ Use `mcp__qsv__qsv_sqlp` for all temporal calculations:
 
 ### Temporal Cross-Referencing with ASOF Joins
 
-When joining datasets with misaligned time periods, use `mcp__qsv__qsv_joinp --asof` instead of complex SQL window functions. ASOF joins match each row to the nearest key in the reference dataset.
+When joining datasets with misaligned time periods, use `mcp__qsv__qsv_joinp` with `asof: true` instead of complex SQL window functions. ASOF joins match each row to the nearest key in the reference dataset.
 
 **Common policy analysis patterns:**
 
@@ -241,7 +241,7 @@ Every policy recommendation must connect spending to measurable outcomes. Always
 
 **Quick screen first**: Run `mcp__qsv__qsv_moarstats` on combined spend-outcome data with `advanced: true, bivariate: true, bivariate_stats: "all"` to get Pearson/Spearman correlations, mutual information/NMI, and Gini across relevant columns (note: `bivariate_stats: "all"` is more expensive than the default `"fast"` mode which only computes Pearson + covariance). This reveals which spend categories have the strongest associations with outcomes before investing in detailed SQL analysis and whether spending reduces inequality in outcomes.
 
-Join budget/expenditure data with outcome datasets (crime rates, graduation rates, health metrics, employment, etc.) using `mcp__qsv__qsv_sqlp` or `mcp__qsv__qsv_joinp`. Match on jurisdiction, year, and program area. When spend and outcome datasets have different temporal granularity (e.g., annual budgets vs. quarterly outcomes), use `mcp__qsv__qsv_joinp --asof --left_by jurisdiction --right_by jurisdiction` to align the nearest time period rather than requiring exact date matches. Normalize spending to constant dollars before comparing across years.
+Join budget/expenditure data with outcome datasets (crime rates, graduation rates, health metrics, employment, etc.) using `mcp__qsv__qsv_sqlp` or `mcp__qsv__qsv_joinp`. Match on jurisdiction, year, and program area. When spend and outcome datasets have different temporal granularity (e.g., annual budgets vs. quarterly outcomes), use `mcp__qsv__qsv_joinp` with `asof: true, left_by: "jurisdiction", right_by: "jurisdiction"` to align the nearest time period rather than requiring exact date matches. Normalize spending to constant dollars before comparing across years.
 
 ### Key Metrics
 

--- a/.claude/skills/agents/policy-analyst.md
+++ b/.claude/skills/agents/policy-analyst.md
@@ -211,10 +211,10 @@ When joining datasets with misaligned time periods, use `mcp__qsv__qsv_joinp` wi
 
 **Common policy analysis patterns:**
 
-- **CPI inflation adjustment**: Join budget rows (with fiscal year dates) to monthly CPI data using `--asof --strategy backward` on the date column. Each budget row matches to the most recent CPI observation.
-- **QCEW/LAUS cross-reference**: Match quarterly employment data to annual budget data. Use `--asof --strategy backward --left_by jurisdiction --right_by jurisdiction` to find the nearest quarter per jurisdiction.
-- **Census ACS alignment**: When ACS reference periods (July estimates) don't match fiscal year boundaries, use `--asof --strategy nearest --tolerance 365d` to match within one year.
-- **Event-to-outcome matching**: Match program start dates to the nearest subsequent outcome measurement using `--strategy forward`.
+- **CPI inflation adjustment**: Join budget rows (with fiscal year dates) to monthly CPI data using `asof: true, strategy: "backward"` on the date column. Each budget row matches to the most recent CPI observation.
+- **QCEW/LAUS cross-reference**: Match quarterly employment data to annual budget data. Use `asof: true, strategy: "backward", left_by: "jurisdiction", right_by: "jurisdiction"` to find the nearest quarter per jurisdiction.
+- **Census ACS alignment**: When ACS reference periods (July estimates) don't match fiscal year boundaries, use `asof: true, strategy: "nearest", tolerance: "365d"` to match within one year.
+- **Event-to-outcome matching**: Match program start dates to the nearest subsequent outcome measurement using `strategy: "forward"`.
 
 **Example — CPI-adjusted budget comparison:**
 ```

--- a/.claude/skills/agents/policy-analyst.md
+++ b/.claude/skills/agents/policy-analyst.md
@@ -89,7 +89,7 @@ Reference these domain knowledge files for best practices:
 - `../skills/infer-ontology/SKILL.md` - Full ontology template and relationship detection heuristics
 - `../skills/data-profile/SKILL.md` - Per-file profiling workflow details
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Data Sources
 
@@ -181,22 +181,22 @@ Use `WebSearch` and `WebFetch` to access public government data for context, ben
 
 1. **Clarify scope**: Identify the jurisdiction, time period, policy domain, and specific questions. Ask clarifying questions if the scope is ambiguous — effective policy analysis requires precise framing.
 2. **Profile & compile ontology**: Check if `ONTOLOGY.md` already exists in the working directory. If it does, read it and skip to step 3. Otherwise, for every tabular file in the working directory:
-   - Run `qsv_index` for fast random access
-   - Run `qsv_sniff` to detect format, `qsv_count` for row count, `qsv_headers` for columns
-   - Run `qsv_stats` with `cardinality: true, stats_jsonl: true` for full column statistics
-   - Run `qsv_moarstats` with `advanced: true` for distribution shape (kurtosis, Gini, entropy). Add `bivariate: true, bivariate_stats: "all"` when the dataset includes both spend and outcome columns — bivariate results go to a separate sidecar file (`<FILESTEM>.stats.bivariate.csv`), not into the main `.stats.csv`. See the "Distribution & Inequality Analysis" section for detailed metric guidance.
-   - Run `qsv_frequency` with `limit: 10` for value distributions
+   - Run `mcp__qsv__qsv_index` for fast random access
+   - Run `mcp__qsv__qsv_sniff` to detect format, `mcp__qsv__qsv_count` for row count, `mcp__qsv__qsv_headers` for columns
+   - Run `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` for full column statistics
+   - Run `mcp__qsv__qsv_moarstats` with `advanced: true` for distribution shape (kurtosis, Gini, entropy). Add `bivariate: true, bivariate_stats: "all"` when the dataset includes both spend and outcome columns — bivariate results go to a separate sidecar file (`<FILESTEM>.stats.bivariate.csv`), not into the main `.stats.csv`. See the "Distribution & Inequality Analysis" section for detailed metric guidance.
+   - Run `mcp__qsv__qsv_frequency` with `limit: 10` for value distributions
    Then detect cross-file relationships by comparing column names, cardinality, and value overlap across files. Classify as 1:1, 1:N, or M:N based on cardinality ratios. Synthesize all findings into `ONTOLOGY.md` with entities, attributes, relationships, domain taxonomy, controlled vocabularies, and data quality flags. Use the ontology to identify which files are relevant to the policy questions, how they connect (foreign keys, shared dimensions), and what quality issues to account for.
-3. **Establish baseline**: Compute historical trends using `qsv_sqlp`. Calculate year-over-year changes, period averages, and identify the baseline period for comparison.
-4. **Cross-reference**: Pull benchmark data from Census (prefer `mcp-census-api` tools when available), BLS (prefer `bls` MCP tools when available), FBI (prefer `fbi-crime-data` MCP tools when available), or Wikidata (prefer `Wikidata MCP` tools when available). Fall back to `WebSearch`/`WebFetch` for sources without dedicated MCP servers. Join external data with local datasets using `qsv_joinp` or `qsv_sqlp`. For temporal cross-referencing where dates don't align exactly (e.g., annual budgets to monthly CPI, quarterly QCEW to fiscal years), prefer `qsv_joinp --asof` with `strategy: "backward", allow_exact_matches: true` to match each record to the most recent reference value.
-5. **Temporal analysis**: Use `qsv_sqlp` window functions for trend decomposition — moving averages, rate-of-change, cumulative totals. Flag inflection points and structural breaks in time series.
+3. **Establish baseline**: Compute historical trends using `mcp__qsv__qsv_sqlp`. Calculate year-over-year changes, period averages, and identify the baseline period for comparison.
+4. **Cross-reference**: Pull benchmark data from Census (prefer `mcp-census-api` tools when available), BLS (prefer `bls` MCP tools when available), FBI (prefer `fbi-crime-data` MCP tools when available), or Wikidata (prefer `Wikidata MCP` tools when available). Fall back to `WebSearch`/`WebFetch` for sources without dedicated MCP servers. Join external data with local datasets using `mcp__qsv__qsv_joinp` or `mcp__qsv__qsv_sqlp`. For temporal cross-referencing where dates don't align exactly (e.g., annual budgets to monthly CPI, quarterly QCEW to fiscal years), prefer `mcp__qsv__qsv_joinp --asof` with `strategy: "backward", allow_exact_matches: true` to match each record to the most recent reference value.
+5. **Temporal analysis**: Use `mcp__qsv__qsv_sqlp` window functions for trend decomposition — moving averages, rate-of-change, cumulative totals. Flag inflection points and structural breaks in time series.
 6. **Comparative analysis**: Benchmark against peer jurisdictions, state averages, and national figures. Normalize for population, inflation, or other relevant denominators.
 7. **Synthesize findings**: Summarize the evidence with confidence levels. Include spend-vs-outcomes efficiency findings when budget data is available. Identify causal factors where supported, and flag where evidence is correlational only.
 8. **Recommend**: Present actionable policy options structured as: finding, evidence strength, policy option, projected impact, trade-offs, and implementation considerations.
 
 ## Temporal Analysis Techniques
 
-Use `qsv_sqlp` for all temporal calculations:
+Use `mcp__qsv__qsv_sqlp` for all temporal calculations:
 
 - **Year-over-year change**: `(value - LAG(value) OVER (ORDER BY year)) / LAG(value) OVER (ORDER BY year) * 100`
 - **Compound Annual Growth Rate (CAGR)**: `POWER(end_value / start_value, 1.0 / years) - 1`
@@ -207,7 +207,7 @@ Use `qsv_sqlp` for all temporal calculations:
 
 ### Temporal Cross-Referencing with ASOF Joins
 
-When joining datasets with misaligned time periods, use `qsv_joinp --asof` instead of complex SQL window functions. ASOF joins match each row to the nearest key in the reference dataset.
+When joining datasets with misaligned time periods, use `mcp__qsv__qsv_joinp --asof` instead of complex SQL window functions. ASOF joins match each row to the nearest key in the reference dataset.
 
 **Common policy analysis patterns:**
 
@@ -227,7 +227,7 @@ joinp
   strategy: "backward"
   allow_exact_matches: true
 ```
-Then compute constant dollars via `qsv_sqlp`:
+Then compute constant dollars via `mcp__qsv__qsv_sqlp`:
 ```sql
 SELECT year, department, amount * (base_cpi / cpi_value) AS real_amount
 FROM joined_result
@@ -239,13 +239,13 @@ Every policy recommendation must connect spending to measurable outcomes. Always
 
 ### Linking Spend to Outcomes
 
-**Quick screen first**: Run `qsv_moarstats` on combined spend-outcome data with `advanced: true, bivariate: true, bivariate_stats: "all"` to get Pearson/Spearman correlations, mutual information/NMI, and Gini across relevant columns (note: `bivariate_stats: "all"` is more expensive than the default `"fast"` mode which only computes Pearson + covariance). This reveals which spend categories have the strongest associations with outcomes before investing in detailed SQL analysis and whether spending reduces inequality in outcomes.
+**Quick screen first**: Run `mcp__qsv__qsv_moarstats` on combined spend-outcome data with `advanced: true, bivariate: true, bivariate_stats: "all"` to get Pearson/Spearman correlations, mutual information/NMI, and Gini across relevant columns (note: `bivariate_stats: "all"` is more expensive than the default `"fast"` mode which only computes Pearson + covariance). This reveals which spend categories have the strongest associations with outcomes before investing in detailed SQL analysis and whether spending reduces inequality in outcomes.
 
-Join budget/expenditure data with outcome datasets (crime rates, graduation rates, health metrics, employment, etc.) using `qsv_sqlp` or `qsv_joinp`. Match on jurisdiction, year, and program area. When spend and outcome datasets have different temporal granularity (e.g., annual budgets vs. quarterly outcomes), use `qsv_joinp --asof --left_by jurisdiction --right_by jurisdiction` to align the nearest time period rather than requiring exact date matches. Normalize spending to constant dollars before comparing across years.
+Join budget/expenditure data with outcome datasets (crime rates, graduation rates, health metrics, employment, etc.) using `mcp__qsv__qsv_sqlp` or `mcp__qsv__qsv_joinp`. Match on jurisdiction, year, and program area. When spend and outcome datasets have different temporal granularity (e.g., annual budgets vs. quarterly outcomes), use `mcp__qsv__qsv_joinp --asof --left_by jurisdiction --right_by jurisdiction` to align the nearest time period rather than requiring exact date matches. Normalize spending to constant dollars before comparing across years.
 
 ### Key Metrics
 
-Use `qsv_sqlp` to compute these efficiency measures:
+Use `mcp__qsv__qsv_sqlp` to compute these efficiency measures:
 
 - **Cost per outcome unit**: `spend / outcome_count` — e.g., policing spend per violent crime reduction, education spend per graduate. Lower is more efficient.
   ```sql
@@ -279,7 +279,7 @@ Use `qsv_sqlp` to compute these efficiency measures:
 
 ### Diminishing Returns Detection
 
-Use `qsv_sqlp` to compute rolling cost-per-unit across years — a rising cost per unit signals diminishing returns:
+Use `mcp__qsv__qsv_sqlp` to compute rolling cost-per-unit across years — a rising cost per unit signals diminishing returns:
 
 ```sql
 SELECT year, spend, outcomes, spend / NULLIF(outcomes, 0) AS cost_per_unit,
@@ -294,7 +294,7 @@ Always establish the baseline outcome trajectory *before* the spend change. Comp
 
 ## Distribution & Inequality Analysis
 
-Use `qsv_moarstats` with `advanced: true` and/or `bivariate: true` to access these policy-relevant statistics. Run after initial profiling (step 2) to inform deeper analysis.
+Use `mcp__qsv__qsv_moarstats` with `advanced: true` and/or `bivariate: true` to access these policy-relevant statistics. Run after initial profiling (step 2) to inform deeper analysis.
 
 ### Inequality Metrics
 
@@ -360,7 +360,7 @@ Structure each recommendation as:
 - Be consultative: ask clarifying questions, present multiple options, highlight trade-offs rather than prescribing a single path
 - Always link spending to measurable outcomes — avoid recommending increased spend without quantifying expected returns
 - When budget data is available, compute cost-per-outcome and compare across programs, years, and peer jurisdictions before recommending resource allocation
-- Use `qsv_moarstats` with `advanced: true, bivariate: true` to screen for inequality patterns (Gini, Atkinson), distribution anomalies (kurtosis, bimodality), and spend-outcome correlations before building detailed SQL analyses
+- Use `mcp__qsv__qsv_moarstats` with `advanced: true, bivariate: true` to screen for inequality patterns (Gini, Atkinson), distribution anomalies (kurtosis, bimodality), and spend-outcome correlations before building detailed SQL analyses
 - Profile before analyzing — run `stats` and `frequency` first to understand data characteristics
-- Use `qsv_search_tools` to discover additional analysis tools if needed
-- For large datasets (> 10MB), consider converting to Parquet with `qsv_to_parquet` for faster `sqlp` queries
+- Use `mcp__qsv__qsv_search_tools` to discover additional analysis tools if needed
+- For large datasets (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet` for faster `sqlp` queries

--- a/.claude/skills/cowork-CLAUDE.md
+++ b/.claude/skills/cowork-CLAUDE.md
@@ -23,7 +23,7 @@ The stats cache accelerates: `frequency`, `schema`, `tojsonl`, `sqlp`, `joinp`, 
 - Save outputs to files with descriptive names rather than returning large results to chat.
 - Ensure output files are saved to the qsv working directory.
 - **Parquet** is ONLY for `sqlp`/DuckDB; all other qsv commands require CSV/TSV/SSV input.
-- **Spreadsheets** (`.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.ods`) must be converted to CSV first using `mcp__qsv__qsv_command` with `command="excel"` before other qsv commands can process them.
+- **Spreadsheets** (`.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.ods`) are automatically converted to CSV by the MCP server before qsv command execution. Use `mcp__qsv__qsv_command` with `command: "excel"` only when you need explicit control over conversion, such as sheet selection.
 - The working directory is automatically synced from the MCP client's root directory when available.
 - If the auto-synced directory is incorrect or no root is provided, call **`mcp__qsv__qsv_set_working_dir`** to set it manually.
 - In Claude Cowork, verify the working directory matches the "Work in a folder" path by calling **`mcp__qsv__qsv_get_working_dir`**, and correct it with **`mcp__qsv__qsv_set_working_dir`** if needed.

--- a/.claude/skills/cowork-CLAUDE.md
+++ b/.claude/skills/cowork-CLAUDE.md
@@ -9,42 +9,42 @@ To disable auto-deployment, set `QSV_NO_COWORK_SETUP=1` in your shell environmen
 ## Workflow Order
 
 For new files:
-1. **`qsv_list_files`** to discover files in the working directory
-2. **`qsv_index`** for files >10MB (enables faster processing)
-3. **`qsv_stats --cardinality --stats-jsonl`** to create a stats cache
+1. **`mcp__qsv__qsv_list_files`** to discover files in the working directory
+2. **`mcp__qsv__qsv_index`** for files >10MB (enables faster processing)
+3. **`mcp__qsv__qsv_stats --cardinality --stats-jsonl`** to create a stats cache
 4. Then run analysis/transformation commands
 
 The stats cache accelerates: `frequency`, `schema`, `tojsonl`, `sqlp`, `joinp`, `pivotp`, `describegpt`, `moarstats`, `sample`.
 
-`qsv_sqlp` auto-converts CSV inputs to Parquet before execution.
+`mcp__qsv__qsv_sqlp` auto-converts CSV inputs to Parquet before execution.
 
 ## File Handling
 
 - Save outputs to files with descriptive names rather than returning large results to chat.
 - Ensure output files are saved to the qsv working directory.
 - **Parquet** is ONLY for `sqlp`/DuckDB; all other qsv commands require CSV/TSV/SSV input.
-- **Spreadsheets** (`.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.ods`) must be converted to CSV first using `qsv_command` with `command="excel"` before other qsv commands can process them.
+- **Spreadsheets** (`.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.ods`) must be converted to CSV first using `mcp__qsv__qsv_command` with `command="excel"` before other qsv commands can process them.
 - The working directory is automatically synced from the MCP client's root directory when available.
-- If the auto-synced directory is incorrect or no root is provided, call **`qsv_set_working_dir`** to set it manually.
-- In Claude Cowork, verify the working directory matches the "Work in a folder" path by calling **`qsv_get_working_dir`**, and correct it with **`qsv_set_working_dir`** if needed.
+- If the auto-synced directory is incorrect or no root is provided, call **`mcp__qsv__qsv_set_working_dir`** to set it manually.
+- In Claude Cowork, verify the working directory matches the "Work in a folder" path by calling **`mcp__qsv__qsv_get_working_dir`**, and correct it with **`mcp__qsv__qsv_set_working_dir`** if needed.
 
 ## Tool Composition
 
-- **`qsv_sqlp`** auto-converts CSV inputs to Parquet, then routes to DuckDB when available for better SQL compatibility and performance; falls back to Polars SQL otherwise.
-- For multi-file SQL queries, convert all files to Parquet first with **`qsv_to_parquet`**, then use `read_parquet()` references in SQL.
-- For custom row-level logic, use **`qsv_command`** with `command="luau"`.
+- **`mcp__qsv__qsv_sqlp`** auto-converts CSV inputs to Parquet, then routes to DuckDB when available for better SQL compatibility and performance; falls back to Polars SQL otherwise.
+- For multi-file SQL queries, convert all files to Parquet first with **`mcp__qsv__qsv_to_parquet`**, then use `read_parquet()` references in SQL.
+- For custom row-level logic, use **`mcp__qsv__qsv_command`** with `command="luau"`.
 
 ## Memory Limits
 
 Commands `dedup`, `sort`, `reverse`, `table`, `transpose`, `pragmastat`, and `stats` (with extended stats) load entire files into memory.
 
-For files >1GB, prefer `extdedup`/`extsort` alternatives via **`qsv_command`**.
+For files >1GB, prefer `extdedup`/`extsort` alternatives via **`mcp__qsv__qsv_command`**.
 
-Check column cardinality with **`qsv_stats`** before running `frequency` or `pivotp` to avoid huge output.
+Check column cardinality with **`mcp__qsv__qsv_stats`** before running `frequency` or `pivotp` to avoid huge output.
 
 ## Tool Discovery
 
-Use **`qsv_search_tools`** to discover commands beyond the initially loaded core tools. There are 51 qsv skill-based commands available covering selection, filtering, transformation, aggregation, joining, validation, formatting, conversion, and more. Tool names may change across versions; check `qsv_search_tools` if any are unrecognized.
+Use **`mcp__qsv__qsv_search_tools`** to discover commands beyond the initially loaded core tools. There are 51 qsv skill-based commands available covering selection, filtering, transformation, aggregation, joining, validation, formatting, conversion, and more. Tool names may change across versions; check `mcp__qsv__qsv_search_tools` if any are unrecognized.
 
 ## Operation Timeout
 
@@ -53,11 +53,11 @@ qsv operations can take significant time on larger files. The MCP server's defau
 ## Cowork-Specific Notes
 
 - **Path Architecture**: qsv runs on the HOST machine. File paths must be valid
-  on the host. Always verify with `qsv_get_working_dir`.
+  on the host. Always verify with `mcp__qsv__qsv_get_working_dir`.
 - **Sequential Operations**: Prefer sequential over parallel qsv calls to avoid
   queuing delays: index → stats → analysis.
-- **Large Files (>5GB)**: Let `qsv_frequency` run to completion (server timeout
-  is 10 min). Only fall back to `qsv_sqlp` with GROUP BY if the server timeout
-  is exceeded. Use `extsort`/`extdedup` via `qsv_command` instead of `sort`/`dedup`.
+- **Large Files (>5GB)**: Let `mcp__qsv__qsv_frequency` run to completion (server timeout
+  is 10 min). Only fall back to `mcp__qsv__qsv_sqlp` with GROUP BY if the server timeout
+  is exceeded. Use `extsort`/`extdedup` via `mcp__qsv__qsv_command` instead of `sort`/`dedup`.
 - **Context Window**: Save outputs to files rather than returning to chat.
-  Use `qsv_slice` or `qsv_sqlp` with LIMIT to inspect subsets.
+  Use `mcp__qsv__qsv_slice` or `mcp__qsv__qsv_sqlp` with LIMIT to inspect subsets.

--- a/.claude/skills/cowork-CLAUDE.md
+++ b/.claude/skills/cowork-CLAUDE.md
@@ -11,7 +11,7 @@ To disable auto-deployment, set `QSV_NO_COWORK_SETUP=1` in your shell environmen
 For new files:
 1. **`mcp__qsv__qsv_list_files`** to discover files in the working directory
 2. **`mcp__qsv__qsv_index`** for files >10MB (enables faster processing)
-3. **`mcp__qsv__qsv_stats --cardinality --stats-jsonl`** to create a stats cache
+3. **`mcp__qsv__qsv_stats`** with `cardinality: true, stats_jsonl: true` to create a stats cache
 4. Then run analysis/transformation commands
 
 The stats cache accelerates: `frequency`, `schema`, `tojsonl`, `sqlp`, `joinp`, `pivotp`, `describegpt`, `moarstats`, `sample`.

--- a/.claude/skills/skills/csv-query/SKILL.md
+++ b/.claude/skills/skills/csv-query/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Query tabular data files using SQL via the Polars-powered `sqlp` command.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Decision Tree
 
@@ -22,17 +22,17 @@ Query tabular data files using SQL via the Polars-powered `sqlp` command.
 - Yes -> Use `sqlp` (Polars SQL engine)
 
 **Is the CSV file very large (> 10MB)?**
-- Yes -> Consider converting to Parquet with `qsv_to_parquet` for faster repeated queries. Note: `sqlp` can also query CSV files of any size directly.
+- Yes -> Consider converting to Parquet with `mcp__qsv__qsv_to_parquet` for faster repeated queries. Note: `sqlp` can also query CSV files of any size directly.
 
 ## Steps
 
-1. **Prepare the file**: Run `qsv_index` and `qsv_stats` with `cardinality: true, stats_jsonl: true` to create index and stats cache.
+1. **Prepare the file**: Run `mcp__qsv__qsv_index` and `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` to create index and stats cache.
 
 2. **Read the stats cache**: Read `<FILESTEM>.stats.csv` (e.g., `data.stats.csv` for `data.csv`) to understand column metadata before writing SQL. This is the most important step for writing efficient queries.
 
-3. **Run frequency on key columns**: For columns you plan to GROUP BY, filter on, or join on, run `qsv_frequency` to see actual value distributions. This reveals the best filter values and whether a GROUP BY will produce a manageable result set.
+3. **Run frequency on key columns**: For columns you plan to GROUP BY, filter on, or join on, run `mcp__qsv__qsv_frequency` to see actual value distributions. This reveals the best filter values and whether a GROUP BY will produce a manageable result set.
 
-4. **Write and run SQL**: Use `qsv_sqlp` with the SQL query informed by stats and frequency data. The table name in SQL is the filename stem (e.g., `data.csv` -> `SELECT * FROM data`). For Parquet files, use `read_parquet('data.parquet')` as the table source instead.
+4. **Write and run SQL**: Use `mcp__qsv__qsv_sqlp` with the SQL query informed by stats and frequency data. The table name in SQL is the filename stem (e.g., `data.csv` -> `SELECT * FROM data`). For Parquet files, use `read_parquet('data.parquet')` as the table source instead.
 
 5. **Refine if needed**: Check results and adjust the query.
 
@@ -56,7 +56,7 @@ After reading the `.stats.csv` cache, use these columns to inform your SQL:
 
 ### Using Frequency for Filter Values
 
-Run `qsv_frequency --select col --limit 20` before writing WHERE clauses on categorical columns:
+Run `mcp__qsv__qsv_frequency --select col --limit 20` before writing WHERE clauses on categorical columns:
 
 - **Pick selective filters**: If `frequency` shows "active" has 90% of rows, filtering on `WHERE status = 'active'` is wasteful — filter on the rare values instead
 - **Validate expected values**: If you plan `WHERE category IN ('A','B','C')`, check frequency first to confirm those values exist and see if you're missing any

--- a/.claude/skills/skills/csv-query/SKILL.md
+++ b/.claude/skills/skills/csv-query/SKILL.md
@@ -56,7 +56,7 @@ After reading the `.stats.csv` cache, use these columns to inform your SQL:
 
 ### Using Frequency for Filter Values
 
-Run `mcp__qsv__qsv_frequency --select col --limit 20` before writing WHERE clauses on categorical columns:
+Run `mcp__qsv__qsv_frequency` with `select: "col", limit: 20` before writing WHERE clauses on categorical columns:
 
 - **Pick selective filters**: If `frequency` shows "active" has 90% of rows, filtering on `WHERE status = 'active'` is wasteful — filter on the rare values instead
 - **Validate expected values**: If you plan `WHERE category IN ('A','B','C')`, check frequency first to confirm those values exist and see if you're missing any

--- a/.claude/skills/skills/csv-wrangling/SKILL.md
+++ b/.claude/skills/skills/csv-wrangling/SKILL.md
@@ -9,14 +9,14 @@ description: Standard workflow order, tool selection matrix, and composition pat
 
 Always follow this sequence when processing CSV data:
 
-0. **Setup (Cowork)** - If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync
+0. **Setup (Cowork)** - If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync
 1. **Index** - `index` (enables fast random access for subsequent commands)
 2. **Discover** - `sniff` (detect format, encoding, delimiter) -> `headers` -> `count`
 3. **Profile** - `stats --cardinality --stats-jsonl` (creates cache used by smart commands)
 4. **Inspect** - `slice --len 5` (preview rows), `frequency --frequency-jsonl` (value distributions with cache for reuse)
 5. **Transform** - select, sort, dedup, rename, replace, search, sqlp, etc.
 6. **Validate** - `validate` (against JSON Schema), `stats` (verify results)
-7. **Export** - `tojsonl`, `table`, `qsv_to_parquet`, `to` (xlsx/sqlite/postgres/ods/datapackage)
+7. **Export** - `tojsonl`, `table`, `mcp__qsv__qsv_to_parquet`, `to` (xlsx/sqlite/postgres/ods/datapackage)
 8. **Document** - `describegpt --all` (AI-generated Data Dictionary, Description & Tags)
 
 ## Tool Selection Matrix
@@ -109,17 +109,17 @@ blake3 file.csv > checksums.b3 (before transfer) -> blake3 --check checksums.b3 
 - `cat rows` requires same column order; use `cat rowskey` for different schemas
 - `dedup` loads all data into memory and sorts internally; use `--sorted` flag if input is already sorted to enable streaming mode with constant memory
 - `sort` loads entire file into memory; for huge files use `sqlp` with ORDER BY
-- For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `qsv_to_parquet` for faster performance. Parquet works ONLY with `sqlp` and DuckDB — all other qsv commands need CSV/TSV/SSV input
+- For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet` for faster performance. Parquet works ONLY with `sqlp` and DuckDB — all other qsv commands need CSV/TSV/SSV input
 
 ## Tool Discovery
 
-Use **`qsv_search_tools`** to discover commands beyond the initially loaded core tools. There are 53+ qsv skill-based commands covering selection, filtering, transformation, aggregation, joining, validation, formatting, conversion, and more.
+Use **`mcp__qsv__qsv_search_tools`** to discover commands beyond the initially loaded core tools. There are 53+ qsv skill-based commands covering selection, filtering, transformation, aggregation, joining, validation, formatting, conversion, and more.
 
 ## Operational Notes
 
 - **Timeout**: Default operation timeout is 10 minutes (configurable via `QSV_MCP_OPERATION_TIMEOUT_MS`, max 30 min). Allow operations to run to completion.
-- **Memory**: `dedup`, `sort`, `reverse`, `table`, `transpose`, `pragmastat`, and `stats` (with extended stats) load entire files into memory. For files >1GB, prefer `extdedup`/`extsort` via `qsv_command`.
-- **Cowork path architecture**: qsv runs on the HOST machine. File paths must be valid on the host. Always verify with `qsv_get_working_dir`.
+- **Memory**: `dedup`, `sort`, `reverse`, `table`, `transpose`, `pragmastat`, and `stats` (with extended stats) load entire files into memory. For files >1GB, prefer `extdedup`/`extsort` via `mcp__qsv__qsv_command`.
+- **Cowork path architecture**: qsv runs on the HOST machine. File paths must be valid on the host. Always verify with `mcp__qsv__qsv_get_working_dir`.
 - **Sequential operations**: Prefer sequential over parallel qsv calls to avoid queuing delays: index → stats → analysis.
-- **Large files (>5GB)**: Let `qsv_frequency` run to completion. Only fall back to `qsv_sqlp` with GROUP BY if the server timeout is exceeded.
-- **Context window**: Save outputs to files rather than returning to chat. Use `qsv_slice` or `qsv_sqlp` with LIMIT to inspect subsets.
+- **Large files (>5GB)**: Let `mcp__qsv__qsv_frequency` run to completion. Only fall back to `mcp__qsv__qsv_sqlp` with GROUP BY if the server timeout is exceeded.
+- **Context window**: Save outputs to files rather than returning to chat. Use `mcp__qsv__qsv_slice` or `mcp__qsv__qsv_sqlp` with LIMIT to inspect subsets.

--- a/.claude/skills/skills/data-clean/SKILL.md
+++ b/.claude/skills/skills/data-clean/SKILL.md
@@ -10,15 +10,15 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Clean the given tabular data file by fixing common data quality issues.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Steps
 
-1. **Index**: Run `qsv_index` on the file for fast random access in subsequent steps.
+1. **Index**: Run `mcp__qsv__qsv_index` on the file for fast random access in subsequent steps.
 
-2. **Assess current state**: Run `qsv_sniff` and `qsv_count` to understand the file format and size.
+2. **Assess current state**: Run `mcp__qsv__qsv_sniff` and `mcp__qsv__qsv_count` to understand the file format and size.
 
-3. **Profile for cleaning decisions**: Run `qsv_stats` with `cardinality: true, stats_jsonl: true`. Read `.stats.csv` to decide which cleaning steps are needed:
+3. **Profile for cleaning decisions**: Run `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true`. Read `.stats.csv` to decide which cleaning steps are needed:
 
    | Stats Column | What It Reveals | Cleaning Action |
    |-------------|-----------------|-----------------|
@@ -29,7 +29,7 @@ Clean the given tabular data file by fixing common data quality issues.
    | `mode`, `mode_count` | Dominant values | If mode_count > 80% of rows, investigate data entry defaults |
    | `type` | Inferred types | String columns that should be numeric indicate format issues |
 
-4. **Check headers**: Run `qsv_headers` to inspect column names. If names contain spaces, special characters, or are duplicated, plan to use `safenames`.
+4. **Check headers**: Run `mcp__qsv__qsv_headers` to inspect column names. If names contain spaces, special characters, or are duplicated, plan to use `safenames`.
 
 5. **Build cleaning steps**: Apply these operations in order (skip any that aren't needed based on assessment):
 
@@ -43,7 +43,7 @@ Clean the given tabular data file by fixing common data quality issues.
 
    e. **`validate`** - If a JSON Schema is available, validate against it and report violations.
 
-6. **Verify results**: Run `qsv_count` on the output to confirm row count. Run `qsv_stats` with `cardinality: true` to verify improvements.
+6. **Verify results**: Run `mcp__qsv__qsv_count` on the output to confirm row count. Run `mcp__qsv__qsv_stats` with `cardinality: true` to verify improvements.
 
 7. **Report changes**: Summarize what was cleaned:
    - Headers renamed (before -> after)
@@ -55,10 +55,10 @@ Clean the given tabular data file by fixing common data quality issues.
 
 Call each tool sequentially, passing the output of one step as input to the next:
 
-1. `qsv_command` with `command: "safenames"`, `input_file: "<file>"`, `output_file: "step1.csv"`
-2. `qsv_command` with `command: "fixlengths"`, `input_file: "step1.csv"`, `output_file: "step2.csv"`
-3. `qsv_sqlp` with `input_file: "step2.csv"`, `sql: "SELECT TRIM(col1) AS col1, TRIM(col2) AS col2, ... FROM _t_1"`, `output_file: "step3.csv"` (list all columns with TRIM)
-4. `qsv_command` with `command: "dedup"`, `input_file: "step3.csv"`, `output_file: "<output>"`
+1. `mcp__qsv__qsv_command` with `command: "safenames"`, `input_file: "<file>"`, `output_file: "step1.csv"`
+2. `mcp__qsv__qsv_command` with `command: "fixlengths"`, `input_file: "step1.csv"`, `output_file: "step2.csv"`
+3. `mcp__qsv__qsv_sqlp` with `input_file: "step2.csv"`, `sql: "SELECT TRIM(col1) AS col1, TRIM(col2) AS col2, ... FROM _t_1"`, `output_file: "step3.csv"` (list all columns with TRIM)
+4. `mcp__qsv__qsv_command` with `command: "dedup"`, `input_file: "step3.csv"`, `output_file: "<output>"`
 
 ## Notes
 
@@ -67,4 +67,4 @@ Call each tool sequentially, passing the output of one step as input to the next
 - `safenames` uses `--mode conditional` by default (only renames if needed)
 - If the user specifies particular columns to clean, use column selection syntax instead of cleaning all columns
 - `dedup` loads all data into memory and sorts internally; if input is already sorted, use `--sorted` for streaming mode
-- Use `qsv_search_tools` to find additional cleaning tools if needed (e.g., `replace` for regex substitution)
+- Use `mcp__qsv__qsv_search_tools` to find additional cleaning tools if needed (e.g., `replace` for regex substitution)

--- a/.claude/skills/skills/data-convert/SKILL.md
+++ b/.claude/skills/skills/data-convert/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Convert tabular data files between formats.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Supported Conversions
 
@@ -28,42 +28,42 @@ Convert tabular data files between formats.
 | TSV | `fmt --out-delimiter '\t'` | `.tsv` |
 | JSONL | `tojsonl` | `.jsonl` |
 | JSON | `slice --json` | `.json` |
-| Parquet | `qsv_to_parquet` (core tool) | `.parquet` |
-| XLSX | `to xlsx` (via `qsv_command`) | `.xlsx` |
-| ODS | `to ods` (via `qsv_command`) | `.ods` |
-| SQLite | `to sqlite` (via `qsv_command`) | `.db` |
-| PostgreSQL | `to postgres` (via `qsv_command`) | N/A |
-| Data Package | `to datapackage` (via `qsv_command`) | `.json` |
+| Parquet | `mcp__qsv__qsv_to_parquet` (core tool) | `.parquet` |
+| XLSX | `to xlsx` (via `mcp__qsv__qsv_command`) | `.xlsx` |
+| ODS | `to ods` (via `mcp__qsv__qsv_command`) | `.ods` |
+| SQLite | `to sqlite` (via `mcp__qsv__qsv_command`) | `.db` |
+| PostgreSQL | `to postgres` (via `mcp__qsv__qsv_command`) | N/A |
+| Data Package | `to datapackage` (via `mcp__qsv__qsv_command`) | `.json` |
 
 ## Steps
 
-1. **Index**: Run `qsv_index` on the file for fast random access in subsequent steps.
+1. **Index**: Run `mcp__qsv__qsv_index` on the file for fast random access in subsequent steps.
 
-2. **Detect source format**: Run `qsv_sniff` to identify the input format, delimiter, and encoding.
+2. **Detect source format**: Run `mcp__qsv__qsv_sniff` to identify the input format, delimiter, and encoding.
 
 3. **Convert**: Use the appropriate command based on the target format:
 
-   - **To CSV** (from Excel/JSONL): The MCP server handles this automatically when you pass non-CSV files to any qsv tool. Use `qsv_command` with `excel` for explicit control over sheet selection.
+   - **To CSV** (from Excel/JSONL): The MCP server handles this automatically when you pass non-CSV files to any qsv tool. Use `mcp__qsv__qsv_command` with `excel` for explicit control over sheet selection.
 
-   - **To TSV**: Use `qsv_command` with `command: "fmt"`, `options: {"out-delimiter": "\t"}`.
+   - **To TSV**: Use `mcp__qsv__qsv_command` with `command: "fmt"`, `options: {"out-delimiter": "\t"}`.
 
-   - **To JSONL**: Use `qsv_command` with `command: "tojsonl"`.
+   - **To JSONL**: Use `mcp__qsv__qsv_command` with `command: "tojsonl"`.
 
-   - **To Parquet (single file)**: Use `qsv_to_parquet` (core tool) — auto-generates stats cache and Polars schema for optimal type inference.
+   - **To Parquet (single file)**: Use `mcp__qsv__qsv_to_parquet` (core tool) — auto-generates stats cache and Polars schema for optimal type inference.
 
-   - **To Parquet (batch)**: Use `qsv_command` with `command: "to"`, `args: ["parquet", "output_dir"]` for batch conversion with explicit compression control.
+   - **To Parquet (batch)**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["parquet", "output_dir"]` for batch conversion with explicit compression control.
 
-   - **To XLSX**: Use `qsv_command` with `command: "to"`, `args: ["xlsx", "output.xlsx"]`.
+   - **To XLSX**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["xlsx", "output.xlsx"]`.
 
-   - **To ODS**: Use `qsv_command` with `command: "to"`, `args: ["ods", "output.ods"]`.
+   - **To ODS**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["ods", "output.ods"]`.
 
-   - **To SQLite**: Use `qsv_command` with `command: "to"`, `args: ["sqlite", "output.db"]`.
+   - **To SQLite**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["sqlite", "output.db"]`.
 
-   - **To PostgreSQL**: Use `qsv_command` with `command: "to"`, `args: ["postgres", "connection_string"]`.
+   - **To PostgreSQL**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["postgres", "connection_string"]`.
 
-   - **To Data Package**: Use `qsv_command` with `command: "to"`, `args: ["datapackage", "output.json"]`.
+   - **To Data Package**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["datapackage", "output.json"]`.
 
-4. **Verify output**: Run `qsv_count` on the output (if CSV-based) to confirm row count matches input.
+4. **Verify output**: Run `mcp__qsv__qsv_count` on the output (if CSV-based) to confirm row count matches input.
 
 ## Notes
 

--- a/.claude/skills/skills/data-convert/SKILL.md
+++ b/.claude/skills/skills/data-convert/SKILL.md
@@ -51,17 +51,17 @@ Convert tabular data files between formats.
 
    - **To Parquet (single file)**: Use `mcp__qsv__qsv_to_parquet` (core tool) — auto-generates stats cache and Polars schema for optimal type inference.
 
-   - **To Parquet (batch)**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["parquet", "output_dir"]` for batch conversion with explicit compression control.
+   - **To Parquet (batch)**: Use `mcp__qsv__qsv_command` with `command: "to"`, `subcommand: "parquet"`, `destination: "output_dir"` for batch conversion with explicit compression control.
 
-   - **To XLSX**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["xlsx", "output.xlsx"]`.
+   - **To XLSX**: Use `mcp__qsv__qsv_command` with `command: "to"`, `subcommand: "xlsx"`, `destination: "output.xlsx"`.
 
-   - **To ODS**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["ods", "output.ods"]`.
+   - **To ODS**: Use `mcp__qsv__qsv_command` with `command: "to"`, `subcommand: "ods"`, `destination: "output.ods"`.
 
-   - **To SQLite**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["sqlite", "output.db"]`.
+   - **To SQLite**: Use `mcp__qsv__qsv_command` with `command: "to"`, `subcommand: "sqlite"`, `destination: "output.db"`.
 
-   - **To PostgreSQL**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["postgres", "connection_string"]`.
+   - **To PostgreSQL**: Use `mcp__qsv__qsv_command` with `command: "to"`, `subcommand: "postgres"`, `destination: "connection_string"`.
 
-   - **To Data Package**: Use `mcp__qsv__qsv_command` with `command: "to"`, `args: ["datapackage", "output.json"]`.
+   - **To Data Package**: Use `mcp__qsv__qsv_command` with `command: "to"`, `subcommand: "datapackage"`, `destination: "output.json"`.
 
 4. **Verify output**: Run `mcp__qsv__qsv_count` on the output (if CSV-based) to confirm row count matches input.
 

--- a/.claude/skills/skills/data-describe/SKILL.md
+++ b/.claude/skills/skills/data-describe/SKILL.md
@@ -10,15 +10,15 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Generate AI-powered documentation for a tabular data file using `describegpt`. Produces a Data Dictionary (column labels, descriptions, types), a natural-language Description of the dataset, and semantic Tags — all via the connected LLM (no API key needed in MCP mode).
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Steps
 
-1. **Index**: Run `qsv_index` on the file for fast random access.
+1. **Index**: Run `mcp__qsv__qsv_index` on the file for fast random access.
 
-2. **Profile**: Run `qsv_stats` with `cardinality: true, stats_jsonl: true` to generate the stats cache. describegpt reads this cache for column metadata, so it must exist first.
+2. **Profile**: Run `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` to generate the stats cache. describegpt reads this cache for column metadata, so it must exist first.
 
-3. **Describe**: Run `qsv_describegpt` with the requested options (recommend `all: true` for comprehensive output). At least one inference option (`dictionary`, `description`, `tags`, or `all`) is required. Output defaults to `<filestem>.describegpt.md`.
+3. **Describe**: Run `mcp__qsv__qsv_describegpt` with the requested options (recommend `all: true` for comprehensive output). At least one inference option (`dictionary`, `description`, `tags`, or `all`) is required. Output defaults to `<filestem>.describegpt.md`.
 
 4. **Present**: Display the generated Data Dictionary table, Description, and Tags to the user.
 

--- a/.claude/skills/skills/data-join/SKILL.md
+++ b/.claude/skills/skills/data-join/SKILL.md
@@ -52,7 +52,7 @@ Join two tabular data files on common columns.
    JOIN file2 b ON a.id = b.id AND a.date BETWEEN b.start_date AND b.end_date
    ```
 
-   For ASOF (nearest-match) joins, use `mcp__qsv__qsv_joinp` with `--asof`:
+   For ASOF (nearest-match) joins, use `mcp__qsv__qsv_joinp` with `asof: true`:
    ```
    joinp
      columns1: "date"
@@ -65,8 +65,8 @@ Join two tabular data files on common columns.
    ```
    - `strategy: "backward"` (default) — match to the last right row with key < left key
    - `strategy: "forward"` — match to the first right row with key > left key
-   - `strategy: "nearest"` — match to the numerically closest row (supports `--tolerance`)
-   - Add `--left_by`/`--right_by` to restrict matching within subgroups (e.g., per jurisdiction)
+   - `strategy: "nearest"` — match to the numerically closest row (supports `tolerance` parameter)
+   - Add `left_by`/`right_by` parameters to restrict matching within subgroups (e.g., per jurisdiction)
    - Add `allow_exact_matches: true` to include equal keys (<=, >=); default is strict inequality (<, >)
 
 6. **Clean up result**: Use `mcp__qsv__qsv_select` to remove duplicate join columns or unnecessary columns from the result.

--- a/.claude/skills/skills/data-join/SKILL.md
+++ b/.claude/skills/skills/data-join/SKILL.md
@@ -33,16 +33,18 @@ Join two tabular data files on common columns.
 4. **Choose strategy**:
    - If cardinality of join column in file1 > file2, put file1 on the left
    - For `joinp`: smaller cardinality table should be on the right for best performance
-   - If join condition is complex (non-equi), use `sqlp`
-   - If join involves date/time matching where exact dates won't align (e.g., quarterly to monthly, event dates to nearest reporting period), use `joinp --asof`
+   - If join condition is complex (non-equi), use `mcp__qsv__qsv_sqlp`
+   - If join involves date/time matching where exact dates won't align (e.g., quarterly to monthly, event dates to nearest reporting period), use `mcp__qsv__qsv_joinp` with `asof: true`
 
 5. **Execute join**: Use `mcp__qsv__qsv_joinp` for standard joins:
    ```
-   joinp --left/--inner/--full/--cross
+   joinp
      columns1: "id"
      input1: "file1.csv"
      columns2: "id"
      input2: "file2.csv"
+     # Join type: omit for inner (default), or set one of:
+     # left: true, full: true, cross: true
    ```
 
    Or use `mcp__qsv__qsv_sqlp` for complex joins:
@@ -98,8 +100,8 @@ Before executing a join, read `.stats.csv` for both files and validate:
 | Left | `--left` | `LEFT JOIN` | All left + matching right |
 | Full outer | `--full` | `FULL OUTER JOIN` | All rows from both |
 | Cross | `--cross` | `CROSS JOIN` | Cartesian product |
-| Anti | `--anti` | `NOT IN` / `NOT EXISTS` | Left rows without match |
-| Semi | `--semi` | `EXISTS` | Left rows with match (no right cols) |
+| Left Anti | `--left-anti` | `NOT IN` / `NOT EXISTS` | Left rows without match |
+| Left Semi | `--left-semi` | `EXISTS` | Left rows with match (no right cols) |
 | ASOF | `--asof` | _(use joinp)_ | Nearest-key match (temporal/numeric) |
 
 ## Notes

--- a/.claude/skills/skills/data-join/SKILL.md
+++ b/.claude/skills/skills/data-join/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Join two tabular data files on common columns.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Strategy Selection
 
@@ -24,11 +24,11 @@ Join two tabular data files on common columns.
 
 ## Steps
 
-1. **Index both files**: Run `qsv_index` on both files for fast random access.
+1. **Index both files**: Run `mcp__qsv__qsv_index` on both files for fast random access.
 
-2. **Inspect both files**: Run `qsv_headers` on both files to identify column names. Determine which columns to join on.
+2. **Inspect both files**: Run `mcp__qsv__qsv_headers` on both files to identify column names. Determine which columns to join on.
 
-3. **Profile join columns**: Run `qsv_stats` with `cardinality: true, stats_jsonl: true` on both files. Check the cardinality of join columns to determine optimal table order.
+3. **Profile join columns**: Run `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` on both files. Check the cardinality of join columns to determine optimal table order.
 
 4. **Choose strategy**:
    - If cardinality of join column in file1 > file2, put file1 on the left
@@ -36,7 +36,7 @@ Join two tabular data files on common columns.
    - If join condition is complex (non-equi), use `sqlp`
    - If join involves date/time matching where exact dates won't align (e.g., quarterly to monthly, event dates to nearest reporting period), use `joinp --asof`
 
-5. **Execute join**: Use `qsv_joinp` for standard joins:
+5. **Execute join**: Use `mcp__qsv__qsv_joinp` for standard joins:
    ```
    joinp --left/--inner/--full/--cross
      columns1: "id"
@@ -45,14 +45,14 @@ Join two tabular data files on common columns.
      input2: "file2.csv"
    ```
 
-   Or use `qsv_sqlp` for complex joins:
+   Or use `mcp__qsv__qsv_sqlp` for complex joins:
    ```sql
    SELECT a.*, b.col1, b.col2
    FROM file1 a
    JOIN file2 b ON a.id = b.id AND a.date BETWEEN b.start_date AND b.end_date
    ```
 
-   For ASOF (nearest-match) joins, use `qsv_joinp` with `--asof`:
+   For ASOF (nearest-match) joins, use `mcp__qsv__qsv_joinp` with `--asof`:
    ```
    joinp
      columns1: "date"
@@ -69,9 +69,9 @@ Join two tabular data files on common columns.
    - Add `--left_by`/`--right_by` to restrict matching within subgroups (e.g., per jurisdiction)
    - Add `allow_exact_matches: true` to include equal keys (<=, >=); default is strict inequality (<, >)
 
-6. **Clean up result**: Use `qsv_select` to remove duplicate join columns or unnecessary columns from the result.
+6. **Clean up result**: Use `mcp__qsv__qsv_select` to remove duplicate join columns or unnecessary columns from the result.
 
-7. **Verify**: Run `qsv_count` on the result. Compare with input counts to validate join behavior:
+7. **Verify**: Run `mcp__qsv__qsv_count` on the result. Compare with input counts to validate join behavior:
    - Inner join: result <= min(left, right)
    - Left join: result >= left count
    - Full outer: result >= max(left, right)
@@ -87,7 +87,7 @@ Before executing a join, read `.stats.csv` for both files and validate:
 | Null density | `nullcount`, `sparsity` | sparsity > 0.3 on join column | Nulls don't match — expect unmatched rows; consider filtering nulls first |
 | Value overlap | `min`, `max` | Non-overlapping ranges across files | No rows will match — verify correct join column |
 | Skew detection | `mode`, `mode_count` | One value dominates (mode_count > 50% of rows) | Join will be heavily skewed many-to-one; verify this is expected |
-| Uniqueness | `uniqueness_ratio` | Both files have uniqueness_ratio < 1.0 on join column | Many-to-many join risk — expect row explosion; verify with `qsv_count` after |
+| Uniqueness | `uniqueness_ratio` | Both files have uniqueness_ratio < 1.0 on join column | Many-to-many join risk — expect row explosion; verify with `mcp__qsv__qsv_count` after |
 | Outlier keys | `outliers_percentage` | outliers_percentage > 5% on numeric join column | Outlier keys may not match across files; consider trimming first |
 
 ## Join Types

--- a/.claude/skills/skills/data-join/SKILL.md
+++ b/.claude/skills/skills/data-join/SKILL.md
@@ -16,11 +16,11 @@ Join two tabular data files on common columns.
 
 | Scenario | Best Tool | Why |
 |----------|-----------|-----|
-| Standard equi-join | `joinp` | Polars engine, fastest |
-| Non-equi join (>, <, BETWEEN) | `sqlp` | SQL supports complex conditions |
-| Cross join / cartesian | `sqlp` | `CROSS JOIN` syntax |
-| Memory-constrained | `join` | Streaming, lower memory |
-| Fuzzy/approximate match | `joinp --asof` | Nearest-match join |
+| Standard equi-join | `mcp__qsv__qsv_joinp` | Polars engine, fastest |
+| Non-equi join (>, <, BETWEEN) | `mcp__qsv__qsv_sqlp` | SQL supports complex conditions |
+| Cross join / cartesian | `mcp__qsv__qsv_sqlp` | `CROSS JOIN` syntax |
+| Memory-constrained | `mcp__qsv__qsv_command` with `command: "join"` | Streaming, lower memory |
+| Fuzzy/approximate match | `mcp__qsv__qsv_joinp` with `asof: true` | Nearest-match join |
 
 ## Steps
 

--- a/.claude/skills/skills/data-profile/SKILL.md
+++ b/.claude/skills/skills/data-profile/SKILL.md
@@ -38,9 +38,9 @@ Profile the given tabular data file to understand its structure, types, and dist
 
 9. **Optional: Robust statistics** (if data is messy/heavy-tailed and < 100K rows): Run `mcp__qsv__qsv_command` with `command: "pragmastat"` for Hodges-Lehmann center and Shamos spread — robust estimators that tolerate up to 29% corrupted data. Especially useful when mean/stddev are misleading due to outliers. **Warning:** pragmastat computes median-of-pairwise statistics (O(n²) complexity) and becomes very slow on large datasets. For files > 100K rows, use `--subsample 10000` for ~100x speedup, or combine `--subsample 10000 --no-bounds` for ~200x speedup.
 
-10. **Screen for PII/PHI**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset_file: "${CLAUDE_PLUGIN_ROOT}/resources/pii-regexes.txt"`, and `flag: "pii_match"` to scan for sensitive data patterns (SSN, credit cards, email, phone, IBAN). Report any columns with matches.
+10. **Screen for PII/PHI**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset-file: "${CLAUDE_PLUGIN_ROOT}/resources/pii-regexes.txt"`, and `flag: "pii_match"` to scan for sensitive data patterns (SSN, credit cards, email, phone, IBAN). Report any columns with matches.
 
-11. **Screen for injection**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset_file: "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"`, and `flag: "injection_match"` to scan for CSV/formula injection and SQL injection payloads. Report any columns with matches.
+11. **Screen for injection**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset-file: "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"`, and `flag: "injection_match"` to scan for CSV/formula injection and SQL injection payloads. Report any columns with matches.
 
 12. **Preview data**: Run `mcp__qsv__qsv_slice` with `len: 5` to show the first 5 rows as a sample.
 

--- a/.claude/skills/skills/data-profile/SKILL.md
+++ b/.claude/skills/skills/data-profile/SKILL.md
@@ -38,9 +38,9 @@ Profile the given tabular data file to understand its structure, types, and dist
 
 9. **Optional: Robust statistics** (if data is messy/heavy-tailed and < 100K rows): Run `mcp__qsv__qsv_command` with `command: "pragmastat"` for Hodges-Lehmann center and Shamos spread — robust estimators that tolerate up to 29% corrupted data. Especially useful when mean/stddev are misleading due to outliers. **Warning:** pragmastat computes median-of-pairwise statistics (O(n²) complexity) and becomes very slow on large datasets. For files > 100K rows, use `--subsample 10000` for ~100x speedup, or combine `--subsample 10000 --no-bounds` for ~200x speedup.
 
-10. **Screen for PII/PHI**: Run `mcp__qsv__qsv_command` with `command: "searchset"` and `args: ["--flag", "pii_match", "${CLAUDE_PLUGIN_ROOT}/resources/pii-regexes.txt"]` to scan for sensitive data patterns (SSN, credit cards, email, phone, IBAN). Report any columns with matches.
+10. **Screen for PII/PHI**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset_file: "${CLAUDE_PLUGIN_ROOT}/resources/pii-regexes.txt"`, and `flag: "pii_match"` to scan for sensitive data patterns (SSN, credit cards, email, phone, IBAN). Report any columns with matches.
 
-11. **Screen for injection**: Run `mcp__qsv__qsv_command` with `command: "searchset"` and `args: ["--flag", "injection_match", "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"]` to scan for CSV/formula injection and SQL injection payloads. Report any columns with matches.
+11. **Screen for injection**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset_file: "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"`, and `flag: "injection_match"` to scan for CSV/formula injection and SQL injection payloads. Report any columns with matches.
 
 12. **Preview data**: Run `mcp__qsv__qsv_slice` with `len: 5` to show the first 5 rows as a sample.
 

--- a/.claude/skills/skills/data-profile/SKILL.md
+++ b/.claude/skills/skills/data-profile/SKILL.md
@@ -10,21 +10,21 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Profile the given tabular data file to understand its structure, types, and distributions.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Steps
 
-1. **Index**: Run `qsv_index` on the file for fast random access in subsequent steps.
+1. **Index**: Run `mcp__qsv__qsv_index` on the file for fast random access in subsequent steps.
 
-2. **Detect format**: Run `qsv_sniff` on the file to detect delimiter, encoding, preamble, and row count estimate.
+2. **Detect format**: Run `mcp__qsv__qsv_sniff` on the file to detect delimiter, encoding, preamble, and row count estimate.
 
-3. **Count rows**: Run `qsv_count` to get the exact row count.
+3. **Count rows**: Run `mcp__qsv__qsv_count` to get the exact row count.
 
-4. **Get headers**: Run `qsv_headers` to list all column names and positions.
+4. **Get headers**: Run `mcp__qsv__qsv_headers` to list all column names and positions.
 
-5. **Compute statistics**: Run `qsv_stats` with `cardinality: true` and `stats_jsonl: true` to generate full column statistics and cache them. Include `--everything` for comprehensive stats (mean, median, mode, stddev, quartiles, etc.). Basic moarstats auto-runs to enrich the cache with ~18 additional columns.
+5. **Compute statistics**: Run `mcp__qsv__qsv_stats` with `cardinality: true` and `stats_jsonl: true` to generate full column statistics and cache them. Include `--everything` for comprehensive stats (mean, median, mode, stddev, quartiles, etc.). Basic moarstats auto-runs to enrich the cache with ~18 additional columns.
 
-6. **Advanced statistics**: Run `qsv_moarstats` with `advanced: true` (omit `output_file` — it updates the stats cache in-place by default). This enriches the stats cache with:
+6. **Advanced statistics**: Run `mcp__qsv__qsv_moarstats` with `advanced: true` (omit `output_file` — it updates the stats cache in-place by default). This enriches the stats cache with:
    - **Distribution shape**: kurtosis, bimodality coefficient, Jarque-Bera test (normality), skewness measures (pearson_skewness)
    - **Inequality/diversity**: Gini coefficient, Atkinson index, Theil index, Shannon entropy, normalized entropy, Simpson's diversity index
    - **Robust central tendency**: winsorized/trimmed means (with stddev, variance, CV, range, stddev ratio)
@@ -32,21 +32,21 @@ Profile the given tabular data file to understand its structure, types, and dist
    - **Outlier statistics**: counts by severity (extreme/mild, lower/upper), outlier mean/stddev/range, impact ratio, fence z-scores
    - **Other**: trimean, midhinge, mode_zscore, min/max z-scores, relative standard error, mean absolute deviation, xsd_type
 
-7. **Show distributions**: Run `qsv_frequency` with `limit: 10` to show top value distributions for each column. For high-cardinality columns (cardinality close to row count), note them as likely unique identifiers.
+7. **Show distributions**: Run `mcp__qsv__qsv_frequency` with `limit: 10` to show top value distributions for each column. For high-cardinality columns (cardinality close to row count), note them as likely unique identifiers.
 
-8. **Optional: Bivariate correlations** (if multiple numeric columns): Run `qsv_moarstats` with `bivariate: true` to compute pairwise Pearson/Spearman/Kendall correlations, covariance, and mutual information. Output goes to `<FILESTEM>.stats.bivariate.csv`. Reveals hidden relationships between columns.
+8. **Optional: Bivariate correlations** (if multiple numeric columns): Run `mcp__qsv__qsv_moarstats` with `bivariate: true` to compute pairwise Pearson/Spearman/Kendall correlations, covariance, and mutual information. Output goes to `<FILESTEM>.stats.bivariate.csv`. Reveals hidden relationships between columns.
 
-9. **Optional: Robust statistics** (if data is messy/heavy-tailed and < 100K rows): Run `qsv_command` with `command: "pragmastat"` for Hodges-Lehmann center and Shamos spread — robust estimators that tolerate up to 29% corrupted data. Especially useful when mean/stddev are misleading due to outliers. **Warning:** pragmastat computes median-of-pairwise statistics (O(n²) complexity) and becomes very slow on large datasets. For files > 100K rows, use `--subsample 10000` for ~100x speedup, or combine `--subsample 10000 --no-bounds` for ~200x speedup.
+9. **Optional: Robust statistics** (if data is messy/heavy-tailed and < 100K rows): Run `mcp__qsv__qsv_command` with `command: "pragmastat"` for Hodges-Lehmann center and Shamos spread — robust estimators that tolerate up to 29% corrupted data. Especially useful when mean/stddev are misleading due to outliers. **Warning:** pragmastat computes median-of-pairwise statistics (O(n²) complexity) and becomes very slow on large datasets. For files > 100K rows, use `--subsample 10000` for ~100x speedup, or combine `--subsample 10000 --no-bounds` for ~200x speedup.
 
-10. **Screen for PII/PHI**: Run `qsv_command` with `command: "searchset"` and `args: ["--flag", "pii_match", "${CLAUDE_PLUGIN_ROOT}/resources/pii-regexes.txt"]` to scan for sensitive data patterns (SSN, credit cards, email, phone, IBAN). Report any columns with matches.
+10. **Screen for PII/PHI**: Run `mcp__qsv__qsv_command` with `command: "searchset"` and `args: ["--flag", "pii_match", "${CLAUDE_PLUGIN_ROOT}/resources/pii-regexes.txt"]` to scan for sensitive data patterns (SSN, credit cards, email, phone, IBAN). Report any columns with matches.
 
-11. **Screen for injection**: Run `qsv_command` with `command: "searchset"` and `args: ["--flag", "injection_match", "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"]` to scan for CSV/formula injection and SQL injection payloads. Report any columns with matches.
+11. **Screen for injection**: Run `mcp__qsv__qsv_command` with `command: "searchset"` and `args: ["--flag", "injection_match", "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"]` to scan for CSV/formula injection and SQL injection payloads. Report any columns with matches.
 
-12. **Preview data**: Run `qsv_slice` with `len: 5` to show the first 5 rows as a sample.
+12. **Preview data**: Run `mcp__qsv__qsv_slice` with `len: 5` to show the first 5 rows as a sample.
 
 13. **Document**: Generate a Data Dictionary, Dataset Description, and Tags as JSON.
 
-    **13a) Primary — use `describegpt`**: Run `qsv_describegpt` with `all: true, format: "JSON"` and `output: "<filestem>.describegpt.json"`. If the user provided a Tag Vocabulary file, also pass `tag_vocab: "<vocab_file>"`. This produces a structured JSON file with three top-level objects: `Dictionary`, `Description`, and `Tags`. Each of these contains a `response` (the main content), optional `reasoning`, and `token_usage` metadata. The data dictionary itself is under `Dictionary.response.fields`, as an array of field descriptors with keys like `name`, `null_count`, `cardinality`, `min`, `max`, `mean`, and `stddev`. Present the results to the user. When MCP sampling is unavailable but the tool still returns prompts, follow those prompts by issuing a follow-up call with `_llm_responses` instead of using the agent fallback.
+    **13a) Primary — use `describegpt`**: Run `mcp__qsv__qsv_describegpt` with `all: true, format: "JSON"` and `output: "<filestem>.describegpt.json"`. If the user provided a Tag Vocabulary file, also pass `tag_vocab: "<vocab_file>"`. This produces a structured JSON file with three top-level objects: `Dictionary`, `Description`, and `Tags`. Each of these contains a `response` (the main content), optional `reasoning`, and `token_usage` metadata. The data dictionary itself is under `Dictionary.response.fields`, as an array of field descriptors with keys like `name`, `null_count`, `cardinality`, `min`, `max`, `mean`, and `stddev`. Present the results to the user. When MCP sampling is unavailable but the tool still returns prompts, follow those prompts by issuing a follow-up call with `_llm_responses` instead of using the agent fallback.
 
     **13b) Fallback — agent generation**: If `describegpt` encounters a tool error or times out, or if following its prompts via `_llm_responses` is not possible, fall back to generating the same artifacts from the statistics (steps 5-6) and frequency distributions (step 7). Save the result as `<filestem>.profile.json` using the same canonical structure as `describegpt`, for example:
 

--- a/.claude/skills/skills/data-validate/SKILL.md
+++ b/.claude/skills/skills/data-validate/SKILL.md
@@ -30,7 +30,7 @@ a. **Index and profile**: Run `mcp__qsv__qsv_index`, then `mcp__qsv__qsv_stats` 
 
 b. **Completeness**: Read `.stats.csv` — check `nullcount` and `sparsity` for each column. Flag columns with sparsity > 0.5.
 
-c. **Uniqueness**: Compare `cardinality` to row count from `mcp__qsv__qsv_count`. Flag key columns (ID, email) where cardinality < row count. Run `mcp__qsv__qsv_command` with `command: "dedup"` and `args: ["--dupes-output", "dupes.csv"]` to find exact duplicates.
+c. **Uniqueness**: Compare `cardinality` to row count from `mcp__qsv__qsv_count`. Flag key columns (ID, email) where cardinality < row count. Run `mcp__qsv__qsv_command` with `command: "dedup"` and `options: {"dupes-output": "dupes.csv"}` to find exact duplicates.
 
 d. **Validity**: Check `type` column in stats — flag String columns that should be numeric. Run `mcp__qsv__qsv_command` with `command: "validate"` against a JSON Schema if available.
 
@@ -45,9 +45,9 @@ g. **Distribution sanity**: Read moarstats columns for deeper validation:
    - `jarque_bera_pvalue` — if < 0.05, data is NOT normally distributed; flag any analysis that assumes normality
    - `mode_count` — if mode accounts for > 50% of values, investigate whether this reflects a data entry default or missing value masking
 
-h. **Join integrity** (if multiple files): Run `mcp__qsv__qsv_joinp` with `--left-anti` to find orphaned foreign keys.
+h. **Join integrity** (if multiple files): Run `mcp__qsv__qsv_joinp` with `left_anti: true` to find orphaned foreign keys.
 
-i. **Injection screening**: Run `mcp__qsv__qsv_command` with `command: "searchset"` and `args: ["--flag", "injection_match", "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"]` to scan for malicious payloads.
+i. **Injection screening**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset_file: "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"`, and `flag: "injection_match"` to scan for malicious payloads.
 
 ### 2. Review Methodology and Assumptions
 

--- a/.claude/skills/skills/data-validate/SKILL.md
+++ b/.claude/skills/skills/data-validate/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Validate data files and analyses for accuracy, methodology, and potential biases before sharing with stakeholders. Generates a confidence assessment and improvement suggestions.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Usage
 
@@ -26,17 +26,17 @@ The input can be:
 
 If a data file is provided, run these checks using qsv:
 
-a. **Index and profile**: Run `qsv_index`, then `qsv_stats` with `cardinality: true, stats_jsonl: true` and `qsv_sniff` to understand the data.
+a. **Index and profile**: Run `mcp__qsv__qsv_index`, then `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` and `mcp__qsv__qsv_sniff` to understand the data.
 
 b. **Completeness**: Read `.stats.csv` — check `nullcount` and `sparsity` for each column. Flag columns with sparsity > 0.5.
 
-c. **Uniqueness**: Compare `cardinality` to row count from `qsv_count`. Flag key columns (ID, email) where cardinality < row count. Run `qsv_command` with `command: "dedup"` and `args: ["--dupes-output", "dupes.csv"]` to find exact duplicates.
+c. **Uniqueness**: Compare `cardinality` to row count from `mcp__qsv__qsv_count`. Flag key columns (ID, email) where cardinality < row count. Run `mcp__qsv__qsv_command` with `command: "dedup"` and `args: ["--dupes-output", "dupes.csv"]` to find exact duplicates.
 
-d. **Validity**: Check `type` column in stats — flag String columns that should be numeric. Run `qsv_command` with `command: "validate"` against a JSON Schema if available.
+d. **Validity**: Check `type` column in stats — flag String columns that should be numeric. Run `mcp__qsv__qsv_command` with `command: "validate"` against a JSON Schema if available.
 
-e. **Consistency**: Run `qsv_frequency` with `limit: 20` on categorical columns — look for case variants ("NYC" vs "nyc"), inconsistent formats, unexpected values.
+e. **Consistency**: Run `mcp__qsv__qsv_frequency` with `limit: 20` on categorical columns — look for case variants ("NYC" vs "nyc"), inconsistent formats, unexpected values.
 
-f. **Accuracy**: Read `.stats.csv` for `min`, `max`, `mean`, `stddev` — flag implausible ranges (negative ages, latitude > 90, future dates). Run `qsv_moarstats` with `advanced: true` — check `outliers_percentage` > 5%, `kurtosis` > 10 (extreme outliers).
+f. **Accuracy**: Read `.stats.csv` for `min`, `max`, `mean`, `stddev` — flag implausible ranges (negative ages, latitude > 90, future dates). Run `mcp__qsv__qsv_moarstats` with `advanced: true` — check `outliers_percentage` > 5%, `kurtosis` > 10 (extreme outliers).
 
 g. **Distribution sanity**: Read moarstats columns for deeper validation:
    - `median_mean_ratio` — if < 0.8 or > 1.2, distribution is significantly skewed; verify the mean isn't misleading
@@ -45,9 +45,9 @@ g. **Distribution sanity**: Read moarstats columns for deeper validation:
    - `jarque_bera_pvalue` — if < 0.05, data is NOT normally distributed; flag any analysis that assumes normality
    - `mode_count` — if mode accounts for > 50% of values, investigate whether this reflects a data entry default or missing value masking
 
-h. **Join integrity** (if multiple files): Run `qsv_joinp` with `--left-anti` to find orphaned foreign keys.
+h. **Join integrity** (if multiple files): Run `mcp__qsv__qsv_joinp` with `--left-anti` to find orphaned foreign keys.
 
-i. **Injection screening**: Run `qsv_command` with `command: "searchset"` and `args: ["--flag", "injection_match", "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"]` to scan for malicious payloads.
+i. **Injection screening**: Run `mcp__qsv__qsv_command` with `command: "searchset"` and `args: ["--flag", "injection_match", "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"]` to scan for malicious payloads.
 
 ### 2. Review Methodology and Assumptions
 
@@ -65,16 +65,16 @@ Systematically review against these pitfalls:
 
 | Pitfall | How to Detect with qsv | Red Flag |
 |---------|----------------------|----------|
-| **Join explosion** | `qsv_count` before and after join | Row count increased after join |
-| **Survivorship bias** | `qsv_frequency` on status/lifecycle columns | Missing churned/deleted/failed entities |
-| **Incomplete period** | `qsv_sqlp` to check date ranges | Partial periods compared to full periods |
-| **Denominator shifting** | `qsv_sqlp` to verify denominator consistency | Definition changed between periods |
-| **Average of averages** | `qsv_sqlp` to recalculate from raw data | Pre-aggregated averages with unequal group sizes |
-| **Selection bias** | `qsv_frequency` on segment definitions | Segments defined by the outcome being measured |
+| **Join explosion** | `mcp__qsv__qsv_count` before and after join | Row count increased after join |
+| **Survivorship bias** | `mcp__qsv__qsv_frequency` on status/lifecycle columns | Missing churned/deleted/failed entities |
+| **Incomplete period** | `mcp__qsv__qsv_sqlp` to check date ranges | Partial periods compared to full periods |
+| **Denominator shifting** | `mcp__qsv__qsv_sqlp` to verify denominator consistency | Definition changed between periods |
+| **Average of averages** | `mcp__qsv__qsv_sqlp` to recalculate from raw data | Pre-aggregated averages with unequal group sizes |
+| **Selection bias** | `mcp__qsv__qsv_frequency` on segment definitions | Segments defined by the outcome being measured |
 
 ### 4. Verify Calculations and Aggregations
 
-Spot-check using `qsv_sqlp`:
+Spot-check using `mcp__qsv__qsv_sqlp`:
 
 - Recalculate key numbers independently
 - Verify subtotals sum to totals: `SELECT SUM(subtotal) as check_total FROM data`
@@ -86,12 +86,12 @@ Spot-check using `qsv_sqlp`:
 
 | Metric Type | Sanity Check via qsv |
 |-------------|---------------------|
-| Counts | `qsv_count` — does it match known figures? |
-| Sums/averages | `qsv_stats` — are min/max/mean in plausible range? |
-| Rates | `qsv_sqlp` — are values between 0% and 100%? |
-| Distributions | `qsv_frequency` — do segment percentages sum to ~100%? |
-| Growth rates | `qsv_sqlp` — is 50%+ MoM growth realistic? |
-| Outliers | `qsv_moarstats` — `outliers_percentage`, `kurtosis` |
+| Counts | `mcp__qsv__qsv_count` — does it match known figures? |
+| Sums/averages | `mcp__qsv__qsv_stats` — are min/max/mean in plausible range? |
+| Rates | `mcp__qsv__qsv_sqlp` — are values between 0% and 100%? |
+| Distributions | `mcp__qsv__qsv_frequency` — do segment percentages sum to ~100%? |
+| Growth rates | `mcp__qsv__qsv_sqlp` — is 50%+ MoM growth realistic? |
+| Outliers | `mcp__qsv__qsv_moarstats` — `outliers_percentage`, `kurtosis` |
 
 #### Red Flags That Warrant Investigation
 
@@ -143,24 +143,24 @@ Rate the analysis on a 3-level scale:
 ## Pre-Delivery QA Checklist
 
 ### Data Quality Checks
-- [ ] **Source verification**: Confirmed data sources. Run `qsv_sniff` to verify format and encoding.
+- [ ] **Source verification**: Confirmed data sources. Run `mcp__qsv__qsv_sniff` to verify format and encoding.
 - [ ] **Freshness**: Data is current enough. Noted the "as of" date.
 - [ ] **Completeness**: No gaps in time series. Check `nullcount`/`sparsity` in `.stats.csv`.
 - [ ] **Null handling**: Nulls handled appropriately (excluded, imputed, or flagged).
-- [ ] **Deduplication**: No double-counting. Verify with `qsv_count` before/after joins, `dedup --dupes-output`.
+- [ ] **Deduplication**: No double-counting. Verify with `mcp__qsv__qsv_count` before/after joins, `dedup --dupes-output`.
 - [ ] **Filter verification**: All filters correct. No unintended exclusions.
 
 ### Calculation Checks
 - [ ] **Aggregation logic**: GROUP BY includes all non-aggregated columns.
 - [ ] **Denominator correctness**: Rate calculations use the right denominator (non-zero).
 - [ ] **Date alignment**: Comparisons use same time period length. Partial periods excluded or noted.
-- [ ] **Join correctness**: JOIN types appropriate. Verify row counts with `qsv_count` after joins.
+- [ ] **Join correctness**: JOIN types appropriate. Verify row counts with `mcp__qsv__qsv_count` after joins.
 - [ ] **Metric definitions**: Metrics match stakeholder definitions. Deviations noted.
-- [ ] **Subtotals sum**: Parts add up to the whole. Verify with `qsv_sqlp`.
+- [ ] **Subtotals sum**: Parts add up to the whole. Verify with `mcp__qsv__qsv_sqlp`.
 
 ### Reasonableness Checks
 - [ ] **Magnitude**: Numbers in plausible range. Check `min`/`max` in `.stats.csv`.
-- [ ] **Trend continuity**: No unexplained jumps. Use `qsv_sqlp` to check period-over-period.
+- [ ] **Trend continuity**: No unexplained jumps. Use `mcp__qsv__qsv_sqlp` to check period-over-period.
 - [ ] **Cross-reference**: Key numbers match other known sources.
 - [ ] **Edge cases**: Checked boundaries — empty segments, zero-activity periods, new entities.
 
@@ -174,22 +174,22 @@ Rate the analysis on a 3-level scale:
 ## Common Analytical Pitfalls (Reference)
 
 ### Join Explosion
-A many-to-many join silently multiplies rows, inflating counts and sums. **Detect**: `qsv_count` before and after join — if count increased, investigate the join relationship. **Prevent**: Use `COUNT(DISTINCT id)` instead of `COUNT(*)` when counting entities through joins.
+A many-to-many join silently multiplies rows, inflating counts and sums. **Detect**: `mcp__qsv__qsv_count` before and after join — if count increased, investigate the join relationship. **Prevent**: Use `COUNT(DISTINCT id)` instead of `COUNT(*)` when counting entities through joins.
 
 ### Survivorship Bias
-Analyzing only entities that exist today, ignoring churned/deleted/failed ones. **Detect**: `qsv_frequency` on status columns — are all lifecycle states represented? **Prevent**: Ask "who is NOT in this dataset?" before drawing conclusions.
+Analyzing only entities that exist today, ignoring churned/deleted/failed ones. **Detect**: `mcp__qsv__qsv_frequency` on status columns — are all lifecycle states represented? **Prevent**: Ask "who is NOT in this dataset?" before drawing conclusions.
 
 ### Incomplete Period Comparison
-Comparing a partial period to a full period. **Detect**: `qsv_sqlp` to check min/max dates per period. **Prevent**: Filter to complete periods or compare same number of days.
+Comparing a partial period to a full period. **Detect**: `mcp__qsv__qsv_sqlp` to check min/max dates per period. **Prevent**: Filter to complete periods or compare same number of days.
 
 ### Denominator Shifting
-The denominator changes between periods, making rates incomparable. **Detect**: `qsv_sqlp` to verify denominator definition consistency. **Prevent**: Use consistent definitions across all compared periods.
+The denominator changes between periods, making rates incomparable. **Detect**: `mcp__qsv__qsv_sqlp` to verify denominator definition consistency. **Prevent**: Use consistent definitions across all compared periods.
 
 ### Average of Averages
-Averaging pre-computed averages gives wrong results when group sizes differ. **Detect**: Compare `qsv_stats` mean against `qsv_sqlp` weighted average. **Prevent**: Always aggregate from raw data.
+Averaging pre-computed averages gives wrong results when group sizes differ. **Detect**: Compare `mcp__qsv__qsv_stats` mean against `mcp__qsv__qsv_sqlp` weighted average. **Prevent**: Always aggregate from raw data.
 
 ### Simpson's Paradox
-Trend reverses when data is aggregated vs. segmented. **Detect**: `qsv_sqlp` GROUP BY at different granularity levels — does the conclusion change? **Prevent**: Always check results at segment level before aggregating.
+Trend reverses when data is aggregated vs. segmented. **Detect**: `mcp__qsv__qsv_sqlp` GROUP BY at different granularity levels — does the conclusion change? **Prevent**: Always check results at segment level before aggregating.
 
 ## Report Format
 

--- a/.claude/skills/skills/data-validate/SKILL.md
+++ b/.claude/skills/skills/data-validate/SKILL.md
@@ -47,7 +47,7 @@ g. **Distribution sanity**: Read moarstats columns for deeper validation:
 
 h. **Join integrity** (if multiple files): Run `mcp__qsv__qsv_joinp` with `left_anti: true` to find orphaned foreign keys.
 
-i. **Injection screening**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset_file: "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"`, and `flag: "injection_match"` to scan for malicious payloads.
+i. **Injection screening**: Run `mcp__qsv__qsv_command` with `command: "searchset"`, `regexset-file: "${CLAUDE_PLUGIN_ROOT}/resources/injection-regexes.txt"`, and `flag: "injection_match"` to scan for malicious payloads.
 
 ### 2. Review Methodology and Assumptions
 

--- a/.claude/skills/skills/data-viz/SKILL.md
+++ b/.claude/skills/skills/data-viz/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Create publication-quality data visualizations from tabular data files. Uses qsv to profile and prepare data, then generates Python charts with best practices for clarity, accuracy, and design.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Steps
 
@@ -24,19 +24,19 @@ Determine:
 
 ### 2. Profile the Data with qsv
 
-a. **Index and detect**: Run `qsv_index`, then `qsv_sniff` to detect format and encoding.
+a. **Index and detect**: Run `mcp__qsv__qsv_index`, then `mcp__qsv__qsv_sniff` to detect format and encoding.
 
-b. **Understand structure**: Run `qsv_headers` and `qsv_count` to get column names and row count.
+b. **Understand structure**: Run `mcp__qsv__qsv_headers` and `mcp__qsv__qsv_count` to get column names and row count.
 
-c. **Profile columns**: Run `qsv_stats` with `cardinality: true, stats_jsonl: true` to understand types, ranges, and distributions. Read `.stats.csv` to inform chart design:
+c. **Profile columns**: Run `mcp__qsv__qsv_stats` with `cardinality: true, stats_jsonl: true` to understand types, ranges, and distributions. Read `.stats.csv` to inform chart design:
    - `type` → choose appropriate axis type (numeric, categorical, date)
    - `min`/`max` → set axis ranges
    - `cardinality` → determine if column is categorical (low) or continuous (high)
    - `nullcount` → note missing data that could affect the chart
 
-d. **Check distributions**: Run `qsv_frequency` with `limit: 20` on columns you plan to plot — this reveals the actual values and whether grouping or filtering is needed.
+d. **Check distributions**: Run `mcp__qsv__qsv_frequency` with `limit: 20` on columns you plan to plot — this reveals the actual values and whether grouping or filtering is needed.
 
-e. **Run moarstats for visualization hints**: Run `qsv_moarstats` with `advanced: true`. Read the enriched `.stats.csv` for chart design decisions:
+e. **Run moarstats for visualization hints**: Run `mcp__qsv__qsv_moarstats` with `advanced: true`. Read the enriched `.stats.csv` for chart design decisions:
 
    | Stats Column | Visualization Hint |
    |-------------|-------------------|
@@ -49,16 +49,16 @@ e. **Run moarstats for visualization hints**: Run `qsv_moarstats` with `advanced
    | `sparsity` | If > 0.5, too many nulls to visualize meaningfully — warn user or show completeness bar |
    | `mode`, `mode_count` | If mode dominates (> 50% of rows), bar chart of top-N values is more informative than histogram |
 
-f. **Preview data**: Run `qsv_slice` with `len: 5` to see actual values and formats.
+f. **Preview data**: Run `mcp__qsv__qsv_slice` with `len: 5` to see actual values and formats.
 
 ### 3. Prepare the Data
 
 Use qsv to prepare visualization-ready data:
 
-- **Filter**: `qsv_search` or `qsv_sqlp` to subset rows
-- **Aggregate**: `qsv_sqlp` for GROUP BY, window functions, computed columns
-- **Select columns**: `qsv_select` to keep only what's needed
-- **Sort**: `qsv_sqlp` with ORDER BY for ordered categories or time series
+- **Filter**: `mcp__qsv__qsv_search` or `mcp__qsv__qsv_sqlp` to subset rows
+- **Aggregate**: `mcp__qsv__qsv_sqlp` for GROUP BY, window functions, computed columns
+- **Select columns**: `mcp__qsv__qsv_select` to keep only what's needed
+- **Sort**: `mcp__qsv__qsv_sqlp` with ORDER BY for ordered categories or time series
 
 Export the prepared data to a CSV file for Python to read.
 
@@ -188,7 +188,7 @@ qsv_sqlp: SELECT group_col, AVG(metric) as avg_metric, COUNT(*) as n
 ## Notes
 
 - Always profile with qsv first — `stats` and `frequency` reveal the right chart type and catch data issues before plotting
-- For large files, use `qsv_sqlp` to aggregate before passing to Python — don't load millions of rows into pandas
+- For large files, use `mcp__qsv__qsv_sqlp` to aggregate before passing to Python — don't load millions of rows into pandas
 - If interactive charts are requested (hover, zoom), use plotly instead of matplotlib
 - Specify "presentation" for larger fonts and higher contrast
 - Multiple charts can be created at once (e.g., "create a 2x2 grid")

--- a/.claude/skills/skills/infer-ontology/SKILL.md
+++ b/.claude/skills/skills/infer-ontology/SKILL.md
@@ -9,15 +9,15 @@ allowed-tools: [mcp__qsv__qsv_sniff, mcp__qsv__qsv_count, mcp__qsv__qsv_headers,
 
 Scan all files in the current working directory, profile each one, then synthesize a semantic ontology describing the entities, their attributes, the relationships between files, and the domain taxonomy.
 
-> **Cowork note:** If relative paths don't resolve, call `qsv_get_working_dir` and `qsv_set_working_dir` to sync the working directory.
+> **Cowork note:** If relative paths don't resolve, call `mcp__qsv__qsv_get_working_dir` and `mcp__qsv__qsv_set_working_dir` to sync the working directory.
 
 ## Steps
 
 ### Phase 1: Discovery
 
-1. **Sync working directory**: Call `qsv_get_working_dir` to confirm the current path. If needed, call `qsv_set_working_dir`.
+1. **Sync working directory**: Call `mcp__qsv__qsv_get_working_dir` to confirm the current path. If needed, call `mcp__qsv__qsv_set_working_dir`.
 
-2. **List files**: Call `qsv_list_files` to get all files in the working directory. Classify each file:
+2. **List files**: Call `mcp__qsv__qsv_list_files` to get all files in the working directory. Classify each file:
 
    **Tabular** (handled natively by qsv MCP Server — auto-converted to CSV if needed):
    - CSV/TSV/SSV/TAB (`.csv`, `.tsv`, `.ssv`, `.tab` and `.sz` compressed variants)
@@ -62,7 +62,7 @@ Scan all files in the current working directory, profile each one, then synthesi
    - Compare value ranges (`min`/`max`) — overlapping ranges suggest a real relationship
    - Compare frequency distributions — if top values in one appear in the other, the relationship is likely valid
    - Check `skewness` — highly skewed join columns (|skewness| > 2) may indicate data quality issues masking relationships
-   - Use `qsv_sqlp` to test overlap when needed:
+   - Use `mcp__qsv__qsv_sqlp` to test overlap when needed:
      ```
      SELECT COUNT(DISTINCT a.col) as overlap
      FROM read_csv('file1.csv') a

--- a/.claude/skills/skills/qsv-performance/SKILL.md
+++ b/.claude/skills/skills/qsv-performance/SKILL.md
@@ -53,7 +53,7 @@ description: Performance guide covering index files, stats cache, and frequency 
 **Rule**: Use Polars commands (sqlp, joinp, pivotp) for files > 100MB or complex queries.
 
 ### Parquet Acceleration
-For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `qsv_to_parquet`. Parquet is a columnar format that speeds up repeated SQL queries in `sqlp`. Use `read_parquet('file.parquet')` as the table source. DuckDB is the preferred engine for Parquet queries; `sqlp` with `SKIP_INPUT` mode also works. Note: `sqlp` can query CSV of any size directly — Parquet is an optimization for repeated queries, not a requirement. Parquet works ONLY with `sqlp` and DuckDB — all other qsv commands require CSV/TSV/SSV input.
+For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet`. Parquet is a columnar format that speeds up repeated SQL queries in `sqlp`. Use `read_parquet('file.parquet')` as the table source. DuckDB is the preferred engine for Parquet queries; `sqlp` with `SKIP_INPUT` mode also works. Note: `sqlp` can query CSV of any size directly — Parquet is an optimization for repeated queries, not a requirement. Parquet works ONLY with `sqlp` and DuckDB — all other qsv commands require CSV/TSV/SSV input.
 
 ## Memory-Aware Command Selection
 

--- a/.claude/skills/skills/qsv-performance/SKILL.md
+++ b/.claude/skills/skills/qsv-performance/SKILL.md
@@ -53,7 +53,7 @@ description: Performance guide covering index files, stats cache, and frequency 
 **Rule**: Use Polars commands (sqlp, joinp, pivotp) for files > 100MB or complex queries.
 
 ### Parquet Acceleration
-For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet`. Parquet is a columnar format that speeds up repeated SQL queries in `sqlp`. Use `read_parquet('file.parquet')` as the table source. DuckDB is the preferred engine for Parquet queries; `sqlp` with `SKIP_INPUT` mode also works. Note: `sqlp` can query CSV of any size directly — Parquet is an optimization for repeated queries, not a requirement. Parquet works ONLY with `sqlp` and DuckDB — all other qsv commands require CSV/TSV/SSV input.
+For repeated SQL queries on large CSV (> 10MB), consider converting to Parquet with `mcp__qsv__qsv_to_parquet`. Parquet is a columnar format that speeds up repeated SQL queries in `mcp__qsv__qsv_sqlp`. Use `read_parquet('file.parquet')` as the table source. DuckDB is the preferred engine for Parquet queries; `mcp__qsv__qsv_sqlp` with `SKIP_INPUT` as the `input_file` value also works. Note: `mcp__qsv__qsv_sqlp` can query CSV of any size directly — Parquet is an optimization for repeated queries, not a requirement. Parquet works ONLY with `mcp__qsv__qsv_sqlp` and DuckDB — all other qsv commands require CSV/TSV/SSV input.
 
 ## Memory-Aware Command Selection
 

--- a/.claude/skills/skills/reproducible-analysis/SKILL.md
+++ b/.claude/skills/skills/reproducible-analysis/SKILL.md
@@ -18,8 +18,8 @@ Create a journal file named `<analysis-name>.journal.jsonl` alongside the analys
 ### Entry Schema
 
 ```jsonl
-{"seq": 1, "ts": "2026-03-19T14:30:00Z", "op": "index", "tool": "qsv_index", "input": "sales.csv", "input_sha256": "a1b2c3...", "input_rows": 50000, "input_cols": 12, "params": {}, "output": "sales.csv.idx", "output_sha256": "d4e5f6...", "duration_ms": 45, "note": "Create index for fast access"}
-{"seq": 2, "ts": "2026-03-19T14:30:01Z", "op": "stats", "tool": "qsv_stats", "input": "sales.csv", "input_sha256": "a1b2c3...", "params": {"cardinality": true, "stats_jsonl": true}, "output": "sales.stats.csv", "output_sha256": "f7a8b9...", "duration_ms": 320, "note": "Generate stats cache with cardinality"}
+{"seq": 1, "ts": "2026-03-19T14:30:00Z", "op": "index", "tool": "mcp__qsv__qsv_index", "input": "sales.csv", "input_sha256": "a1b2c3...", "input_rows": 50000, "input_cols": 12, "params": {}, "output": "sales.csv.idx", "output_sha256": "d4e5f6...", "duration_ms": 45, "note": "Create index for fast access"}
+{"seq": 2, "ts": "2026-03-19T14:30:01Z", "op": "stats", "tool": "mcp__qsv__qsv_stats", "input": "sales.csv", "input_sha256": "a1b2c3...", "params": {"cardinality": true, "stats_jsonl": true}, "output": "sales.stats.csv", "output_sha256": "f7a8b9...", "duration_ms": 320, "note": "Generate stats cache with cardinality"}
 ```
 
 ### Required Fields
@@ -29,7 +29,7 @@ Create a journal file named `<analysis-name>.journal.jsonl` alongside the analys
 | `seq` | integer | 1-based sequence number within the journal |
 | `ts` | string | ISO 8601 UTC timestamp of when the operation ran |
 | `op` | string | Human-readable operation name (e.g., "stats", "filter", "join") |
-| `tool` | string or null | Exact MCP tool name used (e.g., `qsv_stats`, `qsv_sqlp`); null for journal-level entries (`init`, `complete`) |
+| `tool` | string or null | Exact MCP tool name used (e.g., `mcp__qsv__qsv_stats`, `mcp__qsv__qsv_sqlp`); null for journal-level entries (`init`, `complete`) |
 | `input` | string, array, or null | Input file path(s), relative to working directory; null for journal-level entries |
 | `input_sha256` | string, array, or null | SHA-256 hash(es) of input file(s); null for journal-level entries |
 | `params` | object | All parameters passed to the tool (excluding input/output paths) |
@@ -42,8 +42,8 @@ Create a journal file named `<analysis-name>.journal.jsonl` alongside the analys
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `input_rows` | integer | Row count of input (from `qsv_count`) |
-| `input_cols` | integer | Column count of input (from `qsv_headers`) |
+| `input_rows` | integer | Row count of input (from `mcp__qsv__qsv_count`) |
+| `input_cols` | integer | Column count of input (from `mcp__qsv__qsv_headers`) |
 | `output_rows` | integer | Row count of output |
 | `output_cols` | integer | Column count of output |
 | `delta_rows` | integer | Rows added/removed (output_rows - input_rows) |
@@ -55,7 +55,7 @@ Create a journal file named `<analysis-name>.journal.jsonl` alongside the analys
 
 ## How to Compute Hashes
 
-Use `qsv_sqlp` or shell commands to compute SHA-256 hashes:
+Use `mcp__qsv__qsv_sqlp` or shell commands to compute SHA-256 hashes:
 
 ```bash
 # Via shell (when available)


### PR DESCRIPTION
Skill and agent instructional content used bare tool names (e.g., `qsv_index`) while allowed-tools frontmatter used full MCP-qualified names (`mcp__qsv__qsv_index`). This caused intermittent failures when Claude called tools using the bare name or guessed a wrong prefix, neither of which matched the allowed-tools list.

Updated all bare `qsv_*` tool references to `mcp__qsv__qsv_*` across 12 skills, 3 agents, and cowork-CLAUDE.md so content matches frontmatter.