### PR TITLE
refactor(mcp): fix doc drift, make guidance data-driven, mark truncated logs

### DIFF
--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -49,7 +49,7 @@ Prefer reading `.stats.csv` and `.freq.csv` directly over their `.data.jsonl` co
 |----------|-------|----------|
 | `MAX_MCP_RESPONSE_SIZE` | 850 KB | `mcp-tools.ts` — safe for Claude Desktop (< 1MB) |
 | `LARGE_FILE_THRESHOLD_BYTES` | 10 MB | `mcp-tools.ts` — triggers large-file handling |
-| `MAX_LOG_MESSAGE_LEN` | 4096 chars | `mcp-tools.ts` — silently truncated beyond this |
+| `MAX_LOG_MESSAGE_LEN` | 4096 chars | `mcp-tools.ts` — messages beyond this are truncated and suffixed with "…" |
 | `MAX_OUTPUT_SIZE` | 50 MB | `executor.ts` — stdout/stderr cap per execution |
 | Default timeout | 10 min | `executor.ts` — configurable via params or config |
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -127,15 +127,15 @@ npm run mcpb:package
 
 | Category | Count | Skills |
 |----------|-------|--------|
-| **utility** | 23 | blake3, cat, clipboard, count, headers, index, input, partition, pseudo, reverse, sniff, split, template, etc. |
-| **transformation** | 5 | rename, replace, transpose, etc. |
-| **aggregation** | 5 | frequency, moarstats, stats, count, pragmastat |
-| **conversion** | 6 | excel, json, jsonl, to, tojsonl, etc. |
-| **selection** | 3 | select, slice, sample |
+| **utility** | 23 | blake3, cat, dedup, diff, enum, exclude, explode, extdedup, extsort, fill, geocode, headers, index, luau, partition, pivotp, pseudo, sniff, sort, sortcheck, split, sqlp, template |
+| **conversion** | 6 | excel, input, json, jsonl, to, tojsonl |
+| **aggregation** | 5 | count, frequency, moarstats, pragmastat, stats |
+| **transformation** | 5 | datefmt, rename, replace, reverse, transpose |
+| **selection** | 3 | sample, select, slice |
+| **formatting** | 3 | fixlengths, fmt, table |
+| **validation** | 3 | safenames, schema, validate |
 | **filtering** | 2 | search, searchset |
-| **formatting** | 3 | fmt, fixlengths, table |
 | **joining** | 2 | join, joinp |
-| **validation** | 3 | schema, safenames, validate |
 | **documentation** | 1 | describegpt |
 
 **Total Statistics:**

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -127,10 +127,10 @@ npm run mcpb:package
 
 | Category | Count | Skills |
 |----------|-------|--------|
-| **utility** | 22 | cat, clipboard, count, headers, index, input, partition, pseudo, reverse, sniff, split, template, etc. |
+| **utility** | 23 | blake3, cat, clipboard, count, headers, index, input, partition, pseudo, reverse, sniff, split, template, etc. |
 | **transformation** | 5 | rename, replace, transpose, etc. |
 | **aggregation** | 5 | frequency, moarstats, stats, count, pragmastat |
-| **conversion** | 5 | excel, json, jsonl, tojsonl, etc. |
+| **conversion** | 6 | excel, json, jsonl, to, tojsonl, etc. |
 | **selection** | 3 | select, slice, sample |
 | **filtering** | 2 | search, searchset |
 | **formatting** | 3 | fmt, fixlengths, table |

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -21,10 +21,10 @@ The QSV MCP Server now supports **direct access to local tabular data files** (C
 
 This directory contains:
 
-1. **51 Auto-generated Skill Definitions** - JSON files describing all qsv commands (parsed with qsv-docopt)
+1. **53 Auto-generated Skill Definitions** - JSON files describing all qsv commands (parsed with qsv-docopt)
 2. **TypeScript Executor** - Complete implementation for running qsv skills
 3. **MCP Server with Filesystem Access** - Model Context Protocol server for Claude Desktop integration
-5. **Working Demos** - Practical demonstrations of the system
+4. **Working Demos** - Practical demonstrations of the system
 
 Each skill file provides:
 - **Command specification**: Binary, subcommand, arguments, and options (parsed with qsv-docopt)
@@ -123,7 +123,7 @@ npm test
 npm run mcpb:package
 ```
 
-## Generated Skills (51)
+## Generated Skills (53)
 
 | Category | Count | Skills |
 |----------|-------|--------|
@@ -139,7 +139,7 @@ npm run mcpb:package
 | **documentation** | 1 | describegpt |
 
 **Total Statistics:**
-- **Skills**: 51 commands
+- **Skills**: 53 commands
 - **Usage Examples**: 174 from documentation
 - **Options**: 604 command-line options
 - **Arguments**: 87 positional arguments
@@ -148,11 +148,11 @@ npm run mcpb:package
 
 ```
 .claude/skills/
-├── qsv/                    # 51 skill JSON definitions
+├── qsv/                    # 53 skill JSON definitions
 │   ├── qsv-select.json
 │   ├── qsv-stats.json
 │   ├── qsv-moarstats.json
-│   └── ... (48 more)
+│   └── ... (50 more)
 ├── src/                    # TypeScript source
 │   ├── types.ts           # Type definitions
 │   ├── loader.ts          # Skill loading
@@ -201,7 +201,7 @@ npm run mcpb:package
 ```typescript
 import { SkillLoader, SkillExecutor } from './dist/index.js';
 
-// Load all 51 skills
+// Load all 53 skills
 const loader = new SkillLoader();
 await loader.loadAll();
 
@@ -341,7 +341,7 @@ await agent.chat("Remove duplicates from sales.csv");
 
 ## Integration with Claude Desktop (MCP Server)
 
-The QSV MCP Server exposes all 51 qsv skill-based commands to Claude Desktop through the Model Context Protocol.
+The QSV MCP Server exposes all 53 qsv skill-based commands to Claude Desktop through the Model Context Protocol.
 
 ### Quick Start
 
@@ -450,7 +450,7 @@ MIT
 **Updated**: 2026-03-22
 **Version**: 18.0.5
 **Generator**: `qsv --update-mcp-skills`
-**Skills**: 51 commands
+**Skills**: 53 commands
 **Usage Examples**: 174 from documentation
 **Parsing**: qsv-docopt (robust, accurate)
 **Features**: MCP server, filesystem access, type-safe execution

--- a/.claude/skills/data/command-guidance.yaml
+++ b/.claude/skills/data/command-guidance.yaml
@@ -66,6 +66,7 @@ frequency:
     Use --select to target specific columns instead of computing frequency on all columns.
   needsMemoryWarning: true
   hasCommonMistakes: true
+  statsAware: true
 
 join:
   whenToUse: "Join CSV files (<50MB). For large/complex joins, use qsv_joinp."
@@ -78,6 +79,7 @@ joinp:
   commonPattern: "Stats → Join: Use qsv_stats --cardinality on both files, put lower-cardinality join column on right for efficiency. Check nullcount on join columns — nulls never match in joins and high null rates explain missing rows. For time-series joins, use --asof to match on nearest key rather than exact equality; both datasets are auto-sorted on join columns unless --no-sort is set."
   errorPrevention: "Use --try-parsedates for date joins. Check column types with qsv_stats — mismatched types (String vs Integer) cause silent join failures."
   hasCommonMistakes: true
+  statsAware: true
 
 dedup:
   whenToUse: "Remove duplicates. Loads entire CSV. For large files (>1GB), use qsv_extdedup. Use qsv_stats --cardinality to check column cardinality - if key column has unique values only, dedup will be a no-op."
@@ -85,6 +87,7 @@ dedup:
   errorPrevention: "May OOM on files >1GB. Use qsv_extdedup for large files."
   needsMemoryWarning: true
   hasCommonMistakes: true
+  statsAware: true
 
 sort:
   whenToUse: "Sort by columns. Loads entire file. For large files (>1GB), use qsv_extsort. Use stats cache to check if data is already sorted."
@@ -92,6 +95,7 @@ sort:
   errorPrevention: "May OOM on files >1GB. Use qsv_extsort for large files."
   needsMemoryWarning: true
   hasCommonMistakes: true
+  statsAware: true
 
 count:
   whenToUse: "Count rows. Very fast with index. Run qsv_index first for files >10MB."
@@ -150,12 +154,14 @@ cat:
   whenToUse: "Concatenate CSV files. Subcommands: rows (stack vertically), rowskey (different schemas), columns (side-by-side). Specify via subcommand parameter."
   commonPattern: "Combine files: cat rows → headers from first file only. cat rowskey → handles different schemas. cat columns → side-by-side merge."
   errorPrevention: "rows mode requires same column order. Use rowskey for different schemas."
+  subcommandHint: 'Must pass subcommand via args (e.g., args: {subcommand: "rows", input: "file.csv"}).'
   hasCommonMistakes: true
 
 geocode:
   whenToUse: "Geocode locations using Geonames/MaxMind. Subcommands: suggest, reverse, countryinfo, iplookup. Specify via subcommand parameter."
   commonPattern: "Common: suggest for city lookup, reverse for lat/lon → city, iplookup for IP → location."
   errorPrevention: "Needs Geonames index (auto-downloads on first use). iplookup needs MaxMind GeoLite2 DB."
+  subcommandHint: 'Must pass subcommand via args (e.g., args: {subcommand: "suggest", column: "city", input: "data.csv"}).'
   needsIndexHint: true
 
 pivotp:
@@ -163,6 +169,7 @@ pivotp:
   commonPattern: "Stats → Pivot: Use qsv_stats --cardinality to estimate pivot output width (pivot column cardinality × value columns) and keep estimated columns below ~1000. Group-by: omit on-cols, e.g. qsv_pivotp(input_file='data.csv', index='group-col', values='val-col', agg='sum'). Use stats type column to pick the right --agg: sum/mean for numeric, count for categorical."
   errorPrevention: "High-cardinality pivot columns create wide output. Use qsv_stats --cardinality to check cardinality of potential pivot columns. In group-by mode, --index is required, --agg smart resolves to len (count), and none is not supported."
   hasCommonMistakes: true
+  statsAware: true
 
 excel:
   whenToUse: "Convert spreadsheets (Excel and OpenDocument) to CSV. Also can be used to get workbook metadata. Supports multi-sheet workbooks."

--- a/.claude/skills/data/command-guidance.yaml
+++ b/.claude/skills/data/command-guidance.yaml
@@ -5,9 +5,11 @@
 #   whenToUse          — when to select this command (string)
 #   commonPattern      — typical workflow patterns (string)
 #   errorPrevention    — common mistakes and pitfalls (string)
+#   subcommandHint     — inline usage example for commands that require a subcommand (string)
 #   needsMemoryWarning — flag: memory-intensive (boolean, only when true)
 #   needsIndexHint     — flag: benefits from indexing (boolean, only when true)
 #   hasCommonMistakes  — flag: shown with errorPrevention (boolean, only when true)
+#   statsAware         — flag: commonPattern leverages the stats cache; emits 📊 instead of 📋 (boolean, only when true)
 
 select:
   whenToUse: 'Choose columns. Syntax: "1,3,5" (specific), "1-10" (range), "!SSN" (exclude), "/<regex>/" (pattern), "_" (last).'

--- a/.claude/skills/manifest.json
+++ b/.claude/skills/manifest.json
@@ -255,7 +255,7 @@
   "_meta": {
     "com.dathere.qsv": {
       "features": [
-        "66 CLI commands (53 available as skills)",
+        "71 CLI commands (53 available as skills)",
         "Process local files (CSV, Parquet, Excel, JSONL) without uploading",
         "Smart caching with stats/frequency files",
         "Automatic Excel, Parquet and JSONL conversion"

--- a/.claude/skills/src/command-guidance.ts
+++ b/.claude/skills/src/command-guidance.ts
@@ -24,9 +24,11 @@ export interface CommandGuidance {
   whenToUse?: string;
   commonPattern?: string;
   errorPrevention?: string;
+  subcommandHint?: string;
   needsMemoryWarning?: boolean;
   needsIndexHint?: boolean;
   hasCommonMistakes?: boolean;
+  statsAware?: boolean;
 }
 
 // Module-level cache — populated by loadCommandGuidance(), read by getCommandGuidance()
@@ -52,11 +54,17 @@ function resolveGuidancePath(): string {
   return productionPath; // fallback for clear error message
 }
 
-const VALID_STRING_FIELDS = ["whenToUse", "commonPattern", "errorPrevention"];
+const VALID_STRING_FIELDS = [
+  "whenToUse",
+  "commonPattern",
+  "errorPrevention",
+  "subcommandHint",
+];
 const VALID_BOOLEAN_FIELDS = [
   "needsMemoryWarning",
   "needsIndexHint",
   "hasCommonMistakes",
+  "statsAware",
 ];
 
 /** Type guard for a single guidance entry. */
@@ -228,16 +236,17 @@ export function enhanceDescription(skill: QsvSkill): string {
     description += `\n\n💡 ${guidance.whenToUse}`;
   }
 
-  // Add subcommand requirement for commands that need it
-  if (commandName === "cat") {
-    description += `\n\n🔧 SUBCOMMAND: Must pass subcommand via args (e.g., args: {subcommand: "rows", input: "file.csv"}).`;
-  } else if (commandName === "geocode") {
-    description += `\n\n🔧 SUBCOMMAND: Must pass subcommand via args (e.g., args: {subcommand: "suggest", column: "city", input: "data.csv"}).`;
+  // Add subcommand requirement for commands that need it (data-driven via YAML)
+  if (guidance?.subcommandHint) {
+    description += `\n\n🔧 SUBCOMMAND: ${guidance.subcommandHint}`;
   }
 
-  // Add common patterns (helps Claude compose workflows)
+  // Add common patterns (helps Claude compose workflows).
+  // Use 📊 for stats-aware commands where the pattern hinges on the stats cache,
+  // per the skills CLAUDE.md emoji convention.
   if (guidance?.commonPattern) {
-    description += `\n\n📋 ${guidance.commonPattern}`;
+    const icon = guidance.statsAware ? "📊" : "📋";
+    description += `\n\n${icon} ${guidance.commonPattern}`;
   }
 
   // Add performance hints only for commands that benefit from indexing

--- a/.claude/skills/src/tool-constants.ts
+++ b/.claude/skills/src/tool-constants.ts
@@ -28,7 +28,8 @@ export interface PipelineMetadata {
 
 /**
  * Maximum length for qsv_log messages (in characters).
- * Messages exceeding this limit are silently truncated.
+ * Messages exceeding this limit are truncated and suffixed with an
+ * ellipsis ("…") so downstream readers can tell the message was cut.
  */
 export const MAX_LOG_MESSAGE_LEN = 4096;
 

--- a/.claude/skills/src/tool-definitions.ts
+++ b/.claude/skills/src/tool-definitions.ts
@@ -418,7 +418,7 @@ export function createLogTool(): McpToolDefinition {
 - result_summary — Outcome of a completed workflow
 - note — Free-form annotation
 
-⚠️ CAUTION: Keep messages concise. Max ${MAX_LOG_MESSAGE_LEN} chars (truncated silently). Newlines are collapsed to spaces. Logging never fails the workflow.`,
+⚠️ CAUTION: Keep messages concise. Max ${MAX_LOG_MESSAGE_LEN} chars (longer messages are truncated and suffixed with "…"). Newlines are collapsed to spaces. Logging never fails the workflow.`,
     inputSchema: {
       type: "object",
       properties: {

--- a/.claude/skills/src/tool-handlers.ts
+++ b/.claude/skills/src/tool-handlers.ts
@@ -1383,18 +1383,23 @@ export async function handleLogCall(
     return errorResult("message must be a non-empty string.");
   }
 
-  // Trim, strip newlines, and truncate if needed (use Array.from for Unicode-safe truncation)
+  // Trim, strip newlines, and truncate if needed (use Array.from for Unicode-safe truncation).
+  // Append a visible ellipsis marker so downstream readers of the log can tell
+  // the message was cut — silent truncation masks reproducibility issues in pipeline manifests.
   const sanitized = rawMessage.trim().replace(/[\r\n]+/g, " ");
-  // Fast path: if UTF-16 length is within limit, codepoint count is too
+  const TRUNCATION_MARKER = "…";
   let message: string;
+  // Fast path: if UTF-16 length is within limit, codepoint count is too
   if (sanitized.length <= MAX_LOG_MESSAGE_LEN) {
     message = sanitized;
   } else {
     const codepoints = Array.from(sanitized);
-    message =
-      codepoints.length > MAX_LOG_MESSAGE_LEN
-        ? codepoints.slice(0, MAX_LOG_MESSAGE_LEN).join("")
-        : sanitized;
+    if (codepoints.length > MAX_LOG_MESSAGE_LEN) {
+      const budget = MAX_LOG_MESSAGE_LEN - TRUNCATION_MARKER.length;
+      message = codepoints.slice(0, budget).join("") + TRUNCATION_MARKER;
+    } else {
+      message = sanitized;
+    }
   }
 
   const logId = `u-${randomUUID()}`;

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -272,6 +272,21 @@ describe("enhanceDescription", () => {
     assert.ok(result.includes("Run 2nd"));
   });
 
+  test("uses 📊 emoji for statsAware commonPattern", () => {
+    // frequency is tagged statsAware:true in command-guidance.yaml
+    const result = enhanceDescription(makeSkill("frequency"));
+    assert.ok(result.includes("\u{1F4CA}"), "expected 📊 emoji for statsAware command"); // 📊
+    assert.ok(!result.includes("\u{1F4CB} Stats"), "📋 must not be used for a statsAware pattern"); // 📋
+  });
+
+  test("subcommand hint comes from YAML, not hardcoded", () => {
+    // cat has subcommandHint set in command-guidance.yaml
+    const guidance = getCommandGuidance()["cat"];
+    assert.ok(guidance?.subcommandHint, "cat should have subcommandHint in YAML");
+    const result = enhanceDescription(makeSkill("cat"));
+    assert.ok(result.includes(guidance!.subcommandHint!));
+  });
+
   test("adds memory warning for full-memory commands", () => {
     const result = enhanceDescription(
       makeSkill("dedup", { hints: { memory: "full" as const } }),

--- a/.claude/skills/tests/command-guidance.test.ts
+++ b/.claude/skills/tests/command-guidance.test.ts
@@ -276,7 +276,7 @@ describe("enhanceDescription", () => {
     // frequency is tagged statsAware:true in command-guidance.yaml
     const result = enhanceDescription(makeSkill("frequency"));
     assert.ok(result.includes("\u{1F4CA}"), "expected 📊 emoji for statsAware command"); // 📊
-    assert.ok(!result.includes("\u{1F4CB} Stats"), "📋 must not be used for a statsAware pattern"); // 📋
+    assert.ok(!result.includes("\u{1F4CB}"), "📋 must not appear at all for a statsAware command"); // 📋
   });
 
   test("subcommand hint comes from YAML, not hardcoded", () => {


### PR DESCRIPTION

Reconciles README/manifest counts with the actual 53 skills and 71 qsv commands so users aren't misled about tool coverage. Replaces hardcoded cat/geocode subcommand branches and implicit stats-awareness with YAML fields (subcommandHint, statsAware) so new commands can opt in without code changes, and surfaces the documented 📊 emoji for stats-aware commonPatterns. Appends a visible "…" when qsv-log messages exceed MAX_LOG_MESSAGE_LEN so truncated entries are identifiable in pipeline manifests instead of silently cut.