### PR TITLE
stats: review-driven cache & boolean-pattern fixes

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -710,6 +710,9 @@ static BOOLEAN_PATTERNS: OnceLock<Vec<BooleanPattern>> = OnceLock::new();
 struct BooleanPattern {
     true_pattern:  String,
     false_pattern: String,
+    /// True iff both patterns are ASCII-only. When set (and the value being
+    /// matched is also ASCII), `matches` uses an allocation-free comparison.
+    ascii_only:    bool,
 }
 
 impl BooleanPattern {
@@ -734,30 +737,57 @@ impl BooleanPattern {
     /// 1. **Exact match**: The value is compared directly to both patterns (case-insensitive)
     /// 2. **Prefix match**: If a pattern ends with `*`, the value is checked if it starts with the
     ///    prefix (excluding the `*` character)
-    /// 3. **Priority**: Exact matches are checked before prefix matches for better performance
+    /// 3. **Priority**: Exact matches are checked before prefix matches. This is also a correctness
+    ///    requirement when patterns overlap (e.g. `"t*"` true vs. `"t"` false: the exact false
+    ///    match must win for a value of `"t"`).
     fn matches(&self, value: &str) -> Option<bool> {
+        // Fast path: when both patterns and the value are ASCII, we can use
+        // `eq_ignore_ascii_case` and a byte-wise prefix compare without
+        // allocating a lowercased copy of `value`. Patterns are already
+        // lowercased at parse time, so case folding only needs to happen on
+        // `value`, and ASCII case folding is a single bit flip per byte.
+        if self.ascii_only && value.is_ascii() {
+            if value.eq_ignore_ascii_case(&self.true_pattern) {
+                return Some(true);
+            }
+            if value.eq_ignore_ascii_case(&self.false_pattern) {
+                return Some(false);
+            }
+            if let Some(prefix) = self.true_pattern.strip_suffix('*')
+                && value.len() >= prefix.len()
+                && value.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+            {
+                return Some(true);
+            }
+            if let Some(prefix) = self.false_pattern.strip_suffix('*')
+                && value.len() >= prefix.len()
+                && value.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+            {
+                return Some(false);
+            }
+            return None;
+        }
+
+        // Slow path: at least one of the patterns or the value contains
+        // non-ASCII characters, so fall back to Unicode-aware lowercasing.
         let value_lower = value.to_lowercase();
 
-        // Check for exact match first
         if value_lower == self.true_pattern {
             return Some(true);
         } else if value_lower == self.false_pattern {
             return Some(false);
         }
 
-        // Check for prefix match if pattern ends with "*"
-        if self.true_pattern.ends_with('*') {
-            let prefix = &self.true_pattern[..self.true_pattern.len() - 1];
-            if value_lower.starts_with(prefix) {
-                return Some(true);
-            }
+        if let Some(prefix) = self.true_pattern.strip_suffix('*')
+            && value_lower.starts_with(prefix)
+        {
+            return Some(true);
         }
 
-        if self.false_pattern.ends_with('*') {
-            let prefix = &self.false_pattern[..self.false_pattern.len() - 1];
-            if value_lower.starts_with(prefix) {
-                return Some(false);
-            }
+        if let Some(prefix) = self.false_pattern.strip_suffix('*')
+            && value_lower.starts_with(prefix)
+        {
+            return Some(false);
         }
 
         None
@@ -796,13 +826,38 @@ fn parse_boolean_patterns(boolean_patterns: &str) -> CliResult<Vec<BooleanPatter
         let true_pattern = parts.next().unwrap_or("").trim().to_lowercase();
         let false_pattern = parts.next().unwrap_or("").trim().to_lowercase();
 
+        // Reject more than two colon-separated parts (e.g. "a:b:c") so trailing
+        // tokens aren't silently dropped.
+        if parts.next().is_some() {
+            return fail_incorrectusage_clierror!(
+                "Invalid boolean pattern (expected `true:false`): {pair}"
+            );
+        }
+
         if true_pattern.is_empty() || false_pattern.is_empty() {
             return fail_incorrectusage_clierror!("Invalid boolean pattern: {pair}");
         }
 
+        // A bare "*" has an empty prefix, which would match every value.
+        if true_pattern == "*" || false_pattern == "*" {
+            return fail_incorrectusage_clierror!(
+                "Invalid boolean pattern (`*` alone matches everything): {pair}"
+            );
+        }
+
+        // Identical true/false patterns make the false branch unreachable
+        // (true is checked first), so reject as ambiguous.
+        if true_pattern == false_pattern {
+            return fail_incorrectusage_clierror!(
+                "Invalid boolean pattern (true and false patterns are identical): {pair}"
+            );
+        }
+
+        let ascii_only = true_pattern.is_ascii() && false_pattern.is_ascii();
         patterns.push(BooleanPattern {
             true_pattern,
             false_pattern,
+            ascii_only,
         });
     }
     if patterns.is_empty() {
@@ -1187,6 +1242,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             && existing_stats_args_json.flag_delimiter
                                 == current_stats_args.flag_delimiter
                             && existing_stats_args_json.flag_nulls == current_stats_args.flag_nulls
+                            && existing_stats_args_json.flag_weight
+                                == current_stats_args.flag_weight
+                            && existing_stats_args_json.flag_percentile_list
+                                == current_stats_args.flag_percentile_list
                             && existing_stats_args_json.qsv_version
                                 == current_stats_args.qsv_version)
                 {
@@ -2335,9 +2394,15 @@ fn calculate_memory_aware_chunk_size(
             }
         },
         Some(0) => {
-            // Dynamic sizing: sample records to estimate average size
-            // Note: caller already gates on needs_memory_aware_chunking, so we always
-            // use dynamic sizing here. The None arm has its own guard for direct callers.
+            // Dynamic sizing: sample records to estimate average size.
+            // Caller is expected to have gated on `needs_memory_aware_chunking`
+            // (see `parallel_stats`). The assertion locks that invariant in
+            // debug builds so a future caller can't silently bypass it.
+            debug_assert!(
+                needs_memory_aware_chunking,
+                "Some(0) arm requires non-streaming stats; caller must gate on \
+                 needs_memory_aware_chunking()"
+            );
             util::calculate_dynamic_chunk_size(idx_count, njobs, sample_records, |record| {
                 estimate_record_memory(record, which_stats)
             })

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -696,19 +696,20 @@ static BOOLEAN_PATTERNS: OnceLock<Vec<BooleanPattern>> = OnceLock::new();
 /// It supports both exact matches and prefix matching with wildcards for flexible boolean
 /// detection during CSV statistics computation.
 ///
-/// # Fields
-///
-/// * `true_pattern` - The pattern that identifies `true` values (case-insensitive)
-/// * `false_pattern` - The pattern that identifies `false` values (case-insensitive)
-///
 /// # Pattern Matching
 ///
 /// Patterns support two types of matching:
 /// * **Exact match**: The value must exactly match the pattern (case-insensitive)
 /// * **Prefix match**: If the pattern ends with `*`, it matches any value that starts with the
 ///   prefix (e.g., `"yes*"` matches `"yes"`, `"yes please"`, `"YES"`, etc.)
+///
+/// See the field-level docs below for details on each field.
 struct BooleanPattern {
+    /// The pattern that identifies `true` values (case-insensitive). Stored
+    /// already-lowercased; may end with `*` for prefix matching.
     true_pattern:  String,
+    /// The pattern that identifies `false` values (case-insensitive). Stored
+    /// already-lowercased; may end with `*` for prefix matching.
     false_pattern: String,
     /// True iff both patterns are ASCII-only. When set (and the value being
     /// matched is also ASCII), `matches` uses an allocation-free comparison.

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -3290,6 +3290,167 @@ fn stats_infer_boolean_missing_false_pattern() {
 }
 
 #[test]
+fn stats_infer_boolean_bare_asterisk_rejected() {
+    // A bare "*" has an empty prefix, which would match every value.
+    let wrk = Workdir::new("stats_infer_boolean_bare_asterisk_rejected");
+    let test_file = wrk.load_test_file("boston311-10-boolean-tf.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-boolean")
+        .arg("--boolean-patterns")
+        .arg("*:0")
+        .arg(&test_file);
+    wrk.assert_err(&mut cmd);
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-boolean")
+        .arg("--boolean-patterns")
+        .arg("1:*")
+        .arg(&test_file);
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn stats_infer_boolean_identical_patterns_rejected() {
+    let wrk = Workdir::new("stats_infer_boolean_identical_patterns_rejected");
+    let test_file = wrk.load_test_file("boston311-10-boolean-tf.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-boolean")
+        .arg("--boolean-patterns")
+        .arg("y:y")
+        .arg(test_file);
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn stats_infer_boolean_extra_colon_rejected() {
+    let wrk = Workdir::new("stats_infer_boolean_extra_colon_rejected");
+    let test_file = wrk.load_test_file("boston311-10-boolean-tf.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-boolean")
+        .arg("--boolean-patterns")
+        .arg("true:false:extra")
+        .arg(test_file);
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn stats_cache_invalidates_on_percentile_list_change() {
+    // Regression: with --everything, the cache short-circuit must compare
+    // flag_percentile_list. Otherwise, switching --percentile-list returns
+    // stale percentiles from the cache.
+    let wrk = Workdir::new("stats_cache_invalidates_on_percentile_list_change");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["v"],
+            svec!["1"],
+            svec!["2"],
+            svec!["3"],
+            svec!["4"],
+            svec!["5"],
+            svec!["6"],
+            svec!["7"],
+            svec!["8"],
+            svec!["9"],
+            svec!["10"],
+        ],
+    );
+
+    // First run: cache --everything with default percentile list.
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything")
+        .arg("--percentiles")
+        .arg("--cache-threshold")
+        .arg("1")
+        .arg("data.csv");
+    wrk.assert_success(&mut cmd);
+
+    // Second run: same cache file, but a different --percentile-list.
+    // Must NOT reuse the cached row.
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything")
+        .arg("--percentiles")
+        .arg("--percentile-list")
+        .arg("25,75")
+        .arg("data.csv");
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    // For values 1..=10 (nearest-rank): default list "5,10,40,60,90,95" yields
+    // "1|1|4|6|9|10"; the requested "25,75" yields "3|8". A stale cache would
+    // return the default list's value. Either way, the result must differ from
+    // the default and reflect the two requested percentiles (separator-split
+    // gives exactly 2 fields).
+    let header = &got[0];
+    let pct_idx = header
+        .iter()
+        .position(|h| h == "percentiles")
+        .expect("percentiles column present");
+    let pct_value = &got[1][pct_idx];
+    let parts: Vec<&str> = pct_value.split('|').collect();
+    assert_eq!(
+        parts.len(),
+        2,
+        "expected 2 percentiles for --percentile-list 25,75, got {pct_value:?}"
+    );
+}
+
+#[test]
+fn stats_cache_invalidates_on_weight_change() {
+    // Regression: --weight writes to <stem>.stats.weighted.csv regardless of which
+    // weight column is used. The --everything cache short-circuit must compare
+    // flag_weight or different weight columns will silently share a cache.
+    let wrk = Workdir::new("stats_cache_invalidates_on_weight_change");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["v", "w1", "w2"],
+            svec!["1", "1", "10"],
+            svec!["2", "1", "1"],
+            svec!["3", "1", "1"],
+            svec!["4", "1", "1"],
+            svec!["5", "1", "1"],
+        ],
+    );
+
+    // First run: cache with --weight w1 (uniform weights => weighted mean = 3).
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything")
+        .arg("--weight")
+        .arg("w1")
+        .arg("--cache-threshold")
+        .arg("1")
+        .arg("data.csv");
+    wrk.assert_success(&mut cmd);
+
+    // Second run: --weight w2. The first record dominates so the weighted mean
+    // must shift toward 1, not stay at the cached 3.
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything")
+        .arg("--weight")
+        .arg("w2")
+        .arg("data.csv");
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    let header = &got[0];
+    let field_idx = header.iter().position(|h| h == "field").unwrap();
+    let mean_idx = header.iter().position(|h| h == "mean").unwrap();
+    let v_row = got
+        .iter()
+        .skip(1)
+        .find(|r| r[field_idx] == "v")
+        .expect("row for column v");
+    let mean: f64 = v_row[mean_idx].parse().expect("numeric mean");
+    // With weights [10,1,1,1,1] over values [1..=5], weighted mean = 24/14 ≈ 1.714.
+    assert!(
+        (mean - 24.0 / 14.0).abs() < 1e-3,
+        "weighted mean should reflect new weight column, got {mean}"
+    );
+}
+
+#[test]
 fn stats_issue_2668_semicolon_separator() {
     let wrk = Workdir::new("stats_issue_2668_semicolon_separator");
     wrk.create("data.csv", vec![svec!["h1;h2;h3;h4"], svec!["1;2;3;4"]]);


### PR DESCRIPTION
## Summary

Targeted fixes from a review of `src/cmd/stats.rs`:

- **Cache short-circuit bugs.** The `--everything` cache-equality shortcut was missing two fields, so subsequent runs with different `--weight` columns or `--percentile-list` values silently reused stale cached output. Both are now compared.
- **Boolean pattern validation.** `parse_boolean_patterns` previously accepted three malformed inputs silently:
  - bare `*` (empty prefix → matches every value),
  - identical true/false patterns (false branch dead code),
  - extra colons like `a:b:c` (trailing tokens dropped).
  All three are now rejected with clear errors.
- **`BooleanPattern::matches` cleanup.** Added an ASCII fast path using `str::eq_ignore_ascii_case` and a byte-wise prefix compare; the Unicode `to_lowercase` path is preserved as a fallback for non-ASCII patterns. Doc clarified that exact-before-prefix priority is also a correctness requirement (not only performance).
- **`calculate_memory_aware_chunk_size`.** Added a `debug_assert!` in the `Some(0)` arm pinning the caller-gating invariant on `needs_memory_aware_chunking`.

5 regression tests added: 3 for the new pattern validators, 2 for the cache-shortcut bugs.

## Test plan

- [x] `cargo build --bin qsv -F all_features`
- [x] `cargo test -F all_features --test tests -- test_stats::` — 606 passed
- [x] `cargo clippy -F all_features --bin qsv -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)