### PR TITLE
fix(apply): review-driven fixes — malformed CSV, init bugs, doc typos, perf

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -479,8 +479,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     {
         return fail_incorrectusage_clierror!(
             "--new-column (-c) requires a single input column. For multi-column \
-             operations/emptyreplace, omit --new-column to transform columns in place; \
-             optionally use --rename (-r) to rename the transformed columns."
+             operations/emptyreplace, omit --new-column to transform columns in place; optionally \
+             use --rename (-r) to rename the transformed columns."
         );
     }
     // safety: we just checked that sel is not empty above

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -196,7 +196,7 @@ Examples:
   qsv apply calcconv --formatstr '{col1} % 3' --new-column remainder file.csv
 
   # Convert from one unit to another:
-  qsv apply calcconv --formatstr '{col1} Fahrenheit in Celsius" -c metric_temperature file.csv
+  qsv apply calcconv --formatstr '{col1} Fahrenheit in Celsius' -c metric_temperature file.csv
 
   # Mix units and conversions are automatically done for you:
   qsv apply calcconv --formatstr '{col1}km + {col2}mi in meters' -c meters file.csv
@@ -244,7 +244,7 @@ apply arguments:
                                     See DYNFMT example above for more details.
         --new-column=<name>         Put the generated values in a new column.
 
-    CALCONV subcommand:
+    CALCCONV subcommand:
         --formatstr=<string>        The calculation/conversion expression to use.
         --new-column=<name>         Put the calculated/converted values in a new column.
 
@@ -302,11 +302,9 @@ Common options:
 
 use std::{str::FromStr, sync::OnceLock};
 
-use base62;
 use base64_simd::STANDARD as BASE64;
 use censor::{Censor, Sex, Zealous};
 use cpc::eval;
-use crc32fast;
 use dynfmt2::Format;
 use eudex::Hash;
 use gender_guesser::Gender;
@@ -410,7 +408,6 @@ struct Args {
 }
 
 static CENSOR: OnceLock<Censor> = OnceLock::new();
-static CRC32: OnceLock<crc32fast::Hasher> = OnceLock::new();
 static EUDEX_COMPARAND_HASH: OnceLock<eudex::Hash> = OnceLock::new();
 static REGEX_REPLACE: OnceLock<Regex> = OnceLock::new();
 static SENTIMENT_ANALYZER: OnceLock<SentimentIntensityAnalyzer> = OnceLock::new();
@@ -433,6 +430,12 @@ static INDIANCOMMA_POLICY: SeparatorPolicy = SeparatorPolicy {
     groups:    &[3, 2],
     digits:    thousands::digits::ASCII_DECIMAL,
 };
+
+// shared regex for 3-decimal-place workaround used by currencytonum & numtocurrency
+fn fract_3digits_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\.\d\d\d$").unwrap())
+}
 
 // valid subcommands
 #[derive(PartialEq)]
@@ -464,6 +467,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let sel = rconfig.selection(&headers)?;
     if sel.is_empty() {
         return fail_incorrectusage_clierror!("No columns selected. Column selection is empty.");
+    }
+    // --new-column (-c) appends a single field per row, so it would produce
+    // malformed CSV (one header, N data fields) when combined with multi-column
+    // operations or emptyreplace. Use --rename (-r) for multi-column transforms.
+    if args.flag_new_column.is_some()
+        && (args.cmd_operations || args.cmd_emptyreplace)
+        && sel.len() > 1
+    {
+        return fail_incorrectusage_clierror!(
+            "--new-column (-c) requires a single input column. Use --rename (-r) for \
+             multi-column transformations."
+        );
     }
     // safety: we just checked that sel is not empty above
     let column_index = *sel.iter().next().unwrap();
@@ -547,11 +562,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         wtr.write_record(&headers)?;
     }
 
-    // if there is a regex_replace operation and replacement is <NULL> case-insensitive,
-    // we set it to empty string
+    // <NULL> (case-insensitive) is recognized as "delete matches" when regex_replace is in
+    // the operation chain. Note this clears flag_replacement for ALL ops in the chain, so
+    // a chained `regex_replace,replace` with --replacement <NULL> deletes matches in both.
     let flag_replacement = if apply_cmd == ApplySubCmd::Operations
         && ops_vec.contains(&Operations::Regex_Replace)
-        && args.flag_replacement.to_ascii_lowercase() == NULL_VALUE
+        && args.flag_replacement.eq_ignore_ascii_case(NULL_VALUE)
     {
         String::new()
     } else {
@@ -642,18 +658,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         }
                     },
                     ApplySubCmd::DynFmt => {
-                        let mut cell = record[column_index].to_owned();
-                        if !cell.is_empty() {
-                            let mut record_vec: Vec<String> = Vec::with_capacity(record.len());
-                            for field in &record {
-                                record_vec.push(field.to_string());
-                            }
-                            if let Ok(formatted) =
-                                dynfmt2::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
-                            {
-                                cell = formatted.to_string();
-                            }
-                        }
+                        let record_vec: Vec<&str> = record.iter().collect();
+                        let cell = match dynfmt2::SimpleCurlyFormat
+                            .format(&dynfmt_template, &*record_vec)
+                        {
+                            Ok(formatted) => formatted.into_owned(),
+                            Err(_) => record[column_index].to_owned(),
+                        };
                         if flag_new_column.is_some() {
                             record.push_field(&cell);
                         } else {
@@ -661,27 +672,23 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         }
                     },
                     ApplySubCmd::CalcConv => {
-                        let result = if record[column_index].is_empty() {
+                        let record_vec: Vec<&str> = record.iter().collect();
+                        let formatted = match dynfmt2::SimpleCurlyFormat
+                            .format(&dynfmt_template, &*record_vec)
+                        {
+                            Ok(formatted) => formatted.into_owned(),
+                            Err(_) => record[column_index].to_owned(),
+                        };
+
+                        let (cell_for_eval, append_unit) =
+                            if let Some(stripped) = formatted.strip_suffix("<UNIT>") {
+                                (stripped, true)
+                            } else {
+                                (formatted.as_str(), false)
+                            };
+                        let result = if cell_for_eval.trim().is_empty() {
                             String::new()
                         } else {
-                            let mut cell = record[column_index].to_owned();
-                            let mut record_vec: Vec<String> = Vec::with_capacity(record.len());
-                            for field in &record {
-                                record_vec.push(field.to_string());
-                            }
-                            if let Ok(formatted) =
-                                dynfmt2::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
-                            {
-                                cell = formatted.to_string();
-                            }
-
-                            let mut append_unit = false;
-                            let cell_for_eval = if cell.ends_with("<UNIT>") {
-                                append_unit = true;
-                                cell.trim_end_matches("<UNIT>")
-                            } else {
-                                &cell
-                            };
                             match eval(cell_for_eval, true, false) {
                                 Ok(answer) => {
                                     if append_unit {
@@ -690,9 +697,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                         answer.value.to_string()
                                     }
                                 },
-                                Err(e) => {
-                                    format!("ERROR: {e}")
-                                },
+                                Err(e) => format!("ERROR: {e}"),
                             }
                         };
 
@@ -755,7 +760,7 @@ fn validate_operations(
             Operations::Censor | Operations::Censor_Check | Operations::Censor_Count => {
                 if flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--new_column (-c) is required for censor operations."
+                        "--new-column (-c) is required for censor operations."
                     );
                 }
                 if censor_invokes == 0
@@ -776,7 +781,7 @@ fn validate_operations(
             Operations::Copy => {
                 if flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--new_column (-c) is required for copy operation."
+                        "--new-column (-c) is required for copy operation."
                     );
                 }
                 copy_invokes = copy_invokes.saturating_add(1);
@@ -784,7 +789,7 @@ fn validate_operations(
             Operations::Eudex => {
                 if flag_comparand.is_empty() || flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--comparand (-C) and --new_column (-c) is required for eudex."
+                        "--comparand (-C) and --new-column (-c) are required for eudex."
                     );
                 }
                 if eudex_invokes == 0
@@ -834,7 +839,7 @@ fn validate_operations(
             Operations::Sentiment => {
                 if flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--new_column (-c) is required for sentiment operation."
+                        "--new-column (-c) is required for sentiment operation."
                     );
                 }
                 if sentiment_invokes == 0
@@ -855,7 +860,7 @@ fn validate_operations(
             | Operations::Simod => {
                 if flag_comparand.is_empty() || flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--comparand (-C) and --new_column (-c) is required for similarity \
+                        "--comparand (-C) and --new-column (-c) are required for similarity \
                          operations."
                     );
                 }
@@ -868,36 +873,27 @@ fn validate_operations(
                 strip_invokes = strip_invokes.saturating_add(1);
             },
             Operations::Thousands => {
-                let separator_policy = match flag_formatstr {
+                THOUSANDS_POLICY.get_or_init(|| match flag_formatstr {
                     "dot" => policies::DOT_SEPARATOR,
                     "space" => policies::SPACE_SEPARATOR,
                     "underscore" => policies::UNDERSCORE_SEPARATOR,
                     "hexfour" => policies::HEX_FOUR,
                     "indiancomma" => INDIANCOMMA_POLICY,
                     _ => policies::COMMA_SEPARATOR,
-                };
-                if THOUSANDS_POLICY.set(separator_policy).is_err() {
-                    return fail!("Cannot initialize Thousands policy.");
-                }
+                });
             },
-            Operations::Round
-                if ROUND_PLACES
-                    .set(
-                        flag_formatstr
-                            .parse::<u32>()
-                            .unwrap_or(DEFAULT_ROUND_PLACES),
-                    )
-                    .is_err() =>
-            {
-                return fail!("Cannot initialize Round precision.");
+            Operations::Round => {
+                ROUND_PLACES.get_or_init(|| {
+                    flag_formatstr
+                        .parse::<u32>()
+                        .unwrap_or(DEFAULT_ROUND_PLACES)
+                });
             },
-            Operations::Crc32 if CRC32.set(crc32fast::Hasher::new()).is_err() => {
-                return fail!("Cannot initialize CRC32 Hasher.");
-            },
+            Operations::Crc32 => {},
             Operations::Whatlang => {
                 if flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--new_column (-c) is required for whatlang language detection."
+                        "--new-column (-c) is required for whatlang language detection."
                     );
                 }
 
@@ -940,12 +936,10 @@ fn validate_operations(
             Operations::Gender_Guess => {
                 if flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--new_column (-c) is required for Gender_Guess"
+                        "--new-column (-c) is required for gender_guess."
                     );
                 }
-                if GENDER_GUESSER.set(gender_guesser::Detector::new()).is_err() {
-                    return fail!("Cannot initialize Gender Detector.");
-                }
+                GENDER_GUESSER.get_or_init(gender_guesser::Detector::new);
             },
             _ => {},
         }
@@ -1043,13 +1037,7 @@ fn apply_operations(
                 };
             },
             Operations::Crc32 => {
-                // safety: we set CRC32 in validate_operations()
-                // this approach is still better than using the simple hash() function
-                // despite the use of clone(), because it allows us to use the
-                // same hasher for multiple columns.
-                // OTOH, the simple hash() function keeps creating a new hasher for every call,
-                // including selection of the best algorithm repeatedly at runtime
-                let mut crc32_hasher = CRC32.get().unwrap().clone();
+                let mut crc32_hasher = crc32fast::Hasher::new();
                 crc32_hasher.update(cell.as_bytes());
                 itoa::Buffer::new()
                     .format(crc32_hasher.finalize())
@@ -1147,7 +1135,7 @@ fn apply_operations(
                 // This is a workaround around current limitation of qsv-currency
                 // and also of upstream currency-rs, that it cannot
                 // handle currency amounts properly with three decimal places
-                let fract_3digits: &'static Regex = regex_oncelock!(r"\.\d\d\d$");
+                let fract_3digits = fract_3digits_regex();
                 let cell_val = if fract_3digits.is_match(cell) {
                     format!("{cell}0")
                 } else {
@@ -1211,8 +1199,8 @@ fn apply_operations(
             },
             Operations::Numtocurrency => {
                 // same 3 decimal place workaround as currencytonum
-                let fract_3digits2: &'static Regex = regex_oncelock!(r"\.\d\d\d$");
-                let cell_val = if fract_3digits2.is_match(cell) {
+                let fract_3digits = fract_3digits_regex();
+                let cell_val = if fract_3digits.is_match(cell) {
                     format!("{cell}0")
                 } else {
                     cell.clone()

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -470,14 +470,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
     // --new-column (-c) appends a single field per row, so it would produce
     // malformed CSV (one header, N data fields) when combined with multi-column
-    // operations or emptyreplace. Use --rename (-r) for multi-column transforms.
+    // operations or emptyreplace. For multi-column transforms, omit --new-column
+    // to update the selected columns in place; --rename (-r) is optional and only
+    // changes the column names.
     if args.flag_new_column.is_some()
         && (args.cmd_operations || args.cmd_emptyreplace)
         && sel.len() > 1
     {
         return fail_incorrectusage_clierror!(
-            "--new-column (-c) requires a single input column. Use --rename (-r) for \
-             multi-column transformations."
+            "--new-column (-c) requires a single input column. For multi-column \
+             operations/emptyreplace, omit --new-column to transform columns in place; \
+             optionally use --rename (-r) to rename the transformed columns."
         );
     }
     // safety: we just checked that sel is not empty above
@@ -680,12 +683,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             Err(_) => record[column_index].to_owned(),
                         };
 
-                        let (cell_for_eval, append_unit) =
-                            if let Some(stripped) = formatted.strip_suffix("<UNIT>") {
-                                (stripped, true)
-                            } else {
-                                (formatted.as_str(), false)
-                            };
+                        let (cell_for_eval, append_unit) = if formatted.ends_with("<UNIT>") {
+                            // strip ALL trailing <UNIT> occurrences (matches the original
+                            // trim_end_matches behavior — strip_suffix would only remove one)
+                            (formatted.trim_end_matches("<UNIT>"), true)
+                        } else {
+                            (formatted.as_str(), false)
+                        };
                         let result = if cell_for_eval.trim().is_empty() {
                             String::new()
                         } else {

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -77,7 +77,7 @@ Examples:
   qsv applydp operations trim,upper surname -c uppercase_clean_surname file.csv
 
   # Trim, squeeze, then transform to uppercase in place ALL fields that end with "_name"
-  qsv applydp operations trim,squeeze,upper \_name$\ file.csv
+  qsv applydp operations trim,squeeze,upper '/_name$/' file.csv
 
   # Trim, then transform to uppercase the firstname and surname fields and
   # rename the columns ufirstname and usurname.
@@ -87,7 +87,7 @@ Examples:
   qsv applydp operations mtrim description --comparand '()<>' file.csv
 
   # Replace ' and ' with ' & ' in the description field.
-  qsv applydp replace description --comparand ' and ' --replacement ' & ' file.csv
+  qsv applydp operations replace description --comparand ' and ' --replacement ' & ' file.csv
 
   # You can also use this subcommand command to make a copy of a column:
   qsv applydp operations copy col_to_copy -c col_copy file.csv
@@ -137,7 +137,7 @@ apply arguments:
         <column>                The column/s to apply the operations to.
 
     EMPTYREPLACE subcommand:
-        --replacement=<string>  The string to to use to replace empty values.
+        --replacement=<string>  The string to use to replace empty values.
         <column>                The column/s to check for emptiness.
 
     DYNFMT subcommand:
@@ -150,7 +150,7 @@ apply arguments:
 applydp options:
     -c, --new-column <name>     Put the transformed values in a new column instead.
     -r, --rename <name>         New name for the transformed column.
-    -C, --comparand=<string>    The string to compare against for replace & similarity operations.
+    -C, --comparand=<string>    The string to compare against for replace & strip operations.
     -R, --replacement=<string>  The string to use for the replace & emptyreplace operations.
     -f, --formatstr=<string>    This option is used by several subcommands:
 
@@ -266,6 +266,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if sel.is_empty() {
         return fail_incorrectusage_clierror!("No columns selected. Column selection is empty.");
     }
+    // --new-column (-c) appends a single field per row, so it would produce
+    // malformed CSV (one header, N data fields) when combined with multi-column
+    // operations or emptyreplace. Use --rename (-r) for multi-column transforms.
+    if args.flag_new_column.is_some()
+        && (args.cmd_operations || args.cmd_emptyreplace)
+        && sel.len() > 1
+    {
+        return fail_incorrectusage_clierror!(
+            "--new-column (-c) requires a single input column. Use --rename (-r) for \
+             multi-column transformations."
+        );
+    }
     // safety: we just checked that sel is not empty above
     let column_index = *sel.iter().next().unwrap();
 
@@ -290,7 +302,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // so SimpleCurlyFormat is performant
     let dynfmt_template = if args.cmd_dynfmt {
         if args.flag_no_headers {
-            return fail_incorrectusage_clierror!("dynfmt/calcconv subcommand requires headers.");
+            return fail_incorrectusage_clierror!("dynfmt subcommand requires headers.");
         }
 
         let mut dynfmt_template_wrk = args.flag_formatstr.clone();
@@ -330,23 +342,20 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut ops_vec = SmallVec::<[Operations; 4]>::new();
 
     let applydp_cmd = if args.cmd_operations {
-        match validate_operations(
+        ops_vec = validate_operations(
             &args.arg_operations.split(',').collect(),
             &args.flag_comparand,
             &args.flag_replacement,
-            &args.flag_new_column,
+            args.flag_new_column.as_ref(),
             &args.flag_formatstr,
-        ) {
-            Ok(operations_vec) => ops_vec = operations_vec,
-            Err(e) => return Err(e),
-        }
+        )?;
         ApplydpSubCmd::Operations
     } else if args.cmd_dynfmt {
         ApplydpSubCmd::DynFmt
     } else if args.cmd_emptyreplace {
         ApplydpSubCmd::EmptyReplace
     } else {
-        return fail!("Unknown applydp subcommand.");
+        return fail_incorrectusage_clierror!("Unknown applydp subcommand.");
     };
 
     if !rconfig.no_headers {
@@ -356,11 +365,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         wtr.write_record(&headers)?;
     }
 
-    // if there is a regex_replace operation and replacement is <NULL> case-insensitive,
-    // we set it to empty string
+    // <NULL> (case-insensitive) is recognized as "delete matches" when regex_replace is in
+    // the operation chain. Note this clears flag_replacement for ALL ops in the chain, so
+    // a chained `regex_replace,replace` with --replacement <NULL> deletes matches in both.
     let flag_replacement = if applydp_cmd == ApplydpSubCmd::Operations
         && ops_vec.contains(&Operations::Regex_Replace)
-        && args.flag_replacement.to_ascii_lowercase() == NULL_VALUE
+        && args.flag_replacement.eq_ignore_ascii_case(NULL_VALUE)
     {
         String::new()
     } else {
@@ -448,18 +458,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         }
                     },
                     ApplydpSubCmd::DynFmt => {
-                        let mut cell = record[column_index].to_owned();
-                        if !cell.is_empty() {
-                            let mut record_vec: Vec<String> = Vec::with_capacity(record.len());
-                            for field in &record {
-                                record_vec.push(field.to_string());
-                            }
-                            if let Ok(formatted) =
-                                dynfmt2::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
-                            {
-                                cell = formatted.to_string();
-                            }
-                        }
+                        let record_vec: Vec<&str> = record.iter().collect();
+                        let cell = match dynfmt2::SimpleCurlyFormat
+                            .format(&dynfmt_template, &*record_vec)
+                        {
+                            Ok(formatted) => formatted.into_owned(),
+                            Err(_) => record[column_index].to_owned(),
+                        };
                         if flag_new_column.is_some() {
                             record.push_field(&cell);
                         } else {
@@ -489,7 +494,7 @@ fn validate_operations(
     operations: &Vec<&str>,
     flag_comparand: &str,
     flag_replacement: &str,
-    flag_new_column: &Option<String>,
+    flag_new_column: Option<&String>,
     flag_formatstr: &str,
 ) -> Result<SmallVec<[Operations; 4]>, CliError> {
     let mut copy_invokes = 0_u8;
@@ -507,17 +512,17 @@ fn validate_operations(
             Operations::Copy => {
                 if flag_new_column.is_none() {
                     return fail_incorrectusage_clierror!(
-                        "--new_column (-c) is required for copy operation."
+                        "--new-column (-c) is required for copy operation."
                     );
                 }
                 copy_invokes = copy_invokes.saturating_add(1);
             },
-            Operations::Mtrim | Operations::Mltrim | Operations::Mrtrim => {
-                if flag_comparand.is_empty() {
-                    return fail_incorrectusage_clierror!(
-                        "--comparand (-C) is required for match trim operations."
-                    );
-                }
+            Operations::Mtrim | Operations::Mltrim | Operations::Mrtrim
+                if flag_comparand.is_empty() =>
+            {
+                return fail_incorrectusage_clierror!(
+                    "--comparand (-C) is required for match trim operations."
+                );
             },
             Operations::Regex_Replace => {
                 if flag_comparand.is_empty() || flag_replacement.is_empty() {
@@ -555,16 +560,11 @@ fn validate_operations(
                 strip_invokes = strip_invokes.saturating_add(1);
             },
             Operations::Round => {
-                if ROUND_PLACES
-                    .set(
-                        flag_formatstr
-                            .parse::<u32>()
-                            .unwrap_or(DEFAULT_ROUND_PLACES),
-                    )
-                    .is_err()
-                {
-                    return fail!("Cannot initialize Round precision.");
-                };
+                ROUND_PLACES.get_or_init(|| {
+                    flag_formatstr
+                        .parse::<u32>()
+                        .unwrap_or(DEFAULT_ROUND_PLACES)
+                });
             },
             _ => {},
         }

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -278,8 +278,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     {
         return fail_incorrectusage_clierror!(
             "--new-column (-c) requires a single input column. For multi-column \
-             operations/emptyreplace, omit --new-column to transform columns in place; \
-             optionally use --rename (-r) to rename the transformed columns."
+             operations/emptyreplace, omit --new-column to transform columns in place; optionally \
+             use --rename (-r) to rename the transformed columns."
         );
     }
     // safety: we just checked that sel is not empty above

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -150,7 +150,8 @@ apply arguments:
 applydp options:
     -c, --new-column <name>     Put the transformed values in a new column instead.
     -r, --rename <name>         New name for the transformed column.
-    -C, --comparand=<string>    The string to compare against for replace & strip operations.
+    -C, --comparand=<string>    The string to compare against for replace, strip,
+                                match-trim (mtrim/mltrim/mrtrim) & regex_replace operations.
     -R, --replacement=<string>  The string to use for the replace & emptyreplace operations.
     -f, --formatstr=<string>    This option is used by several subcommands:
 
@@ -268,14 +269,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
     // --new-column (-c) appends a single field per row, so it would produce
     // malformed CSV (one header, N data fields) when combined with multi-column
-    // operations or emptyreplace. Use --rename (-r) for multi-column transforms.
+    // operations or emptyreplace. For multi-column transforms, omit --new-column
+    // to update the selected columns in place; --rename (-r) is optional and only
+    // changes the column names.
     if args.flag_new_column.is_some()
         && (args.cmd_operations || args.cmd_emptyreplace)
         && sel.len() > 1
     {
         return fail_incorrectusage_clierror!(
-            "--new-column (-c) requires a single input column. Use --rename (-r) for \
-             multi-column transformations."
+            "--new-column (-c) requires a single input column. For multi-column \
+             operations/emptyreplace, omit --new-column to transform columns in place; \
+             optionally use --rename (-r) to rename the transformed columns."
         );
     }
     // safety: we just checked that sel is not empty above

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1393,8 +1393,9 @@ fn apply_ops_multi_column_new_column_rejected() {
     let got = wrk.output_stderr(&mut cmd);
     assert_eq!(
         got,
-        "usage error: --new-column (-c) requires a single input column. Use --rename (-r) \
-         for multi-column transformations.\n"
+        "usage error: --new-column (-c) requires a single input column. For multi-column \
+         operations/emptyreplace, omit --new-column to transform columns in place; \
+         optionally use --rename (-r) to rename the transformed columns.\n"
     );
     wrk.assert_err(&mut cmd);
 }

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1394,8 +1394,8 @@ fn apply_ops_multi_column_new_column_rejected() {
     assert_eq!(
         got,
         "usage error: --new-column (-c) requires a single input column. For multi-column \
-         operations/emptyreplace, omit --new-column to transform columns in place; \
-         optionally use --rename (-r) to rename the transformed columns.\n"
+         operations/emptyreplace, omit --new-column to transform columns in place; optionally use \
+         --rename (-r) to rename the transformed columns.\n"
     );
     wrk.assert_err(&mut cmd);
 }

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1367,8 +1367,34 @@ fn apply_ops_chain_validation_error_missing_comparand() {
     let got = wrk.output_stderr(&mut cmd);
     assert_eq!(
         got,
-        "usage error: --comparand (-C) and --new_column (-c) is required for similarity \
+        "usage error: --comparand (-C) and --new-column (-c) are required for similarity \
          operations.\n"
+    );
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn apply_ops_multi_column_new_column_rejected() {
+    // --new-column with multiple selected columns would produce malformed CSV
+    // (one header field, N data fields per row). Should be rejected at validation.
+    let wrk = Workdir::new("apply_ops_multi_column_new_column_rejected");
+    wrk.create(
+        "data.csv",
+        vec![svec!["a", "b"], svec!["foo", "bar"], svec!["baz", "qux"]],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("upper")
+        .arg("a,b")
+        .arg("-c")
+        .arg("new")
+        .arg("data.csv");
+
+    let got = wrk.output_stderr(&mut cmd);
+    assert_eq!(
+        got,
+        "usage error: --new-column (-c) requires a single input column. Use --rename (-r) \
+         for multi-column transformations.\n"
     );
     wrk.assert_err(&mut cmd);
 }

--- a/tests/test_applydp.rs
+++ b/tests/test_applydp.rs
@@ -668,8 +668,9 @@ fn applydp_ops_multi_column_new_column_rejected() {
     let got = wrk.output_stderr(&mut cmd);
     assert_eq!(
         got,
-        "usage error: --new-column (-c) requires a single input column. Use --rename (-r) \
-         for multi-column transformations.\n"
+        "usage error: --new-column (-c) requires a single input column. For multi-column \
+         operations/emptyreplace, omit --new-column to transform columns in place; \
+         optionally use --rename (-r) to rename the transformed columns.\n"
     );
     wrk.assert_err(&mut cmd);
 }

--- a/tests/test_applydp.rs
+++ b/tests/test_applydp.rs
@@ -649,6 +649,32 @@ fn applydp_ops_chain_validation_error_missing_comparand() {
 }
 
 #[test]
+fn applydp_ops_multi_column_new_column_rejected() {
+    // --new-column with multiple selected columns would produce malformed CSV
+    // (one header field, N data fields per row). Should be rejected at validation.
+    let wrk = Workdir::new("applydp_ops_multi_column_new_column_rejected");
+    wrk.create(
+        "data.csv",
+        vec![svec!["a", "b"], svec!["foo", "bar"], svec!["baz", "qux"]],
+    );
+    let mut cmd = wrk.command("applydp");
+    cmd.arg("operations")
+        .arg("upper")
+        .arg("a,b")
+        .arg("-c")
+        .arg("new")
+        .arg("data.csv");
+
+    let got = wrk.output_stderr(&mut cmd);
+    assert_eq!(
+        got,
+        "usage error: --new-column (-c) requires a single input column. Use --rename (-r) \
+         for multi-column transformations.\n"
+    );
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
 fn applydp_ops_chain_squeeze0() {
     let wrk = Workdir::new("applydp");
     wrk.create(

--- a/tests/test_applydp.rs
+++ b/tests/test_applydp.rs
@@ -669,8 +669,8 @@ fn applydp_ops_multi_column_new_column_rejected() {
     assert_eq!(
         got,
         "usage error: --new-column (-c) requires a single input column. For multi-column \
-         operations/emptyreplace, omit --new-column to transform columns in place; \
-         optionally use --rename (-r) to rename the transformed columns.\n"
+         operations/emptyreplace, omit --new-column to transform columns in place; optionally use \
+         --rename (-r) to rename the transformed columns.\n"
     );
     wrk.assert_err(&mut cmd);
 }


### PR DESCRIPTION
- Reject --new-column (-c) with multi-column selection for operations and
  emptyreplace: the loop pushed N data fields per row but only one new header,
  producing malformed CSV. Add validation + regression test.
- Switch Round/Thousands/Crc32/Gender_Guess from OnceLock::set to get_or_init
  so reusing them in a chain no longer fails with a misleading "Cannot
  initialize" error.
- Drop the CRC32 OnceLock entirely (the lock just stored a fresh hasher that
  was cloned per row — equivalent to constructing one inline).
- Fix --new_column → --new-column in user-facing validation errors (the actual
  flag is hyphenated; copy-paste of the old text fails).
- Fix two docstring typos (mismatched quotes in calcconv example; "CALCONV" →
  "CALCCONV").
- DynFmt/CalcConv: stop silently outputting "" when the first selected column
  is empty (the formatstr may not even reference that column). Always run the
  template; for CalcConv, only skip eval if the formatted expression is blank.
- DynFmt/CalcConv: build the format-args buffer as Vec<&str> instead of cloning
  every field into Vec<String> per row.
- Hoist the duplicated fract_3digits regex into a shared helper.
- Use eq_ignore_ascii_case for the <NULL> check (avoids per-row allocation)
  and clarify the comment that the substitution is chain-wide.
- Drop unused `use base62;` and `use crc32fast;` extern-crate-style imports.

https://claude.ai/code/session_018dUycY9NG1Z8hr7ruR3wN3