### PR TITLE
refactor(moarstats): safety fixes, perf cleanup, and unit tests

### DIFF
--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -1882,7 +1882,9 @@ fn compute_entropy_from_counts(counts: &HashMap<String, u64>, total: u64) -> Opt
 
 /// Compute normalized mutual information from mutual information and entropies
 /// NMI = MI / sqrt(H(X) * H(Y))
-/// Returns None if either entropy is invalid (0, negative, or None) or if the denominator is 0
+/// Returns None if either entropy is invalid (0, negative, or None) or if the denominator
+/// is smaller than f64::EPSILON (guards against subnormal products from extremely low
+/// entropies producing Inf/NaN).
 fn compute_normalized_mutual_information(
     mi: Option<f64>,
     h_x: Option<f64>,
@@ -2352,8 +2354,12 @@ where
 
             // Only compute frequency counts if needed for mutual information
             if needs_freq_counts {
-                // Optimization #2 & #6: String interning - get() first (borrowing),
-                // only clone on cache hit; insert + 1 clone on cache miss (cold path)
+                // NOTE: this is not true string interning — each lookup still yields
+                // a cloned String (needed because xy_counts keys by owned tuples).
+                // The benefit over the prior HashMap<String, String> form is just
+                // one fewer clone on insert (cache miss). A future change to
+                // Arc<str> or SmolStr would give real interning (cheap clones on
+                // cache hit), at the cost of a wider refactor of xy_counts.
                 let x_str_interned = if let Some(cached) = string_interner.get(x_str) {
                     cached.clone()
                 } else {
@@ -3108,9 +3114,9 @@ fn compute_all_bivariatestats_sequential(
 
                 // Only compute frequency counts if needed for mutual information
                 if needs_freq_counts {
-                    // Optimization #2 & #6: Reduce string allocations using string interning
-                    // Intern strings - get() first (borrowing), only clone on cache hit;
-                    // insert + 1 clone on cache miss (cold path)
+                    // See note in compute_chunk_bivariate: this is not true interning —
+                    // each cache hit still clones the full String. The only saving
+                    // over ad-hoc cloning is one fewer clone on insert (cache miss).
                     let x_str = if let Some(cached) = string_interner.get(value_str_x) {
                         cached.clone()
                     } else {

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -340,7 +340,7 @@ use std::{
 
 use crossbeam_channel;
 use csv::{ReaderBuilder, StringRecord, WriterBuilder};
-use foldhash::{HashMap, HashMapExt, HashSet};
+use foldhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use indexmap::IndexMap;
 use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use qsv_dateparser::parse_with_preference;
@@ -351,6 +351,12 @@ use stats::{atkinson, gini, kurtosis};
 use threadpool::ThreadPool;
 
 use crate::{CliError, CliResult, config::Config, regex_oncelock, util};
+
+/// Minimum record count before parallel processing is worthwhile for outliers and
+/// bivariate stats. Below this, the scheduling overhead outweighs the speedup, so
+/// fall back to the sequential path.
+const PARALLEL_THRESHOLD: usize = 10_000;
+
 #[derive(Debug, Deserialize)]
 struct Args {
     arg_input:                  Option<String>,
@@ -1367,11 +1373,21 @@ struct OutlierFieldInfo {
     upper_threshold: f64, // For winsorization/trimming (Q3 or percentile)
 }
 
+// Indices into `OutlierStats::counts` (keep in sync with OUTLIER_COUNTS_LEN).
+const OUTLIER_EXTREME_LOWER: usize = 0;
+const OUTLIER_MILD_LOWER: usize = 1;
+const OUTLIER_NORMAL: usize = 2;
+const OUTLIER_MILD_UPPER: usize = 3;
+const OUTLIER_EXTREME_UPPER: usize = 4;
+const OUTLIER_TOTAL: usize = 5;
+const OUTLIER_COUNTS_LEN: usize = 6;
+
 /// Statistics tracked during outlier scanning
 #[derive(Clone, Default)]
 struct OutlierStats {
-    // Counts: [extreme_lower, mild_lower, normal, mild_upper, extreme_upper, total]
-    counts:                 [u64; 6],
+    // Counts indexed by OUTLIER_{EXTREME_LOWER, MILD_LOWER, NORMAL, MILD_UPPER, EXTREME_UPPER,
+    // TOTAL}
+    counts:                 [u64; OUTLIER_COUNTS_LEN],
     // Sums
     sum_outliers:           f64,
     sum_normal:             f64,
@@ -1787,7 +1803,9 @@ fn compute_kendall_tau(x: &[f64], y: &[f64]) -> Option<f64> {
     let n1 = ties_x as f64;
     let n2 = ties_y as f64;
 
-    let denominator = ((n0 - n1) * (n0 - n2)).sqrt();
+    // Clamp factors to >= 0 to guard against tiny negative values from rounding
+    // on tie-heavy data, which would otherwise produce sqrt(NaN).
+    let denominator = ((n0 - n1).max(0.0) * (n0 - n2).max(0.0)).sqrt();
 
     if denominator.abs() < f64::EPSILON {
         return None;
@@ -1867,7 +1885,7 @@ fn compute_normalized_mutual_information(
 
     // Compute denominator: sqrt(H(X) * H(Y))
     let denominator = (h_x_val * h_y_val).sqrt();
-    if denominator == 0.0 {
+    if denominator < f64::EPSILON {
         return None;
     }
 
@@ -1981,35 +1999,35 @@ where
 
             // Count outliers and track statistics based on fence comparisons
             if val < field_info.lower_outer {
-                stats.counts[0] += 1; // extreme_lower
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_EXTREME_LOWER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
                 stats.max_outliers = Some(stats.max_outliers.map_or(val, |m| m.max(val)));
             } else if val < field_info.lower_inner {
-                stats.counts[1] += 1; // mild_lower
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_MILD_LOWER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
                 stats.max_outliers = Some(stats.max_outliers.map_or(val, |m| m.max(val)));
             } else if val <= field_info.upper_inner {
-                stats.counts[2] += 1; // normal
+                stats.counts[OUTLIER_NORMAL] += 1;
                 stats.sum_normal += val;
                 stats.sum_squares_normal = val.mul_add(val, stats.sum_squares_normal);
                 stats.min_normal = Some(stats.min_normal.map_or(val, |m| m.min(val)));
                 stats.max_normal = Some(stats.max_normal.map_or(val, |m| m.max(val)));
             } else if val <= field_info.upper_outer {
-                stats.counts[3] += 1; // mild_upper
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_MILD_UPPER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
                 stats.max_outliers = Some(stats.max_outliers.map_or(val, |m| m.max(val)));
             } else {
-                stats.counts[4] += 1; // extreme_upper
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_EXTREME_UPPER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
@@ -2047,8 +2065,8 @@ fn count_all_outliers(
             return Ok(HashMap::new());
         }
 
-        // Only parallelize if file is large enough (threshold: 10k records)
-        if idx_count < 10_000 {
+        // Only parallelize if file is large enough
+        if idx_count < PARALLEL_THRESHOLD {
             // Fall back to sequential for small files
             let mut rdr = rconfig.reader_file()?;
             let _headers = rdr.headers()?.clone();
@@ -2108,7 +2126,7 @@ fn count_all_outliers(
             for (field_name, stats) in chunk_stats {
                 if let Some(total_stats) = all_stats.get_mut(&field_name) {
                     // Aggregate counts
-                    for i in 0..6 {
+                    for i in 0..OUTLIER_COUNTS_LEN {
                         total_stats.counts[i] += stats.counts[i];
                     }
                     // Aggregate sums
@@ -2218,12 +2236,13 @@ where
     // Optimization #1: Date parsing cache - Cache parsed dates to avoid re-parsing same strings
     let mut date_cache: HashMap<String, Option<f64>> = HashMap::with_capacity(estimated_capacity);
 
-    // Optimization #6: String interning - Cache frequently used strings to reduce allocations
-    // Only needed if we're computing mutual information
-    let mut string_interner: HashMap<String, String> = if needs_freq_counts {
-        HashMap::with_capacity(estimated_unique_strings)
+    // Optimization #6: String interning - Cache frequently used strings to reduce allocations.
+    // Only needed if we're computing mutual information. A HashSet suffices since key==value;
+    // saves one clone per cache miss over the prior HashMap<String, String> form.
+    let mut string_interner: HashSet<String> = if needs_freq_counts {
+        HashSet::with_capacity(estimated_unique_strings)
     } else {
-        HashMap::new()
+        HashSet::new()
     };
 
     #[allow(unused_assignments)]
@@ -2318,19 +2337,19 @@ where
             // Only compute frequency counts if needed for mutual information
             if needs_freq_counts {
                 // Optimization #2 & #6: String interning - get() first (borrowing),
-                // only clone on cache hit; insert + 2 clones on cache miss (cold path)
+                // only clone on cache hit; insert + 1 clone on cache miss (cold path)
                 let x_str_interned = if let Some(cached) = string_interner.get(x_str) {
                     cached.clone()
                 } else {
                     let owned = x_str.clone();
-                    string_interner.insert(owned.clone(), owned.clone());
+                    string_interner.insert(owned.clone());
                     owned
                 };
                 let y_str_interned = if let Some(cached) = string_interner.get(y_str) {
                     cached.clone()
                 } else {
                     let owned = y_str.clone();
-                    string_interner.insert(owned.clone(), owned.clone());
+                    string_interner.insert(owned.clone());
                     owned
                 };
 
@@ -2445,35 +2464,35 @@ fn count_all_outliers_from_reader(
 
             // Count outliers and track statistics based on fence comparisons
             if val < field_info.lower_outer {
-                stats.counts[0] += 1; // extreme_lower
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_EXTREME_LOWER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
                 stats.max_outliers = Some(stats.max_outliers.map_or(val, |m| m.max(val)));
             } else if val < field_info.lower_inner {
-                stats.counts[1] += 1; // mild_lower
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_MILD_LOWER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
                 stats.max_outliers = Some(stats.max_outliers.map_or(val, |m| m.max(val)));
             } else if val <= field_info.upper_inner {
-                stats.counts[2] += 1; // normal
+                stats.counts[OUTLIER_NORMAL] += 1;
                 stats.sum_normal += val;
                 stats.sum_squares_normal = val.mul_add(val, stats.sum_squares_normal);
                 stats.min_normal = Some(stats.min_normal.map_or(val, |m| m.min(val)));
                 stats.max_normal = Some(stats.max_normal.map_or(val, |m| m.max(val)));
             } else if val <= field_info.upper_outer {
-                stats.counts[3] += 1; // mild_upper
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_MILD_UPPER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
                 stats.max_outliers = Some(stats.max_outliers.map_or(val, |m| m.max(val)));
             } else {
-                stats.counts[4] += 1; // extreme_upper
-                stats.counts[5] += 1; // total
+                stats.counts[OUTLIER_EXTREME_UPPER] += 1;
+                stats.counts[OUTLIER_TOTAL] += 1;
                 stats.sum_outliers += val;
                 stats.sum_squares_outliers = val.mul_add(val, stats.sum_squares_outliers);
                 stats.min_outliers = Some(stats.min_outliers.map_or(val, |m| m.min(val)));
@@ -2522,8 +2541,8 @@ fn compute_all_bivariatestats(
             return Ok(HashMap::new());
         }
 
-        // Only parallelize if file is large enough (threshold: 10k records)
-        if idx_count < 10_000 {
+        // Only parallelize if file is large enough
+        if idx_count < PARALLEL_THRESHOLD {
             // Fall back to sequential for small files
             let mut rdr = rconfig.reader_file()?;
             let _headers = rdr.headers()?.clone();
@@ -2680,94 +2699,111 @@ fn compute_all_bivariatestats(
         // Finalize statistics from aggregated chunk stats (parallelized)
         let final_stats: HashMap<(u16, u16), BivariateStats> = all_stats
             .into_par_iter()
-            .map(|(pair_key, chunk_stats)| {
-                if let Some(pb) = progress {
-                    pb.inc(1);
-                }
-                let n_pairs = chunk_stats
-                    .correlation_state
-                    .count
-                    .max(chunk_stats.total_pairs);
+            .map(
+                |(pair_key, chunk_stats)| -> CliResult<((u16, u16), BivariateStats)> {
+                    if let Some(pb) = progress {
+                        pb.inc(1);
+                    }
+                    let n_pairs = chunk_stats
+                        .correlation_state
+                        .count
+                        .max(chunk_stats.total_pairs);
 
-                // Get field info for this pair to check cardinality threshold
-                let (field1_info, field2_info) = field_pairs
-                    .get(&pair_key)
-                    .unwrap_or_else(|| panic!("Field pair not found: {pair_key:?}"));
+                    // Get field info for this pair to check cardinality threshold.
+                    // chunk_stats is pre-populated from field_pairs (see debug_assert!s earlier),
+                    // so a miss here indicates an invariant violation from a refactor.
+                    let (field1_info, field2_info) =
+                        field_pairs.get(&pair_key).ok_or_else(|| {
+                            CliError::Other(format!(
+                                "Invariant violation: field pair not found: {pair_key:?}"
+                            ))
+                        })?;
 
-                // Early exit: skip all correlation/covariance computations if variance is zero
-                let has_zero_variance = field1_info.stddev.is_some_and(|s| s.abs() < f64::EPSILON)
-                    || field2_info.stddev.is_some_and(|s| s.abs() < f64::EPSILON)
-                    || field1_info.variance.is_some_and(|v| v.abs() < f64::EPSILON)
-                    || field2_info.variance.is_some_and(|v| v.abs() < f64::EPSILON);
+                    // Early exit: skip all correlation/covariance computations if variance is zero
+                    let has_zero_variance =
+                        field1_info.stddev.is_some_and(|s| s.abs() < f64::EPSILON)
+                            || field2_info.stddev.is_some_and(|s| s.abs() < f64::EPSILON)
+                            || field1_info.variance.is_some_and(|v| v.abs() < f64::EPSILON)
+                            || field2_info.variance.is_some_and(|v| v.abs() < f64::EPSILON);
 
-                // Compute Pearson correlation if requested
-                let pearson = if !stats_config.pearson
-                    || has_zero_variance
-                    || chunk_stats.correlation_state.count < 2
-                {
-                    None
-                } else {
-                    finalize_pearson_correlation(&chunk_stats.correlation_state)
-                };
+                    // Compute Pearson correlation if requested
+                    let pearson = if !stats_config.pearson
+                        || has_zero_variance
+                        || chunk_stats.correlation_state.count < 2
+                    {
+                        None
+                    } else {
+                        finalize_pearson_correlation(&chunk_stats.correlation_state)
+                    };
 
-                // Compute covariance if requested
-                let covariance_sample = if !stats_config.covariance
-                    || has_zero_variance
-                    || chunk_stats.correlation_state.count < 2
-                {
-                    None
-                } else {
-                    finalize_covariance(&chunk_stats.correlation_state, true)
-                };
-                let covariance_population = if !stats_config.covariance
-                    || has_zero_variance
-                    || chunk_stats.correlation_state.count < 2
-                {
-                    None
-                } else {
-                    finalize_covariance(&chunk_stats.correlation_state, false)
-                };
+                    // Compute covariance if requested
+                    let covariance_sample = if !stats_config.covariance
+                        || has_zero_variance
+                        || chunk_stats.correlation_state.count < 2
+                    {
+                        None
+                    } else {
+                        finalize_covariance(&chunk_stats.correlation_state, true)
+                    };
+                    let covariance_population = if !stats_config.covariance
+                        || has_zero_variance
+                        || chunk_stats.correlation_state.count < 2
+                    {
+                        None
+                    } else {
+                        finalize_covariance(&chunk_stats.correlation_state, false)
+                    };
 
-                // Compute Spearman correlation if requested
-                let spearman = if !stats_config.spearman
-                    || has_zero_variance
-                    || chunk_stats.x_values.len() < 2
-                {
-                    None
-                } else {
-                    compute_spearman_correlation(&chunk_stats.x_values, &chunk_stats.y_values)
-                };
+                    // Compute Spearman correlation if requested
+                    let spearman = if !stats_config.spearman
+                        || has_zero_variance
+                        || chunk_stats.x_values.len() < 2
+                    {
+                        None
+                    } else {
+                        compute_spearman_correlation(&chunk_stats.x_values, &chunk_stats.y_values)
+                    };
 
-                // Compute Kendall's tau if requested
-                let kendall =
-                    if !stats_config.kendall || has_zero_variance || chunk_stats.x_values.len() < 2
+                    // Compute Kendall's tau if requested
+                    let kendall = if !stats_config.kendall
+                        || has_zero_variance
+                        || chunk_stats.x_values.len() < 2
                     {
                         None
                     } else {
                         compute_kendall_tau(&chunk_stats.x_values, &chunk_stats.y_values)
                     };
 
-                // Compute mutual information if requested and apply cardinality threshold
-                let mutual_information = if !stats_config.mi || chunk_stats.total_pairs == 0 {
-                    None
-                } else if let Some(threshold) = cardinality_threshold {
-                    // Check if either field exceeds cardinality threshold
-                    let exceeds_threshold = field1_info.cardinality.is_some_and(|c| c > threshold)
-                        || field2_info.cardinality.is_some_and(|c| c > threshold);
-                    if exceeds_threshold {
-                        // Convert indices to names for logging (u16 -> usize for indexing)
-                        let (idx1, idx2) = pair_key;
-                        let field1_name = field_names
-                            .get(idx1 as usize)
-                            .map_or("?", std::string::String::as_str);
-                        let field2_name = field_names
-                            .get(idx2 as usize)
-                            .map_or("?", std::string::String::as_str);
-                        log::debug!(
-                            "Skipping mutual information for pair ({field1_name}, {field2_name}) \
-                             - cardinality exceeds threshold {threshold}"
-                        );
+                    // Compute mutual information if requested and apply cardinality threshold
+                    let mutual_information = if !stats_config.mi || chunk_stats.total_pairs == 0 {
                         None
+                    } else if let Some(threshold) = cardinality_threshold {
+                        // Check if either field exceeds cardinality threshold
+                        let exceeds_threshold =
+                            field1_info.cardinality.is_some_and(|c| c > threshold)
+                                || field2_info.cardinality.is_some_and(|c| c > threshold);
+                        if exceeds_threshold {
+                            // Convert indices to names for logging (u16 -> usize for indexing)
+                            let (idx1, idx2) = pair_key;
+                            let field1_name = field_names
+                                .get(idx1 as usize)
+                                .map_or("?", std::string::String::as_str);
+                            let field2_name = field_names
+                                .get(idx2 as usize)
+                                .map_or("?", std::string::String::as_str);
+                            log::debug!(
+                                "Skipping mutual information for pair ({field1_name}, \
+                                 {field2_name}) - cardinality exceeds threshold {threshold}"
+                            );
+                            None
+                        } else {
+                            compute_mutual_information_from_counts(
+                                &chunk_stats.xy_counts,
+                                &chunk_stats.x_counts,
+                                &chunk_stats.y_counts,
+                                chunk_stats.total_pairs,
+                            )
+                        }
                     } else {
                         compute_mutual_information_from_counts(
                             &chunk_stats.xy_counts,
@@ -2775,40 +2811,56 @@ fn compute_all_bivariatestats(
                             &chunk_stats.y_counts,
                             chunk_stats.total_pairs,
                         )
-                    }
-                } else {
-                    compute_mutual_information_from_counts(
-                        &chunk_stats.xy_counts,
-                        &chunk_stats.x_counts,
-                        &chunk_stats.y_counts,
-                        chunk_stats.total_pairs,
-                    )
-                };
+                    };
 
-                // Compute normalized mutual information if requested
-                // NMI requires MI and entropies computed from the same frequency counts
-                let normalized_mutual_information = if !stats_config.nmi
-                    || chunk_stats.total_pairs == 0
-                {
-                    None
-                } else if let Some(threshold) = cardinality_threshold {
-                    // Check if either field exceeds cardinality threshold (same as MI)
-                    let exceeds_threshold = field1_info.cardinality.is_some_and(|c| c > threshold)
-                        || field2_info.cardinality.is_some_and(|c| c > threshold);
-                    if exceeds_threshold {
-                        // Convert indices to names for logging (u16 -> usize for indexing)
-                        let (idx1, idx2) = pair_key;
-                        let field1_name = field_names
-                            .get(idx1 as usize)
-                            .map_or("?", std::string::String::as_str);
-                        let field2_name = field_names
-                            .get(idx2 as usize)
-                            .map_or("?", std::string::String::as_str);
-                        log::debug!(
-                            "Skipping normalized mutual information for pair ({field1_name}, \
-                             {field2_name}) - cardinality exceeds threshold {threshold}"
-                        );
+                    // Compute normalized mutual information if requested
+                    // NMI requires MI and entropies computed from the same frequency counts
+                    let normalized_mutual_information = if !stats_config.nmi
+                        || chunk_stats.total_pairs == 0
+                    {
                         None
+                    } else if let Some(threshold) = cardinality_threshold {
+                        // Check if either field exceeds cardinality threshold (same as MI)
+                        let exceeds_threshold =
+                            field1_info.cardinality.is_some_and(|c| c > threshold)
+                                || field2_info.cardinality.is_some_and(|c| c > threshold);
+                        if exceeds_threshold {
+                            // Convert indices to names for logging (u16 -> usize for indexing)
+                            let (idx1, idx2) = pair_key;
+                            let field1_name = field_names
+                                .get(idx1 as usize)
+                                .map_or("?", std::string::String::as_str);
+                            let field2_name = field_names
+                                .get(idx2 as usize)
+                                .map_or("?", std::string::String::as_str);
+                            log::debug!(
+                                "Skipping normalized mutual information for pair ({field1_name}, \
+                                 {field2_name}) - cardinality exceeds threshold {threshold}"
+                            );
+                            None
+                        } else {
+                            // Compute entropies from marginal frequency counts
+                            let h_x = compute_entropy_from_counts(
+                                &chunk_stats.x_counts,
+                                chunk_stats.total_pairs,
+                            );
+                            let h_y = compute_entropy_from_counts(
+                                &chunk_stats.y_counts,
+                                chunk_stats.total_pairs,
+                            );
+                            // Compute MI if not already computed (needed for NMI)
+                            let mi = if mutual_information.is_some() {
+                                mutual_information
+                            } else {
+                                compute_mutual_information_from_counts(
+                                    &chunk_stats.xy_counts,
+                                    &chunk_stats.x_counts,
+                                    &chunk_stats.y_counts,
+                                    chunk_stats.total_pairs,
+                                )
+                            };
+                            compute_normalized_mutual_information(mi, h_x, h_y)
+                        }
                     } else {
                         // Compute entropies from marginal frequency counts
                         let h_x = compute_entropy_from_counts(
@@ -2831,42 +2883,24 @@ fn compute_all_bivariatestats(
                             )
                         };
                         compute_normalized_mutual_information(mi, h_x, h_y)
-                    }
-                } else {
-                    // Compute entropies from marginal frequency counts
-                    let h_x =
-                        compute_entropy_from_counts(&chunk_stats.x_counts, chunk_stats.total_pairs);
-                    let h_y =
-                        compute_entropy_from_counts(&chunk_stats.y_counts, chunk_stats.total_pairs);
-                    // Compute MI if not already computed (needed for NMI)
-                    let mi = if mutual_information.is_some() {
-                        mutual_information
-                    } else {
-                        compute_mutual_information_from_counts(
-                            &chunk_stats.xy_counts,
-                            &chunk_stats.x_counts,
-                            &chunk_stats.y_counts,
-                            chunk_stats.total_pairs,
-                        )
                     };
-                    compute_normalized_mutual_information(mi, h_x, h_y)
-                };
 
-                (
-                    pair_key,
-                    BivariateStats {
-                        pearson,
-                        spearman,
-                        kendall,
-                        covariance_sample,
-                        covariance_population,
-                        mutual_information,
-                        normalized_mutual_information,
-                        n_pairs,
-                    },
-                )
-            })
-            .collect();
+                    Ok((
+                        pair_key,
+                        BivariateStats {
+                            pearson,
+                            spearman,
+                            kendall,
+                            covariance_sample,
+                            covariance_population,
+                            mutual_information,
+                            normalized_mutual_information,
+                            n_pairs,
+                        },
+                    ))
+                },
+            )
+            .collect::<CliResult<HashMap<_, _>>>()?;
 
         // Finish progress bar after final statistics computation
         if let Some(pb) = progress {
@@ -2961,12 +2995,13 @@ fn compute_all_bivariatestats_sequential(
     // Optimization #1: Date parsing cache - Cache parsed dates to avoid re-parsing same strings
     let mut date_cache: HashMap<String, Option<f64>> = HashMap::with_capacity(estimated_capacity);
 
-    // Optimization #6: String interning - Cache frequently used strings to reduce allocations
-    // Only needed if we're computing mutual information
-    let mut string_interner: HashMap<String, String> = if needs_freq_counts {
-        HashMap::with_capacity(estimated_unique_strings)
+    // Optimization #6: String interning - Cache frequently used strings to reduce allocations.
+    // Only needed if we're computing mutual information. A HashSet suffices since key==value;
+    // saves one clone per cache miss over the prior HashMap<String, String> form.
+    let mut string_interner: HashSet<String> = if needs_freq_counts {
+        HashSet::with_capacity(estimated_unique_strings)
     } else {
-        HashMap::new()
+        HashSet::new()
     };
 
     // amortize allocations
@@ -3054,19 +3089,19 @@ fn compute_all_bivariatestats_sequential(
                 if needs_freq_counts {
                     // Optimization #2 & #6: Reduce string allocations using string interning
                     // Intern strings - get() first (borrowing), only clone on cache hit;
-                    // insert + 2 clones on cache miss (cold path)
+                    // insert + 1 clone on cache miss (cold path)
                     let x_str = if let Some(cached) = string_interner.get(value_str_x) {
                         cached.clone()
                     } else {
                         let owned = value_str_x.to_string();
-                        string_interner.insert(owned.clone(), owned.clone());
+                        string_interner.insert(owned.clone());
                         owned
                     };
                     let y_str = if let Some(cached) = string_interner.get(value_str_y) {
                         cached.clone()
                     } else {
                         let owned = value_str_y.to_string();
-                        string_interner.insert(owned.clone(), owned.clone());
+                        string_interner.insert(owned.clone());
                         owned
                     };
 
@@ -3092,10 +3127,14 @@ fn compute_all_bivariatestats_sequential(
 
     for (pair_key, (x_nums, y_nums, correlation_state, xy_counts, _, _, total_pairs)) in pair_values
     {
-        // Get field info for this pair to check variance and cardinality
-        let (field1_info, field2_info) = field_pairs
-            .get(&pair_key)
-            .unwrap_or_else(|| panic!("Field pair not found: {pair_key:?}"));
+        // Get field info for this pair to check variance and cardinality.
+        // pair_values was built from field_pairs keys (see debug_assert!s earlier),
+        // so a miss here indicates an invariant violation from a refactor.
+        let (field1_info, field2_info) = field_pairs.get(&pair_key).ok_or_else(|| {
+            CliError::Other(format!(
+                "Invariant violation: field pair not found: {pair_key:?}"
+            ))
+        })?;
 
         // Compute marginal frequencies from joint frequencies if needed for mutual information
         // This ensures x_counts and y_counts are computed from the same set of records
@@ -3672,7 +3711,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let stats_args_vec: Vec<&str> = args.flag_stats_options.split_whitespace().collect();
         let mut stats_cmd_args = stats_args_vec.clone();
         stats_cmd_args.push("--output");
-        stats_cmd_args.push(temp_stats_path.to_str().unwrap());
+        let temp_stats_path_str = temp_stats_path
+            .to_str()
+            .ok_or_else(|| CliError::Other("Invalid temp stats path".to_string()))?;
+        stats_cmd_args.push(temp_stats_path_str);
 
         let qsv_path = env::current_exe()
             .map_err(|e| CliError::Other(format!("Failed to get current executable path: {e:?}")))?
@@ -4630,20 +4672,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             BivariateFieldInfo {
                                 col_idx:     field1_col_idx,
                                 field_type:  field1_type,
-                                // mean:        field1_mean,
                                 stddev:      field1_stddev,
                                 variance:    field1_variance,
                                 cardinality: field1_cardinality,
-                                // nullcount:   field1_nullcount,
                             },
                             BivariateFieldInfo {
                                 col_idx:     field2_col_idx,
                                 field_type:  field2_type,
-                                // mean:        field2_mean,
                                 stddev:      field2_stddev,
                                 variance:    field2_variance,
                                 cardinality: field2_cardinality,
-                                // nullcount:   field2_nullcount,
                             },
                         ),
                     );
@@ -5212,32 +5250,32 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             {
                 // Write counts (with _cnt suffix)
                 if let Some(idx) = new_column_indices.get("outliers_extreme_lower_cnt") {
-                    new_values[*idx] = stats.counts[0].to_string();
+                    new_values[*idx] = stats.counts[OUTLIER_EXTREME_LOWER].to_string();
                 }
                 if let Some(idx) = new_column_indices.get("outliers_mild_lower_cnt") {
-                    new_values[*idx] = stats.counts[1].to_string();
+                    new_values[*idx] = stats.counts[OUTLIER_MILD_LOWER].to_string();
                 }
                 if let Some(idx) = new_column_indices.get("outliers_normal_cnt") {
-                    new_values[*idx] = stats.counts[2].to_string();
+                    new_values[*idx] = stats.counts[OUTLIER_NORMAL].to_string();
                 }
                 if let Some(idx) = new_column_indices.get("outliers_mild_upper_cnt") {
-                    new_values[*idx] = stats.counts[3].to_string();
+                    new_values[*idx] = stats.counts[OUTLIER_MILD_UPPER].to_string();
                 }
                 if let Some(idx) = new_column_indices.get("outliers_extreme_upper_cnt") {
-                    new_values[*idx] = stats.counts[4].to_string();
+                    new_values[*idx] = stats.counts[OUTLIER_EXTREME_UPPER].to_string();
                 }
                 if let Some(idx) = new_column_indices.get("outliers_total_cnt") {
-                    new_values[*idx] = stats.counts[5].to_string();
+                    new_values[*idx] = stats.counts[OUTLIER_TOTAL].to_string();
                 }
 
                 // Compute means
-                let mean_outliers = if stats.counts[5] > 0 {
-                    Some(stats.sum_outliers / stats.counts[5] as f64)
+                let mean_outliers = if stats.counts[OUTLIER_TOTAL] > 0 {
+                    Some(stats.sum_outliers / stats.counts[OUTLIER_TOTAL] as f64)
                 } else {
                     None
                 };
-                let mean_normal = if stats.counts[2] > 0 {
-                    Some(stats.sum_normal / stats.counts[2] as f64)
+                let mean_normal = if stats.counts[OUTLIER_NORMAL] > 0 {
+                    Some(stats.sum_normal / stats.counts[OUTLIER_NORMAL] as f64)
                 } else {
                     None
                 };
@@ -5248,8 +5286,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 };
 
                 // Compute outliers variance and stddev once for reuse
-                let (variance_outliers, stddev_outliers) = if stats.counts[5] > 1 {
-                    let n = stats.counts[5] as f64;
+                let (variance_outliers, stddev_outliers) = if stats.counts[OUTLIER_TOTAL] > 1 {
+                    let n = stats.counts[OUTLIER_TOTAL] as f64;
                     let variance = (stats.sum_squares_outliers
                         - (stats.sum_outliers * stats.sum_outliers / n))
                         / (n - 1.0);
@@ -5306,8 +5344,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     }
 
                     // Variance and stddev of non-outliers
-                    if stats.counts[2] > 1 {
-                        let n = stats.counts[2] as f64;
+                    if stats.counts[OUTLIER_NORMAL] > 1 {
+                        let n = stats.counts[OUTLIER_NORMAL] as f64;
                         let variance_normal = (stats.sum_squares_normal
                             - (stats.sum_normal * stats.sum_normal / n))
                             / (n - 1.0);
@@ -5354,7 +5392,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 if stats.count_all > 0
                     && let Some(idx) = new_column_indices.get("outliers_percentage")
                 {
-                    let percentage = (stats.counts[5] as f64 / stats.count_all as f64) * 100.0;
+                    let percentage =
+                        (stats.counts[OUTLIER_TOTAL] as f64 / stats.count_all as f64) * 100.0;
                     new_values[*idx] = util::round_num(percentage, args.flag_round);
                 }
 

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -222,10 +222,11 @@ automatically deleted after computing the bivariate statistics.
 The bivariate statistics are saved to `<FILESTEM>.stats.bivariate.joined.csv`.
 
 Non-finite numeric tokens ("NaN", "Infinity", "-Infinity", and their case variants) are
-treated as missing values and excluded from all statistical computations. They are counted
-toward the null/missing totals reported by the underlying `stats` command, not as numeric
-observations. This prevents a single bad cell from silently poisoning correlation, variance
-and mean calculations.
+excluded from moarstats computations — the parser in moarstats filters them out before they
+reach correlation, variance and mean calculations, preventing a single bad cell from silently
+poisoning the results. Note that the baseline `stats` command may still count these tokens
+as Float observations, so the `type`/`null_count` columns in `<FILESTEM>.stats.csv` are not
+affected by this filter.
 
 Examples:
 
@@ -2098,8 +2099,8 @@ fn count_all_outliers(
         // Process each chunk in parallel. Share the read-only field map via Arc
         // instead of deep-cloning the HashMap into every worker. Since the caller
         // no longer needs `fields_to_count` after this call, we move it directly
-        // into the Arc — zero map clones.
-        let input_path_string = input_path.to_str().unwrap_or("").to_string();
+        // into the Arc — zero map clones. `input_path_string` from above is already
+        // UTF-8-validated, so no need to re-validate here.
         let fields_arc = Arc::new(fields_to_count);
         for i in 0..nchunks {
             let send = send.clone();
@@ -2598,8 +2599,8 @@ fn compute_all_bivariatestats(
         // Process each chunk in parallel. Share the read-only field-pair map via
         // Arc instead of deep-cloning the HashMap into every worker. The caller
         // no longer needs `field_pairs` after this call, so we move it directly
-        // into the Arc — zero map clones.
-        let input_path_string = input_path.to_str().unwrap_or("").to_string();
+        // into the Arc — zero map clones. `input_path_string` from above is already
+        // UTF-8-validated, so no need to re-validate here.
         let field_pairs_arc = Arc::new(field_pairs);
         for i in 0..nchunks {
             let send = send.clone();

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -221,6 +221,12 @@ that share common join keys. The joined dataset is saved as a temporary file tha
 automatically deleted after computing the bivariate statistics.
 The bivariate statistics are saved to `<FILESTEM>.stats.bivariate.joined.csv`.
 
+Non-finite numeric tokens ("NaN", "Infinity", "-Infinity", and their case variants) are
+treated as missing values and excluded from all statistical computations. They are counted
+toward the null/missing totals reported by the underlying `stats` command, not as numeric
+observations. This prevents a single bad cell from silently poisoning correlation, variance
+and mean calculations.
+
 Examples:
 
   # Add moar stats to existing stats file
@@ -2049,7 +2055,7 @@ where
 /// Count outliers for all fields, using parallel processing if index is available
 /// Returns a HashMap mapping field names to their outlier statistics
 fn count_all_outliers(
-    fields_to_count: &HashMap<String, OutlierFieldInfo>,
+    fields_to_count: HashMap<String, OutlierFieldInfo>,
     input_path: &Path,
     flag_jobs: Option<usize>,
 ) -> CliResult<HashMap<String, OutlierStats>> {
@@ -2077,7 +2083,7 @@ fn count_all_outliers(
             // Fall back to sequential for small files
             let mut rdr = rconfig.reader_file()?;
             let _headers = rdr.headers()?.clone();
-            return count_all_outliers_from_reader(fields_to_count, rdr);
+            return count_all_outliers_from_reader(&fields_to_count, rdr);
         }
 
         let njobs = util::njobs(flag_jobs);
@@ -2090,9 +2096,11 @@ fn count_all_outliers(
         let (send, recv) = crossbeam_channel::bounded(nchunks);
 
         // Process each chunk in parallel. Share the read-only field map via Arc
-        // instead of deep-cloning the HashMap into every worker.
+        // instead of deep-cloning the HashMap into every worker. Since the caller
+        // no longer needs `fields_to_count` after this call, we move it directly
+        // into the Arc — zero map clones.
         let input_path_string = input_path.to_str().unwrap_or("").to_string();
-        let fields_arc = Arc::new(fields_to_count.clone());
+        let fields_arc = Arc::new(fields_to_count);
         for i in 0..nchunks {
             let send = send.clone();
             let fields_arc = Arc::clone(&fields_arc);
@@ -2123,7 +2131,7 @@ fn count_all_outliers(
         drop(send);
 
         // Aggregate results from all chunks
-        let mut all_stats: HashMap<String, OutlierStats> = fields_to_count
+        let mut all_stats: HashMap<String, OutlierStats> = fields_arc
             .keys()
             .map(|k| (k.clone(), OutlierStats::default()))
             .collect();
@@ -2193,7 +2201,7 @@ fn count_all_outliers(
         // Sequential fallback when no index exists
         let mut rdr = rconfig.reader_file()?;
         let _headers = rdr.headers()?.clone();
-        count_all_outliers_from_reader(fields_to_count, rdr)
+        count_all_outliers_from_reader(&fields_to_count, rdr)
     }
 }
 
@@ -2517,7 +2525,7 @@ fn count_all_outliers_from_reader(
 /// Otherwise, uses sequential processing.
 /// Returns a HashMap mapping field pairs to their bivariate statistics.
 fn compute_all_bivariatestats(
-    field_pairs: &HashMap<(u16, u16), (BivariateFieldInfo, BivariateFieldInfo)>,
+    field_pairs: HashMap<(u16, u16), (BivariateFieldInfo, BivariateFieldInfo)>,
     field_names: &[String],
     input_path: &Path,
     progress: Option<&ProgressBar>,
@@ -2555,7 +2563,7 @@ fn compute_all_bivariatestats(
             let _headers = rdr.headers()?.clone();
             winfo!("Computing bivariate statistics sequentially...");
             return compute_all_bivariatestats_sequential(
-                field_pairs,
+                &field_pairs,
                 field_names,
                 rdr,
                 progress,
@@ -2588,9 +2596,11 @@ fn compute_all_bivariatestats(
         let (send, recv) = crossbeam_channel::bounded(nchunks);
 
         // Process each chunk in parallel. Share the read-only field-pair map via
-        // Arc instead of deep-cloning the HashMap into every worker.
+        // Arc instead of deep-cloning the HashMap into every worker. The caller
+        // no longer needs `field_pairs` after this call, so we move it directly
+        // into the Arc — zero map clones.
         let input_path_string = input_path.to_str().unwrap_or("").to_string();
-        let field_pairs_arc = Arc::new(field_pairs.clone());
+        let field_pairs_arc = Arc::new(field_pairs);
         for i in 0..nchunks {
             let send = send.clone();
             let field_pairs_arc = Arc::clone(&field_pairs_arc);
@@ -2622,7 +2632,7 @@ fn compute_all_bivariatestats(
 
         // Aggregate results from all chunks
         // Pre-allocate based on idx_count to avoid repeated reallocations during extend
-        let mut all_stats: HashMap<(u16, u16), BivariateChunkStats> = field_pairs
+        let mut all_stats: HashMap<(u16, u16), BivariateChunkStats> = field_pairs_arc
             .keys()
             .map(|k| {
                 let mut stats = BivariateChunkStats::default();
@@ -2723,7 +2733,7 @@ fn compute_all_bivariatestats(
                     // chunk_stats is pre-populated from field_pairs (see debug_assert!s earlier),
                     // so a miss here indicates an invariant violation from a refactor.
                     let (field1_info, field2_info) =
-                        field_pairs.get(&pair_key).ok_or_else(|| {
+                        field_pairs_arc.get(&pair_key).ok_or_else(|| {
                             CliError::Other(format!(
                                 "Invariant violation: field pair not found: {pair_key:?}"
                             ))
@@ -2923,7 +2933,7 @@ fn compute_all_bivariatestats(
         let mut rdr = rconfig.reader_file()?;
         let _headers = rdr.headers()?.clone();
         compute_all_bivariatestats_sequential(
-            field_pairs,
+            &field_pairs,
             field_names,
             rdr,
             progress,
@@ -4503,8 +4513,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }
         });
 
-        // Count outliers (will use parallel processing if index exists)
-        count_all_outliers(&fields_to_count, actual_input_path, args.flag_jobs)?
+        // Count outliers (will use parallel processing if index exists).
+        // Pass fields_to_count by value so the parallel path can move it
+        // directly into an Arc without an extra deep-clone.
+        count_all_outliers(fields_to_count, actual_input_path, args.flag_jobs)?
     };
 
     // Compute kurtosis, Gini coefficient & Atkinson Index for all fields
@@ -4740,7 +4752,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             );
 
             let result = compute_all_bivariatestats(
-                &field_pairs,
+                field_pairs,
                 &field_names,
                 actual_input_path,
                 progress.as_ref(),

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -5697,3 +5697,90 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_float_opt_filters_nan_and_infinity() {
+        assert_eq!(parse_float_opt(""), None);
+        assert_eq!(parse_float_opt("1.5"), Some(1.5));
+        assert_eq!(parse_float_opt("NaN"), None);
+        assert_eq!(parse_float_opt("nan"), None);
+        assert_eq!(parse_float_opt("Infinity"), None);
+        assert_eq!(parse_float_opt("-Infinity"), None);
+        assert_eq!(parse_float_opt("inf"), None);
+        assert_eq!(parse_float_opt("not a number"), None);
+    }
+
+    #[test]
+    fn parse_float_opt_from_bytes_filters_nan_and_infinity() {
+        assert_eq!(parse_float_opt_from_bytes(b""), None);
+        assert_eq!(parse_float_opt_from_bytes(b"42"), Some(42.0));
+        assert_eq!(parse_float_opt_from_bytes(b"NaN"), None);
+        assert_eq!(parse_float_opt_from_bytes(b"inf"), None);
+    }
+
+    #[test]
+    fn compute_pearson_skewness_handles_zero_stddev() {
+        // Zero stddev -> None (avoid divide-by-zero)
+        assert_eq!(
+            compute_pearson_skewness(Some(5.0), Some(5.0), Some(0.0)),
+            None,
+        );
+        // Any None input -> None
+        assert_eq!(compute_pearson_skewness(None, Some(5.0), Some(1.0)), None);
+        // Normal case: 3 * (mean - median) / stddev
+        assert_eq!(
+            compute_pearson_skewness(Some(10.0), Some(8.0), Some(2.0)),
+            Some(3.0),
+        );
+    }
+
+    #[test]
+    fn compute_kendall_tau_no_nan_on_all_ties() {
+        // All identical values: every pair is a tie in both x and y.
+        // Pre-fix this would produce sqrt(NaN) from rounding making
+        // (n0 - n1) or (n0 - n2) slightly negative.
+        let x = vec![1.0; 10];
+        let y = vec![2.0; 10];
+        let tau = compute_kendall_tau(&x, &y);
+        // Denominator is zero -> None, never NaN.
+        assert!(tau.is_none());
+    }
+
+    #[test]
+    fn compute_kendall_tau_perfect_concordance() {
+        let x: Vec<f64> = (1..=5).map(f64::from).collect();
+        let y: Vec<f64> = (1..=5).map(f64::from).collect();
+        assert_eq!(compute_kendall_tau(&x, &y), Some(1.0));
+    }
+
+    #[test]
+    fn compute_normalized_mutual_information_epsilon_guard() {
+        // h_x = 0 -> None (early guard)
+        assert_eq!(
+            compute_normalized_mutual_information(Some(0.5), Some(0.0), Some(1.0)),
+            None,
+        );
+        // Very small positive entropies that would produce a subnormal
+        // denominator -> None (epsilon guard, not float-equality).
+        let tiny = 1e-200;
+        assert_eq!(
+            compute_normalized_mutual_information(Some(tiny), Some(tiny), Some(tiny)),
+            None,
+        );
+    }
+
+    #[test]
+    fn outlier_count_indices_are_in_range() {
+        // Guard against a refactor changing these without updating COUNTS_LEN.
+        assert!(OUTLIER_EXTREME_LOWER < OUTLIER_COUNTS_LEN);
+        assert!(OUTLIER_MILD_LOWER < OUTLIER_COUNTS_LEN);
+        assert!(OUTLIER_NORMAL < OUTLIER_COUNTS_LEN);
+        assert!(OUTLIER_MILD_UPPER < OUTLIER_COUNTS_LEN);
+        assert!(OUTLIER_EXTREME_UPPER < OUTLIER_COUNTS_LEN);
+        assert!(OUTLIER_TOTAL < OUTLIER_COUNTS_LEN);
+    }
+}

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -2109,18 +2109,29 @@ fn count_all_outliers(
             let fields_arc = Arc::clone(&fields_arc);
             let input_path_string_clone = input_path_string.clone();
             pool.execute(move || {
-                // Open index for this thread
+                // Open index for this thread. If this fails, propagate an error
+                // through the channel — dropping the chunk silently would
+                // under-count outliers without any indication to the user.
                 let rconfig_chunk = Config::new(Some(&input_path_string_clone));
-                // safety: we know the file is indexed and seekable
-                let Ok(Some(mut idx_chunk)) = rconfig_chunk.indexed() else {
-                    // If we can't open index, send empty result
-                    let _ = send.send(Ok(HashMap::new()));
-                    return;
+                let mut idx_chunk = match rconfig_chunk.indexed() {
+                    Ok(Some(idx)) => idx,
+                    Ok(None) => {
+                        let _ = send.send(Err(CliError::Other(format!(
+                            "Chunk {i}: index is not available for {input_path_string_clone}"
+                        ))));
+                        return;
+                    },
+                    Err(e) => {
+                        let _ = send.send(Err(CliError::Other(format!(
+                            "Chunk {i}: failed to open index: {e}"
+                        ))));
+                        return;
+                    },
                 };
 
                 // Seek to chunk start position
                 if let Err(e) = idx_chunk.seek((i * chunk_size) as u64) {
-                    let _ = send.send(Err(CliError::Other(format!("Seek failed: {e}"))));
+                    let _ = send.send(Err(CliError::Other(format!("Chunk {i}: seek failed: {e}"))));
                     return;
                 }
 
@@ -2613,18 +2624,29 @@ fn compute_all_bivariatestats(
             let field_pairs_arc = Arc::clone(&field_pairs_arc);
             let input_path_string_clone = input_path_string.clone();
             pool.execute(move || {
-                // Open index for this thread
+                // Open index for this thread. If this fails, propagate an error
+                // through the channel — dropping the chunk silently would
+                // produce incorrect bivariate stats without any indication.
                 let rconfig_chunk = Config::new(Some(&input_path_string_clone));
-                // safety: we know the file is indexed and seekable
-                let Ok(Some(mut idx_chunk)) = rconfig_chunk.indexed() else {
-                    // If we can't open index, send empty result
-                    let _ = send.send(Ok(HashMap::new()));
-                    return;
+                let mut idx_chunk = match rconfig_chunk.indexed() {
+                    Ok(Some(idx)) => idx,
+                    Ok(None) => {
+                        let _ = send.send(Err(CliError::Other(format!(
+                            "Chunk {i}: index is not available for {input_path_string_clone}"
+                        ))));
+                        return;
+                    },
+                    Err(e) => {
+                        let _ = send.send(Err(CliError::Other(format!(
+                            "Chunk {i}: failed to open index: {e}"
+                        ))));
+                        return;
+                    },
                 };
 
                 // Seek to chunk start position
                 if let Err(e) = idx_chunk.seek((i * chunk_size) as u64) {
-                    let _ = send.send(Err(CliError::Other(format!("Seek failed: {e}"))));
+                    let _ = send.send(Err(CliError::Other(format!("Chunk {i}: seek failed: {e}"))));
                     return;
                 }
 

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -335,6 +335,7 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
     process::Command,
+    sync::Arc,
     time::Instant,
 };
 
@@ -880,7 +881,11 @@ fn parse_float_opt(s: &str) -> Option<f64> {
     if s.is_empty() {
         return None;
     }
-    fast_float2::parse::<f64, &[u8]>(s.as_bytes()).ok()
+    // Filter NaN/±Infinity: a single non-finite cell would poison Welford
+    // correlation state and propagate silently through all downstream statistics.
+    fast_float2::parse::<f64, &[u8]>(s.as_bytes())
+        .ok()
+        .filter(|v| v.is_finite())
 }
 
 /// Parse a numeric value from bytes, handling empty bytes and invalid values
@@ -889,7 +894,9 @@ fn parse_float_opt_from_bytes(bytes: &[u8]) -> Option<f64> {
     if bytes.is_empty() {
         return None;
     }
-    fast_float2::parse::<f64, &[u8]>(bytes).ok()
+    fast_float2::parse::<f64, &[u8]>(bytes)
+        .ok()
+        .filter(|v| v.is_finite())
 }
 
 /// Parse a percentile value from the percentiles column string
@@ -2082,14 +2089,14 @@ fn count_all_outliers(
         let pool = ThreadPool::new(njobs);
         let (send, recv) = crossbeam_channel::bounded(nchunks);
 
-        // Process each chunk in parallel
+        // Process each chunk in parallel. Share the read-only field map via Arc
+        // instead of deep-cloning the HashMap into every worker.
         let input_path_string = input_path.to_str().unwrap_or("").to_string();
+        let fields_arc = Arc::new(fields_to_count.clone());
         for i in 0..nchunks {
-            let (send, fields_to_count_clone, input_path_string_clone) = (
-                send.clone(),
-                fields_to_count.clone(),
-                input_path_string.clone(),
-            );
+            let send = send.clone();
+            let fields_arc = Arc::clone(&fields_arc);
+            let input_path_string_clone = input_path_string.clone();
             pool.execute(move || {
                 // Open index for this thread
                 let rconfig_chunk = Config::new(Some(&input_path_string_clone));
@@ -2108,7 +2115,7 @@ fn count_all_outliers(
 
                 // Process chunk records
                 let it = idx_chunk.byte_records().take(chunk_size);
-                let result = count_chunk_outliers(&fields_to_count_clone, it);
+                let result = count_chunk_outliers(&fields_arc, it);
                 let _ = send.send(result);
             });
         }
@@ -2580,11 +2587,14 @@ fn compute_all_bivariatestats(
         let pool = ThreadPool::new(njobs);
         let (send, recv) = crossbeam_channel::bounded(nchunks);
 
-        // Process each chunk in parallel
+        // Process each chunk in parallel. Share the read-only field-pair map via
+        // Arc instead of deep-cloning the HashMap into every worker.
         let input_path_string = input_path.to_str().unwrap_or("").to_string();
+        let field_pairs_arc = Arc::new(field_pairs.clone());
         for i in 0..nchunks {
-            let (send, field_pairs_clone, input_path_string_clone) =
-                (send.clone(), field_pairs.clone(), input_path_string.clone());
+            let send = send.clone();
+            let field_pairs_arc = Arc::clone(&field_pairs_arc);
+            let input_path_string_clone = input_path_string.clone();
             pool.execute(move || {
                 // Open index for this thread
                 let rconfig_chunk = Config::new(Some(&input_path_string_clone));
@@ -2603,7 +2613,7 @@ fn compute_all_bivariatestats(
 
                 // Process chunk records
                 let it = idx_chunk.byte_records().take(chunk_size);
-                let result = compute_chunk_bivariate(&field_pairs_clone, it, stats_config);
+                let result = compute_chunk_bivariate(&field_pairs_arc, it, stats_config);
                 let _ = send.send(result);
             });
         }


### PR DESCRIPTION
## Summary

Follow-up to the recent \`moarstats\` work (#3654 and subsequent). Splits a code review of \`src/cmd/moarstats.rs\` into three reviewable commits covering safety, perf, and test-coverage wins. No behavior change in the happy path; non-finite inputs are now filtered instead of silently poisoning correlation state.

### 1. \`refactor(moarstats): safety fixes + allocation/const cleanup\` (1eab485)
- Replace \`panic!(\"Field pair not found...\")\` at two sites with \`CliError\` propagation. The parallel rayon closure now returns \`CliResult\` and is \`.collect()\`'d into \`CliResult<HashMap<_,_>>\`. The \`debug_assert!\`s that guard the invariant stay in place.
- Clamp Kendall's tau factors with \`.max(0.0)\` before \`sqrt\` so tie-heavy data can't produce \`sqrt(NaN)\` from rounding.
- NMI: \`denominator == 0.0\` → \`denominator < f64::EPSILON\`, matching the epsilon-comparison pattern used elsewhere in the file.
- \`temp_stats_path.to_str().unwrap()\` → \`ok_or_else(CliError::Other(...))\`.
- Swap \`HashMap<String, String>\` string interner (key == value) for \`HashSet<String>\`, saving one clone per cache miss on the mutual-information hot path.
- Named constants \`OUTLIER_EXTREME_LOWER..OUTLIER_TOTAL\` + \`OUTLIER_COUNTS_LEN\` replace ~25 \`stats.counts[0..=5]\` magic-index sites.
- Promote the duplicated \`10_000\` parallel threshold to \`PARALLEL_THRESHOLD\` const.
- Drop commented-out \`// mean\` / \`// nullcount\` initializers from \`BivariateFieldInfo\` constructors.

### 2. \`perf(moarstats): NaN guard + Arc-share field maps across chunks\` (91cbf04)
- \`parse_float_opt\` / \`parse_float_opt_from_bytes\` now filter non-finite values. Previously a cell that \`fast_float2\` parsed as \`NaN\` or \`±Infinity\` (it accepts the \"nan\"/\"inf\" tokens) would poison Welford correlation state and propagate silently through all downstream statistics.
- Parallel outlier and bivariate paths \`Arc\`-wrap the read-only \`fields_to_count\` / \`field_pairs\` \`HashMap\`s instead of deep-cloning them into every worker — one clone + (nchunks - 1) cheap \`Arc\` clones instead of \`nchunks\` full-map clones.

### 3. \`test(moarstats): unit tests for pure helpers\` (ef26335)
- New \`#[cfg(test)] mod tests\` in \`moarstats.rs\` with 7 unit tests pinning the invariants established above: NaN/Inf rejection in both float parsers, zero-stddev Pearson skew, all-ties Kendall returning \`None\` (not \`NaN\`), perfect-concordance tau, NMI's zero-entropy and epsilon-denominator guards, and \`OUTLIER_*\` index-bounds.

## Deferred (follow-up PRs)

- **Welford-mean for univariate sums** — changes output in the last few ULPs; needs a baseline-comparison run.
- **Parallel/sequential generic core refactor** — \`count_all_outliers\` / \`..._from_reader\` and \`compute_all_bivariatestats\` / \`..._sequential\` collapse to an iterator-generic shared core (~600 lines of duplication). Worth its own PR to agree on the abstraction shape.
- **Submodule split of \`moarstats.rs\`** — best after the dedup above.

## Test plan

- [x] \`cargo build --locked --bin qsv -F all_features\`
- [x] \`cargo test -F all_features test_moarstats\` — all **73** integration tests pass
- [x] \`cargo test --bin qsv -F all_features cmd::moarstats::tests\` — all **7** new unit tests pass
- [x] \`cargo clippy --locked --bin qsv -F all_features -- -D warnings\` — clean
- [ ] Sanity check on a real dataset with the \`--bivariate\` path before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)