### PR TITLE
fetch/fetchpost: review-driven cache, panic and safety fixes

### DIFF
--- a/docs/help/fetch.md
+++ b/docs/help/fetch.md
@@ -75,6 +75,14 @@ URL OPTIONS:
 <url-column> needs to be a fully qualified URL path. Alternatively, you can dynamically
 construct URLs for each CSV record with the --url-template option (see Examples below).
 
+JSON RESPONSE HANDLING:
+When --jaq is not used, fetch parses each successful response with serde_json and
+writes it back out (minified by default, or pretty-printed with --pretty). This means
+the response body is normalized — JSON object key order is sorted, integer/float
+representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
+stripped. If you need byte-exact server output, post-process the response yourself or
+use --jaq to extract specific fields.
+
 EXAMPLES USING THE URL-COLUMN ARGUMENT:
 
 data.csv

--- a/docs/help/fetch.md
+++ b/docs/help/fetch.md
@@ -77,11 +77,15 @@ construct URLs for each CSV record with the --url-template option (see Examples 
 
 JSON RESPONSE HANDLING:
 When --jaq is not used, fetch parses each successful response with serde_json and
-writes it back out (minified by default, or pretty-printed with --pretty). This means
-the response body is normalized — JSON object key order is sorted, integer/float
-representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
-stripped. If you need byte-exact server output, post-process the response yourself or
-use --jaq to extract specific fields.
+writes it back out (compact by default, or re-indented with --pretty). Object key
+order is preserved (qsv enables serde_json's preserve_order feature), but the body
+is otherwise normalized: all insignificant whitespace is removed (compact) or
+re-indented (--pretty); number representations are canonicalized (e.g. 1e2 -> 100,
+leading zeros stripped, exponent form normalized); duplicate keys within a JSON
+object are collapsed (last value wins); and responses that are not valid JSON are
+written as an empty cell (or the parse error if --store-error is set). If you need
+byte-exact server output, post-process the response yourself or use --jaq to
+extract specific fields.
 
 EXAMPLES USING THE URL-COLUMN ARGUMENT:
 

--- a/docs/help/fetchpost.md
+++ b/docs/help/fetchpost.md
@@ -97,11 +97,15 @@ from which the URL value will be retrieved for each record, or as the URL litera
 
 JSON RESPONSE HANDLING:
 When --jaq is not used, fetchpost parses each successful response with serde_json and
-writes it back out (minified by default, or pretty-printed with --pretty). This means
-the response body is normalized — JSON object key order is sorted, integer/float
-representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
-stripped. If you need byte-exact server output, post-process the response yourself or
-use --jaq to extract specific fields.
+writes it back out (compact by default, or re-indented with --pretty). Object key
+order is preserved (qsv enables serde_json's preserve_order feature), but the body
+is otherwise normalized: all insignificant whitespace is removed (compact) or
+re-indented (--pretty); number representations are canonicalized (e.g. 1e2 -> 100,
+leading zeros stripped, exponent form normalized); duplicate keys within a JSON
+object are collapsed (last value wins); and responses that are not valid JSON are
+written as an empty cell (or the parse error if --store-error is set). If you need
+byte-exact server output, post-process the response yourself or use --jaq to
+extract specific fields.
 
 EXAMPLES:
 

--- a/docs/help/fetchpost.md
+++ b/docs/help/fetchpost.md
@@ -95,6 +95,14 @@ URL OPTIONS:
 <url-column> needs to be a fully qualified URL path. It can be specified as a column name
 from which the URL value will be retrieved for each record, or as the URL literal itself.
 
+JSON RESPONSE HANDLING:
+When --jaq is not used, fetchpost parses each successful response with serde_json and
+writes it back out (minified by default, or pretty-printed with --pretty). This means
+the response body is normalized — JSON object key order is sorted, integer/float
+representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
+stripped. If you need byte-exact server output, post-process the response yourself or
+use --jaq to extract specific fields.
+
 EXAMPLES:
 
 data.csv

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -61,6 +61,14 @@ URL OPTIONS:
 <url-column> needs to be a fully qualified URL path. Alternatively, you can dynamically
 construct URLs for each CSV record with the --url-template option (see Examples below).
 
+JSON RESPONSE HANDLING:
+When --jaq is not used, fetch parses each successful response with serde_json and
+writes it back out (minified by default, or pretty-printed with --pretty). This means
+the response body is normalized — JSON object key order is sorted, integer/float
+representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
+stripped. If you need byte-exact server output, post-process the response yourself or
+use --jaq to extract specific fields.
+
 EXAMPLES USING THE URL-COLUMN ARGUMENT:
 
 data.csv

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -418,14 +418,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // connect to Redis at localhost, using database 1 by default when --redis-cache is enabled
     // fetch uses database 1 by default, as opposed to the database 2 with fetchpost
+    // safety: OnceLocks are set exactly once at startup
     DEFAULT_REDIS_CONN_STRING
         .set("redis://127.0.0.1:6379/1".to_string())
         .unwrap();
 
     // set memcache size
+    // safety: OnceLock set exactly once at startup
     MEM_CACHE_SIZE.set(args.flag_mem_cache_size).unwrap();
 
     // set timeout
+    // safety: OnceLock set exactly once at startup
     TIMEOUT_SECS
         .set(util::timeout_secs(args.flag_timeout)?)
         .unwrap();
@@ -434,9 +437,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let diskcache_dir = match &args.flag_disk_cache_dir {
         Some(dir) => {
             if dir.starts_with('~') {
-                // expand the tilde
-                let expanded_dir = expand_tilde(dir).unwrap();
-                expanded_dir.to_string_lossy().to_string()
+                // expand the tilde - returns None only if no home directory can be resolved
+                match expand_tilde(dir) {
+                    Some(expanded_dir) => expanded_dir.to_string_lossy().to_string(),
+                    None => {
+                        return fail_clierror!(r#"Cannot expand "{dir}": no home directory found"#);
+                    },
+                }
             } else {
                 dir.to_string()
             }
@@ -463,12 +470,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         {
             return fail_clierror!(r#"Cannot create cache directory "{diskcache_dir}": {e:?}"#);
         }
+        // safety: OnceLocks are set exactly once on the disk-cache path
         DISKCACHE_DIR.set(diskcache_dir).unwrap();
         // initialize DiskCache Config
         DISKCACHECONFIG.set(DiskCacheConfig::new()).unwrap();
         CacheType::Disk
     } else if args.flag_redis_cache {
         // initialize Redis Config
+        // safety: OnceLock set exactly once on the redis-cache path
         REDISCONFIG.set(RedisConfig::new()).unwrap();
 
         // check if redis connection is valid
@@ -542,10 +551,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if args.flag_url_template.is_none() {
         rconfig = rconfig.select(args.arg_url_column);
         let sel = rconfig.selection(&headers)?;
-        column_index = *sel.iter().next().unwrap();
         if sel.len() != 1 {
             return fail!("Only a single URL column may be selected.");
         }
+        // safety: sel.len() == 1 verified above
+        column_index = *sel.iter().next().unwrap();
     }
 
     let mut dynfmt_url_template = String::new();
@@ -578,7 +588,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     let rate_limit = match args.flag_rate_limit {
+        // safety: u32::MAX is non-zero
         0 => NonZeroU32::new(u32::MAX).unwrap(),
+        // safety: matched arm guarantees value is in 1..=1000
         1..=1000 => NonZeroU32::new(args.flag_rate_limit).unwrap(),
         _ => {
             return fail_incorrectusage_clierror!(
@@ -620,6 +632,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         map.append(
             reqwest::header::ACCEPT_ENCODING,
+            // safety: DEFAULT_ACCEPT_ENCODING is a static valid header value
             HeaderValue::from_str(DEFAULT_ACCEPT_ENCODING).unwrap(),
         );
         map
@@ -643,6 +656,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // set rate limiter with allow_burst set to 1 - see https://github.com/antifuchs/governor/issues/39
     let limiter =
+        // safety: 1 is non-zero
         RateLimiter::direct(Quota::per_second(rate_limit).allow_burst(NonZeroU32::new(1).unwrap()));
 
     // prep progress bars
@@ -692,15 +706,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         };
     }
 
-    // prepare report
-    let report = if args.flag_report.to_lowercase().starts_with('d') {
-        // if it starts with d, its a detailed report
-        ReportKind::Detailed
-    } else if args.flag_report.to_lowercase().starts_with('s') {
-        // if it starts with s, its a short report
-        ReportKind::Short
-    } else {
-        ReportKind::None
+    // prepare report - match on first byte to avoid two lowercase allocations
+    let report = match args.flag_report.as_bytes().first() {
+        Some(b'd' | b'D') => ReportKind::Detailed,
+        Some(b's' | b'S') => ReportKind::Short,
+        _ => ReportKind::None,
     };
 
     let mut report_wtr;
@@ -858,7 +868,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         // log::debug!("Disk cache hit for {url} hit: {disk_cache_hits}");
                     }
                     if !args.flag_cache_error && final_response.status_code != 200 {
-                        let _ = GET_DISKCACHE_RESPONSE.cache_remove(&url);
+                        // key must match get_diskcache_response's convert macro
+                        let key = format!(
+                            "{}{:?}{}{}{}",
+                            url,
+                            jaq_selector,
+                            args.flag_store_error,
+                            args.flag_pretty,
+                            include_existing_columns
+                        );
+                        let _ = GET_DISKCACHE_RESPONSE.cache_remove(&key);
                         // log::debug!("Removed Disk cache for {url}");
                     }
                 },
@@ -985,8 +1004,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             error_progress.finish_and_clear();
         } else if running_error_count >= args.flag_max_errors {
             error_progress.finish();
-            // sleep so we can dependably write eprintln without messing up progress bars
-            thread::sleep(time::Duration::from_nanos(10));
+            // sleep so we can dependably write eprintln without messing up progress bars.
+            // 100 ms covers a single 5Hz draw cycle of the multi-progress redraw thread.
+            thread::sleep(time::Duration::from_millis(100));
             let abort_msg = format!(
                 "{} max errors. Fetch aborted.",
                 HumanCount(args.flag_max_errors)
@@ -1010,6 +1030,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if report != ReportKind::None {
         use std::fmt::Write;
 
+        // safety: write! to a String is infallible
         write!(
             &mut end_msg,
             " {} report created: \"{}{FETCH_REPORT_SUFFIX}\"",
@@ -1159,6 +1180,7 @@ fn get_redis_response(
     flag_max_retries: u8,
 ) -> Result<cached::Return<String>, CliError> {
     Ok(Return::new({
+        // safety: FetchResponse only has String/u16/u8 fields - serialization is infallible
         simd_json::to_string(&get_response(
             url,
             client,
@@ -1190,7 +1212,8 @@ pub fn get_ratelimit_header_value<'a>(
 /// return 1 if the value is 0
 pub fn parse_ratelimit_header_value(value: Option<&HeaderValue>, sentinel_value: u64) -> u64 {
     value.map_or(sentinel_value, |v| {
-        atoi_simd::parse_pos::<u64, false>(v.to_str().unwrap().as_bytes()).unwrap_or(1)
+        // non-ASCII header bytes -> empty str -> parse fails -> fall through to 1
+        atoi_simd::parse_pos::<u64, false>(v.to_str().unwrap_or("").as_bytes()).unwrap_or(1)
     })
 }
 
@@ -1404,7 +1427,7 @@ fn get_response(
                 // wait before retrying, which is a valid value
                 // however, we don't want to do date-parsing here, so we just
                 // wait timeout_secs seconds before retrying
-                atoi_simd::parse_pos::<u64, false>(retry_after.to_str().unwrap().as_bytes())
+                atoi_simd::parse_pos::<u64, false>(retry_after.to_str().unwrap_or("").as_bytes())
                     .unwrap_or(timeout_secs)
             } else {
                 parse_ratelimit_header_value(ratelimit_reset.or(ratelimit_reset_sec), 0)

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -63,11 +63,15 @@ construct URLs for each CSV record with the --url-template option (see Examples 
 
 JSON RESPONSE HANDLING:
 When --jaq is not used, fetch parses each successful response with serde_json and
-writes it back out (minified by default, or pretty-printed with --pretty). This means
-the response body is normalized — JSON object key order is sorted, integer/float
-representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
-stripped. If you need byte-exact server output, post-process the response yourself or
-use --jaq to extract specific fields.
+writes it back out (compact by default, or re-indented with --pretty). Object key
+order is preserved (qsv enables serde_json's preserve_order feature), but the body
+is otherwise normalized: all insignificant whitespace is removed (compact) or
+re-indented (--pretty); number representations are canonicalized (e.g. 1e2 -> 100,
+leading zeros stripped, exponent form normalized); duplicate keys within a JSON
+object are collapsed (last value wins); and responses that are not valid JSON are
+written as an empty cell (or the parse error if --store-error is set). If you need
+byte-exact server output, post-process the response yourself or use --jaq to
+extract specific fields.
 
 EXAMPLES USING THE URL-COLUMN ARGUMENT:
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -706,7 +706,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         };
     }
 
-    // prepare report - match on first byte to avoid two lowercase allocations
+    // prepare report - match on first byte to avoid two lowercase allocations.
+    // ASCII-only by design: documented values are "detailed" / "short" / "none".
     let report = match args.flag_report.as_bytes().first() {
         Some(b'd' | b'D') => ReportKind::Detailed,
         Some(b's' | b'S') => ReportKind::Short,
@@ -868,14 +869,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         // log::debug!("Disk cache hit for {url} hit: {disk_cache_hits}");
                     }
                     if !args.flag_cache_error && final_response.status_code != 200 {
-                        // key must match get_diskcache_response's convert macro
-                        let key = format!(
-                            "{}{:?}{}{}{}",
-                            url,
-                            jaq_selector,
+                        let key = cross_session_cache_key(
+                            &url,
+                            jaq_selector.as_ref(),
                             args.flag_store_error,
                             args.flag_pretty,
-                            include_existing_columns
+                            include_existing_columns,
                         );
                         let _ = GET_DISKCACHE_RESPONSE.cache_remove(&key);
                         // log::debug!("Removed Disk cache for {url}");
@@ -906,13 +905,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         },
                     };
                     if !args.flag_cache_error && final_response.status_code != 200 {
-                        let key = format!(
-                            "{}{:?}{}{}{}",
-                            url,
-                            jaq_selector,
+                        let key = cross_session_cache_key(
+                            &url,
+                            jaq_selector.as_ref(),
                             args.flag_store_error,
                             args.flag_pretty,
-                            include_existing_columns
+                            include_existing_columns,
                         );
 
                         if GET_REDIS_RESPONSE.cache_remove(&key).is_err() && log_enabled!(Warn) {
@@ -1093,6 +1091,24 @@ fn get_cached_response(
     ))
 }
 
+// Cross-session cache key used by both the disk and redis caches.
+// Defined once and called from each `convert` macro and each `cache_remove`
+// call site so the format cannot drift (the original cache-eviction bug came
+// from a divergence between these).
+#[inline]
+fn cross_session_cache_key(
+    url: &str,
+    flag_jaq: Option<&String>,
+    flag_store_error: bool,
+    flag_pretty: bool,
+    include_existing_columns: bool,
+) -> String {
+    format!(
+        "{}{:?}{}{}{}",
+        url, flag_jaq, flag_store_error, flag_pretty, include_existing_columns
+    )
+}
+
 // this is a disk cache that can be used across qsv sessions
 // so we need to include the values of flag_jaq, flag_store_error, flag_pretty and
 // include_existing_columns in the cache key
@@ -1101,7 +1117,7 @@ fn get_cached_response(
     ty = "cached::DiskCache<String, FetchResponse>",
     cache_prefix_block = r##"{ "dc_" }"##,
     key = "String",
-    convert = r##"{ format!("{}{:?}{}{}{}", url, flag_jaq, flag_store_error, flag_pretty, include_existing_columns) }"##,
+    convert = r##"{ cross_session_cache_key(url, flag_jaq, flag_store_error, flag_pretty, include_existing_columns) }"##,
     create = r##"{
         let cache_dir = DISKCACHE_DIR.get().unwrap();
         let diskcache_config = DISKCACHECONFIG.get().unwrap();
@@ -1149,7 +1165,7 @@ fn get_diskcache_response(
 #[io_cached(
     ty = "cached::RedisCache<String, String>",
     key = "String",
-    convert = r##"{ format!("{}{:?}{}{}{}", url, flag_jaq, flag_store_error, flag_pretty, include_existing_columns) }"##,
+    convert = r##"{ cross_session_cache_key(url, flag_jaq, flag_store_error, flag_pretty, include_existing_columns) }"##,
     create = r##" {
         let redis_config = REDISCONFIG.get().unwrap();
         let rediscache = RedisCache::new("f", redis_config.ttl_secs)

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -83,11 +83,15 @@ from which the URL value will be retrieved for each record, or as the URL litera
 
 JSON RESPONSE HANDLING:
 When --jaq is not used, fetchpost parses each successful response with serde_json and
-writes it back out (minified by default, or pretty-printed with --pretty). This means
-the response body is normalized — JSON object key order is sorted, integer/float
-representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
-stripped. If you need byte-exact server output, post-process the response yourself or
-use --jaq to extract specific fields.
+writes it back out (compact by default, or re-indented with --pretty). Object key
+order is preserved (qsv enables serde_json's preserve_order feature), but the body
+is otherwise normalized: all insignificant whitespace is removed (compact) or
+re-indented (--pretty); number representations are canonicalized (e.g. 1e2 -> 100,
+leading zeros stripped, exponent form normalized); duplicate keys within a JSON
+object are collapsed (last value wins); and responses that are not valid JSON are
+written as an empty cell (or the parse error if --store-error is set). If you need
+byte-exact server output, post-process the response yourself or use --jaq to
+extract specific fields.
 
 EXAMPLES:
 

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -725,7 +725,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         };
     }
 
-    // prepare report - match on first byte to avoid two lowercase allocations
+    // prepare report - match on first byte to avoid two lowercase allocations.
+    // ASCII-only by design: documented values are "detailed" / "short" / "none".
     let report = match args.flag_report.as_bytes().first() {
         Some(b'd' | b'D') => ReportKind::Detailed,
         Some(b's' | b'S') => ReportKind::Short,
@@ -917,7 +918,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     final_response = intermediate_value.value;
                     was_cached = intermediate_value.was_cached;
                     if !args.flag_cache_error && final_response.status_code != 200 {
-                        // key must match get_cached_response's convert macro
+                        // key matches get_cached_response's convert macro
+                        // (body-only — see NOTE above the cached fn).
                         let key = format!("{form_body_jsonmap:?}");
                         let mut cache = GET_CACHED_RESPONSE.lock();
                         cache.cache_remove(&key);
@@ -944,17 +946,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         // log::debug!("Disk cache hit for {url} hit: {disk_cache_hits}");
                     }
                     if !args.flag_cache_error && final_response.status_code != 200 {
-                        // key must match get_diskcache_response's convert macro
-                        let key = format!(
-                            "{}{:?}{}{:?}{}{}{}{}",
-                            url,
-                            form_body_jsonmap,
+                        let key = cross_session_cache_key(
+                            &url,
+                            &form_body_jsonmap,
                             payload_content_type,
-                            jaq_selector,
+                            jaq_selector.as_ref(),
                             args.flag_store_error,
                             args.flag_pretty,
                             args.flag_compress,
-                            include_existing_columns
+                            include_existing_columns,
                         );
                         let _ = GET_DISKCACHE_RESPONSE.cache_remove(&key);
                         // log::debug!("Removed Disk cache for {url}");
@@ -988,17 +988,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         },
                     };
                     if !args.flag_cache_error && final_response.status_code != 200 {
-                        // key must match get_redis_response's convert macro
-                        let key = format!(
-                            "{}{:?}{}{:?}{}{}{}{}",
-                            url,
-                            form_body_jsonmap,
+                        let key = cross_session_cache_key(
+                            &url,
+                            &form_body_jsonmap,
                             payload_content_type,
-                            jaq_selector,
+                            jaq_selector.as_ref(),
                             args.flag_store_error,
                             args.flag_pretty,
                             args.flag_compress,
-                            include_existing_columns
+                            include_existing_columns,
                         );
 
                         if GET_REDIS_RESPONSE.cache_remove(&key).is_err() && log_enabled!(Warn) {
@@ -1147,8 +1145,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     Ok(wtr.flush()?)
 }
 
-// we only need url in the cache key
-// as this is an in-memory cache that is only used for one qsv session
+// NOTE: keyed only by form_body_jsonmap (not URL/flags) — within a single
+// qsv session the flags are constant and the URL is typically a single
+// endpoint with the body varying per row, so the body alone discriminates.
+// If you call fetchpost with a CSV that varies BOTH URL and body, two rows
+// sharing a body but using different URLs will collide on the same in-memory
+// entry. The disk and redis caches use the wider cross_session_cache_key.
 #[cached(
     ty = "SizedCache<String, Return<FetchResponse>>",
     create = r##"{
@@ -1189,6 +1191,34 @@ fn get_cached_response(
     ))
 }
 
+// Cross-session cache key used by both the disk and redis caches.
+// Defined once and called from each `convert` macro and each `cache_remove`
+// call site so the format cannot drift (the original cache-eviction bug came
+// from a divergence between these).
+#[inline]
+fn cross_session_cache_key(
+    url: &str,
+    form_body_jsonmap: &serde_json::Map<String, Value>,
+    payload_content_type: ContentType,
+    flag_jaq: Option<&String>,
+    flag_store_error: bool,
+    flag_pretty: bool,
+    flag_compress: bool,
+    include_existing_columns: bool,
+) -> String {
+    format!(
+        "{}{:?}{}{:?}{}{}{}{}",
+        url,
+        form_body_jsonmap,
+        payload_content_type,
+        flag_jaq,
+        flag_store_error,
+        flag_pretty,
+        flag_compress,
+        include_existing_columns
+    )
+}
+
 // this is a disk cache that can be used across qsv sessions
 // so we need to include the values of flag_jaq, flag_store_error, flag_pretty and
 // include_existing_columns in the cache key
@@ -1197,7 +1227,7 @@ fn get_cached_response(
     ty = "cached::DiskCache<String, FetchResponse>",
     cache_prefix_block = r##"{ "dc_" }"##,
     key = "String",
-    convert = r#"{ format!("{}{:?}{}{:?}{}{}{}{}", url, form_body_jsonmap, payload_content_type, flag_jaq, flag_store_error, flag_pretty, flag_compress, include_existing_columns) }"#,
+    convert = r#"{ cross_session_cache_key(url, form_body_jsonmap, payload_content_type, flag_jaq, flag_store_error, flag_pretty, flag_compress, include_existing_columns) }"#,
     create = r##"{
         let cache_dir = DISKCACHE_DIR.get().unwrap();
         let diskcache_config = DISKCACHECONFIG.get().unwrap();
@@ -1251,7 +1281,7 @@ fn get_diskcache_response(
 #[io_cached(
     ty = "cached::RedisCache<String, String>",
     key = "String",
-    convert = r#"{ format!("{}{:?}{}{:?}{}{}{}{}", url, form_body_jsonmap, payload_content_type, flag_jaq, flag_store_error, flag_pretty, flag_compress, include_existing_columns) }"#,
+    convert = r#"{ cross_session_cache_key(url, form_body_jsonmap, payload_content_type, flag_jaq, flag_store_error, flag_pretty, flag_compress, include_existing_columns) }"#,
     create = r##" {
         let redis_config = REDISCONFIG.get().unwrap();
         let rediscache = RedisCache::new("fp", redis_config.ttl_secs)

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -372,11 +372,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let fp_redis_conn_str = std::env::var("QSV_FP_REDIS_CONNSTR")
         .unwrap_or_else(|_| "redis://127.0.0.1:6379/2".to_string());
 
+    // safety: OnceLocks are set exactly once at startup
     DEFAULT_REDIS_CONN_STRING.set(fp_redis_conn_str).unwrap();
 
     // set memcache size
+    // safety: OnceLock set exactly once at startup
     MEM_CACHE_SIZE.set(args.flag_mem_cache_size).unwrap();
 
+    // safety: OnceLock set exactly once at startup
     TIMEOUT_FP_SECS
         .set(util::timeout_secs(args.flag_timeout)?)
         .unwrap();
@@ -385,9 +388,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let diskcache_dir = match &args.flag_disk_cache_dir {
         Some(dir) => {
             if dir.starts_with('~') {
-                // expand the tilde
-                let expanded_dir = expand_tilde(dir).unwrap();
-                expanded_dir.to_string_lossy().to_string()
+                // expand the tilde - returns None only if no home directory can be resolved
+                match expand_tilde(dir) {
+                    Some(expanded_dir) => expanded_dir.to_string_lossy().to_string(),
+                    None => {
+                        return fail_clierror!(r#"Cannot expand "{dir}": no home directory found"#);
+                    },
+                }
             } else {
                 dir.to_string()
             }
@@ -414,12 +421,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         {
             return fail_clierror!(r#"Cannot create cache directory "{diskcache_dir}": {e:?}"#);
         }
+        // safety: OnceLocks are set exactly once on the disk-cache path
         DISKCACHE_DIR.set(diskcache_dir).unwrap();
         // initialize DiskCache Config
         DISKCACHECONFIG.set(DiskCacheConfig::new()).unwrap();
         CacheType::Disk
     } else if args.flag_redis_cache {
         // initialize Redis Config
+        // safety: OnceLock set exactly once on the redis-cache path
         REDISCONFIG.set(RedisConfig::new()).unwrap();
 
         // check if redis connection is valid
@@ -538,14 +547,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if !literal_url_used {
         rconfig = rconfig.select(args.arg_url_column);
         let sel = rconfig.selection(&headers)?;
-        column_index = *sel.iter().next().unwrap();
         if sel.len() != 1 {
             return fail!("Only a single URL column may be selected.");
         }
+        // safety: sel.len() == 1 verified above
+        column_index = *sel.iter().next().unwrap();
     }
 
     let rate_limit = match args.flag_rate_limit {
+        // safety: u32::MAX is non-zero
         0 => NonZeroU32::new(u32::MAX).unwrap(),
+        // safety: matched arm guarantees value is in 1..=1000
         1..=1000 => NonZeroU32::new(args.flag_rate_limit).unwrap(),
         _ => {
             return fail_incorrectusage_clierror!(
@@ -603,6 +615,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         map.append(
             reqwest::header::ACCEPT_ENCODING,
+            // safety: DEFAULT_ACCEPT_ENCODING is a static valid header value
             HeaderValue::from_str(DEFAULT_ACCEPT_ENCODING).unwrap(),
         );
 
@@ -662,6 +675,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // set rate limiter with allow_burst set to 1 - see https://github.com/antifuchs/governor/issues/39
     let limiter =
+        // safety: 1 is non-zero
         RateLimiter::direct(Quota::per_second(rate_limit).allow_burst(NonZeroU32::new(1).unwrap()));
 
     // prep progress bars
@@ -711,15 +725,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         };
     }
 
-    // prepare report
-    let report = if args.flag_report.to_lowercase().starts_with('d') {
-        // if it starts with d, its a detailed report
-        ReportKind::Detailed
-    } else if args.flag_report.to_lowercase().starts_with('s') {
-        // if it starts with s, its a short report
-        ReportKind::Short
-    } else {
-        ReportKind::None
+    // prepare report - match on first byte to avoid two lowercase allocations
+    let report = match args.flag_report.as_bytes().first() {
+        Some(b'd' | b'D') => ReportKind::Detailed,
+        Some(b's' | b'S') => ReportKind::Short,
+        _ => ReportKind::None,
     };
 
     let mut report_wtr;
@@ -907,8 +917,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     final_response = intermediate_value.value;
                     was_cached = intermediate_value.was_cached;
                     if !args.flag_cache_error && final_response.status_code != 200 {
+                        // key must match get_cached_response's convert macro
+                        let key = format!("{form_body_jsonmap:?}");
                         let mut cache = GET_CACHED_RESPONSE.lock();
-                        cache.cache_remove(&url);
+                        cache.cache_remove(&key);
                     }
                 },
                 CacheType::Disk => {
@@ -932,7 +944,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         // log::debug!("Disk cache hit for {url} hit: {disk_cache_hits}");
                     }
                     if !args.flag_cache_error && final_response.status_code != 200 {
-                        let _ = GET_DISKCACHE_RESPONSE.cache_remove(&url);
+                        // key must match get_diskcache_response's convert macro
+                        let key = format!(
+                            "{}{:?}{}{:?}{}{}{}{}",
+                            url,
+                            form_body_jsonmap,
+                            payload_content_type,
+                            jaq_selector,
+                            args.flag_store_error,
+                            args.flag_pretty,
+                            args.flag_compress,
+                            include_existing_columns
+                        );
+                        let _ = GET_DISKCACHE_RESPONSE.cache_remove(&key);
                         // log::debug!("Removed Disk cache for {url}");
                     }
                 },
@@ -964,12 +988,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         },
                     };
                     if !args.flag_cache_error && final_response.status_code != 200 {
+                        // key must match get_redis_response's convert macro
                         let key = format!(
-                            "{}{:?}{}{}{}",
+                            "{}{:?}{}{:?}{}{}{}{}",
                             url,
+                            form_body_jsonmap,
+                            payload_content_type,
                             jaq_selector,
                             args.flag_store_error,
                             args.flag_pretty,
+                            args.flag_compress,
                             include_existing_columns
                         );
 
@@ -1066,8 +1094,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             error_progress.finish_and_clear();
         } else if running_error_count >= args.flag_max_errors {
             error_progress.finish();
-            // sleep so we can dependably write eprintln without messing up progress bars
-            thread::sleep(time::Duration::from_nanos(10));
+            // sleep so we can dependably write eprintln without messing up progress bars.
+            // 100 ms covers a single 5Hz draw cycle of the multi-progress redraw thread.
+            thread::sleep(time::Duration::from_millis(100));
             let abort_msg = format!(
                 "{} max errors. Fetchpost aborted.",
                 HumanCount(args.flag_max_errors)
@@ -1091,6 +1120,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if report != ReportKind::None {
         use std::fmt::Write;
 
+        // safety: write! to a String is infallible
         write!(
             &mut end_msg,
             " {} report created: \"{}{FETCHPOST_REPORT_SUFFIX}\"",
@@ -1255,6 +1285,7 @@ fn get_redis_response(
     flag_max_retries: u8,
 ) -> Result<cached::Return<String>, CliError> {
     Ok(Return::new({
+        // safety: FetchResponse only has String/u16/u8 fields - serialization is infallible
         simd_json::to_string(&get_response(
             url,
             form_body_jsonmap,
@@ -1521,7 +1552,7 @@ fn get_response(
                 // wait before retrying, which is a valid value
                 // however, we don't want to do date-parsing here, so we just
                 // wait timeout_secs seconds before retrying
-                atoi_simd::parse_pos::<u64, false>(retry_after.to_str().unwrap().as_bytes())
+                atoi_simd::parse_pos::<u64, false>(retry_after.to_str().unwrap_or("").as_bytes())
                     .unwrap_or(timeout_secs)
             } else {
                 parse_ratelimit_header_value(ratelimit_reset.or(ratelimit_reset_sec), 0)

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -81,6 +81,14 @@ URL OPTIONS:
 <url-column> needs to be a fully qualified URL path. It can be specified as a column name
 from which the URL value will be retrieved for each record, or as the URL literal itself.
 
+JSON RESPONSE HANDLING:
+When --jaq is not used, fetchpost parses each successful response with serde_json and
+writes it back out (minified by default, or pretty-printed with --pretty). This means
+the response body is normalized — JSON object key order is sorted, integer/float
+representations may be canonicalized (e.g. 1e2 -> 100), and trailing whitespace is
+stripped. If you need byte-exact server output, post-process the response yourself or
+use --jaq to extract specific fields.
+
 EXAMPLES:
 
 data.csv

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -361,14 +361,17 @@ fn fetch_simple_diskcache() {
 
     let fetchreport_noelapsed = wrk.stdout::<String>(&mut cmd3);
     // read the output file and compare it with the expected output
+    // Note: error rows (404 and invalid URL) show cache_hit=0 because non-200
+    // responses are evicted from the disk cache when --cache-error is not set.
+    // Successful (200) rows are cached and show cache_hit=1.
     assert_eq!(
         fetchreport_noelapsed,
         r#"url,status,cache_hit,retries,response
-https://api.zippopotam.us/us/99999,404,1,5,"{""errors"":[{""title"":""HTTP ERROR"",""detail"":""HTTP ERROR 404 - Not Found""}]}"
+https://api.zippopotam.us/us/99999,404,0,5,"{""errors"":[{""title"":""HTTP ERROR"",""detail"":""HTTP ERROR 404 - Not Found""}]}"
 https://api.zippopotam.us/us/90210,200,1,0,"{""country"":""United States"",""country abbreviation"":""US"",""post code"":""90210"",""places"":[{""place name"":""Beverly Hills"",""longitude"":""-118.4065"",""latitude"":""34.0901"",""state"":""California"",""state abbreviation"":""CA""}]}"
 https://api.zippopotam.us/us/94105,200,1,0,"{""country"":""United States"",""country abbreviation"":""US"",""post code"":""94105"",""places"":[{""place name"":""San Francisco"",""longitude"":""-122.3892"",""latitude"":""37.7864"",""state"":""California"",""state abbreviation"":""CA""}]}"
 https://api.zippopotam.us/us/92802,200,1,0,"{""country"":""United States"",""country abbreviation"":""US"",""post code"":""92802"",""places"":[{""place name"":""Anaheim"",""longitude"":""-117.9228"",""latitude"":""33.8085"",""state"":""California"",""state abbreviation"":""CA""}]}"
-thisisnotaurl,404,1,0,"{""errors"":[{""title"":""Invalid URL"",""detail"":""relative URL without a base""}]}""#
+thisisnotaurl,404,0,0,"{""errors"":[{""title"":""Invalid URL"",""detail"":""relative URL without a base""}]}""#
     );
 }
 


### PR DESCRIPTION
## Summary

Review-driven correctness, panic-safety and clarity fixes for `fetch` and `fetchpost`. Refined across four commits in response to two roborev passes.

**Critical bugs fixed**

- **Disk-cache `cache_remove` key mismatch.** `cache_remove(&url)` looked up bare URLs against composite keys built by the `io_cached` `convert` macro, so non-200 responses were never evicted from disk when `--cache-error` was unset. Fixed in `fetch.rs` (Disk path) and `fetchpost.rs` (**InMemory + Disk + Redis** paths — fetchpost had the bug on all three cache types, with the in-memory key actually being `format!(\"{:?}\", form_body_jsonmap)`).
- **Selection panic on empty selector.** Reordered the `sel.len() != 1` check before `sel.iter().next().unwrap()` so an empty URL-column selection returns a friendly error instead of panicking.
- **`HeaderValue::to_str().unwrap()` on adversarial headers.** Replaced with `.unwrap_or(\"\")` in `retry-after` and `ratelimit-*` parsing so non-ASCII header bytes can't crash the process.

**Other fixes**

- Bumped the post-error 10ns progress-bar drain sleep to 100 ms (covers one 5 Hz redraw cycle).
- Replaced two `to_lowercase()` allocations on `--report` with a `match` on the first byte (ASCII-only by design — documented values are `detailed` / `short` / `none`).
- Converted `expand_tilde(dir).unwrap()` to a graceful `fail_clierror!` for systems with no resolvable home directory.
- Added `// safety:` comments on the remaining infallible unwraps (OnceLock::set, NonZeroU32::new on constants, infallible String `write!`, infallible simd_json::to_string of `FetchResponse`) per qsv conventions.

**Refactor (in response to roborev 1680)**

- Extracted `cross_session_cache_key()` helper in both files. The `convert` macros and the `cache_remove` call sites now both go through the helper, eliminating the format-string duplication that introduced the original eviction bug. The fetchpost in-memory cache retains its body-only key but now has an accurate NOTE flagging the URL-collision edge case (widening was deferred as a behavior change).

**Documentation (in response to roborev 1682)**

- Added a `JSON RESPONSE HANDLING` section to both USAGE blocks. Without `--jaq`, every successful response is parsed by `serde_json` and re-serialized: object key order is preserved (qsv enables `preserve_order`), but all insignificant whitespace is removed, number representations are canonicalized (e.g. `1e2` -> `100`), duplicate keys are collapsed (last-value-wins), and non-JSON responses become empty cells (or the parse error if `--store-error` is set). Help-md regenerated.

**Test updated**

- `tests/test_fetch.rs::fetch_simple_diskcache` was asserting `cache_hit=1` for the 404 and \"Invalid URL\" rows on the second pass — i.e. it was *encoding the disk-cache bug*. Updated to expect `cache_hit=0`, with a comment explaining that non-200 responses are correctly evicted when `--cache-error` is unset.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features` — clean
- [x] `cargo +nightly fmt -- --check` — clean
- [x] `cargo +nightly clippy --bin qsv -F all_features -- -W clippy::perf` — no fetch-related warnings
- [x] `cargo test --locked -F all_features fetch` — 41 passed, 1 ignored, 0 failed
- [x] Two roborev passes on the diff, both findings addressed and closed (1680, 1682)

## Deferred (not in this PR)

- `#![allow(unused_assignments)]` suppression — legitimate pre-allocation pattern; removing it forces `Option<...>` wrapping that fights the match-arm structure
- Unconditional `OnceLock::set` at startup — cosmetic; only `DEFAULT_REDIS_CONN_STRING` is genuinely conditional, ~3 lines of churn
- Loop-hoisted `intermediate_value` / `intermediate_redis_value` — the \"amortization\" comment is wrong (Strings are dropped on each reassignment) but moving the declarations is pure shuffling

🤖 Generated with [Claude Code](https://claude.com/claude-code)