### PR TITLE
validate: review-driven correctness and consistency fixes

### DIFF
--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1390,8 +1390,8 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
                     Ok(obj) => obj,
                     Err(e) => {
                         std::hint::cold_path();
-                        // row number was appended as the last field via itoa, so it is always
-                        // valid ASCII; the unwrap can never fire in practice.
+                        // safety: row number was appended as the last field via itoa, so it is
+                        // always valid ASCII; the unwrap can never fire in practice.
                         let row_number_string =
                             simdutf8::basic::from_utf8(&record[header_len]).unwrap();
                         return Some(format!("{row_number_string}\t<RECORD>\t{e}"));
@@ -1417,6 +1417,8 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
                     None
                 } else {
                     std::hint::cold_path();
+                    // safety: row number was appended as the last field via itoa, so it is
+                    // always valid ASCII; the unwrap can never fire in practice.
                     let row_number_string =
                         simdutf8::basic::from_utf8(&record[header_len]).unwrap();
 

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -441,13 +441,14 @@ impl Keyword for DynEnumValidator {
         &self,
         instance: &'instance Value,
     ) -> Result<(), ValidationError<'instance>> {
-        if self.dynenum_set.contains(instance.as_str().unwrap()) {
-            Ok(())
-        } else {
-            let error =
-                ValidationError::custom(format!("{instance} is not a valid dynamicEnum value"));
-            Err(error)
+        if let Value::String(s) = instance
+            && self.dynenum_set.contains(s)
+        {
+            return Ok(());
         }
+        Err(ValidationError::custom(format!(
+            "{instance} is not a valid dynamicEnum value"
+        )))
     }
 
     #[inline]
@@ -1030,8 +1031,17 @@ fn dyn_enum_validator_factory<'a>(
             } else {
                 // Try finding column by name
                 match rdr.headers() {
-                    Ok(headers) => headers.iter().position(|h| h == col_name).unwrap_or(0),
-                    Err(_) => 0,
+                    Ok(headers) => match headers.iter().position(|h| h == col_name) {
+                        Some(i) => i,
+                        None => {
+                            return fail_validation_error!(
+                                "dynamicEnum column '{col_name}' not found in headers"
+                            );
+                        },
+                    },
+                    Err(e) => {
+                        return fail_validation_error!("Error reading dynamicEnum headers: {e}");
+                    },
                 }
             }
         } else {
@@ -1380,12 +1390,10 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
                     Ok(obj) => obj,
                     Err(e) => {
                         std::hint::cold_path();
-                        // Only convert to string when we have an error
-                        // safety: row number was added as last column. We can do index access, not
-                        // use get(), and unwrap_unchecked safely since we know its there
-                        let row_number_string = unsafe {
-                            simdutf8::basic::from_utf8(&record[header_len]).unwrap_unchecked()
-                        };
+                        // row number was appended as the last field via itoa, so it is always
+                        // valid ASCII; the unwrap can never fire in practice.
+                        let row_number_string =
+                            simdutf8::basic::from_utf8(&record[header_len]).unwrap();
                         return Some(format!("{row_number_string}\t<RECORD>\t{e}"));
                     },
                 };
@@ -1409,11 +1417,8 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
                     None
                 } else {
                     std::hint::cold_path();
-                    // Only convert to string when we have validation errors
-                    // safety: see safety comment above
-                    let row_number_string = unsafe {
-                        simdutf8::basic::from_utf8(&record[header_len]).unwrap_unchecked()
-                    };
+                    let row_number_string =
+                        simdutf8::basic::from_utf8(&record[header_len]).unwrap();
 
                     // Collect errors into a vector
                     let errors: Vec<_> = evaluation.iter_errors().collect();
@@ -1895,7 +1900,7 @@ fn split_invalid_records(
     let mut record = csv::ByteRecord::new();
     while rdr.read_byte_record(&mut record)? {
         // length of valid_flags is max number of rows we can split
-        if split_row_num > valid_flags_len {
+        if split_row_num >= valid_flags_len {
             break;
         }
 
@@ -1966,8 +1971,16 @@ fn to_json_instance(
                 }
             },
             JSONtypes::Number => {
-                if let Ok(float) = fast_float2::parse(value) {
-                    Value::Number(Number::from_f64(float).unwrap_or_else(|| Number::from(0)))
+                if let Ok(float) = fast_float2::parse::<f64, _>(value) {
+                    match Number::from_f64(float) {
+                        Some(n) => Value::Number(n),
+                        None => {
+                            return fail_clierror!(
+                                "Non-finite Number. key: {key}, value: {}",
+                                String::from_utf8_lossy(value)
+                            );
+                        },
+                    }
                 } else {
                     return fail_clierror!(
                         "Can't cast to Number. key: {key}, value: {}",

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -555,7 +555,10 @@ fn validate_dynenum_with_invalid_column() {
     // Check error output
     let got = wrk.output_stderr(&mut cmd);
     #[cfg(feature = "lite")]
-    assert_eq!(got, "1 out of 1 records invalid.\n");
+    assert!(got.ends_with(
+        "Cannot compile JSONschema. error: dynamicEnum column 'nonexistent_column' not found in \
+         headers\nTry running `qsv validate schema schema.json` to check the JSON Schema file.\n"
+    ));
     #[cfg(not(feature = "lite"))]
     assert!(got.ends_with(
         "Cannot compile JSONschema. error: Column 'nonexistent_column' not found in lookup \


### PR DESCRIPTION
## Summary

Fixes from a code review of `src/cmd/validate.rs`:

- **`DynEnumValidator::validate`** — replaced `instance.as_str().unwrap()` with the `Value::String` pattern that `is_valid` already uses. The old code panics if `validate` is ever entered with a non-string instance.
- **`split_invalid_records` off-by-one** — changed `>` to `>=` in the bounds check. The old guard fires one row late, so when the input file has more rows than `valid_flags` (file grew between passes, or `--fail-fast` truncation), the next iteration indexes `valid_flags[valid_flags_len]` and panics.
- **Lite-mode `dyn_enum_validator_factory`** — was silently defaulting to column 0 when the named column wasn't found or when `rdr.headers()` errored, which built `dynamicEnum` sets from the wrong column with no warning. Now mirrors the non-lite version and returns a proper validation error.
- **Unnecessary `unsafe { unwrap_unchecked }`** in the Rayon validation loop — both call sites are already gated by `std::hint::cold_path()`, so the perf savings are zero. Replaced with safe `unwrap()` plus a one-line comment explaining why it cannot fire (row number is appended via `itoa`, always valid ASCII).
- **`to_json_instance` NaN/inf handling** — `fast_float2::parse` accepts `"NaN"`/`"inf"`, then `Number::from_f64` rejects non-finite floats and the old fallback silently coerced to `0`. That would let invalid numbers slip past schema constraints like `minimum`/`maximum`. Now surfaces a `Non-finite Number` error.

Three other issues flagged during review were investigated and dismissed — see commit message and PR conversation for details (no real race in `UniqueCombinedWithValidator`, no Windows file-handle conflict in `split_invalid_records`, `obj.values()` ordering is correct because `serde_json` is built with `preserve_order`).

## Test plan

- [x] `cargo test test_validate -F all_features` — 62/62 pass
- [x] `cargo test test_validate -F lite` — 62/62 pass (after updating `validate_dynenum_with_invalid_column` lite assertion to match the new correct error path; the old assertion was asserting the silent-fallback bug)
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` — clean
- [x] `cargo build --bin qsv -F all_features` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)