### PR TITLE
slice: review-driven panic and underflow fixes

### DIFF
--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -42,10 +42,10 @@ Examples:
   # Slice from the second record, two records
   qsv slice -s 1 --len 2 data.csv
 
-  # Slice records 10 to 20 as JSON
+  # Slice records 10 to 19 as JSON (--end is exclusive)
   qsv slice --start 9 --end 19 --json data.csv
 
-  # Slice records 1 to 9 and 21 to the end as JSON
+  # Slice records 1 to 9 and 20 to the end as JSON
   qsv slice --start 9 --len 10 --invert --json data.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_slice.rs.
@@ -123,7 +123,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .canonicalize()?
         .into_os_string()
         .into_string()
-        .unwrap();
+        .map_err(|os| {
+            crate::CliError::Other(format!(
+                "input path is not valid UTF-8: {}",
+                os.to_string_lossy()
+            ))
+        })?;
 
     args.arg_input = Some(input_filename);
 
@@ -138,25 +143,30 @@ impl Args {
         let mut rdr = self.rconfig().reader()?;
 
         let (start, end) = self.range()?;
+        // empty slice with no inversion: nothing to do
+        if end == start && !self.flag_invert {
+            if !self.flag_json {
+                let mut wtr = self.wconfig().writer()?;
+                self.rconfig().write_headers(&mut rdr, &mut wtr)?;
+                wtr.flush()?;
+            }
+            return Ok(());
+        }
+
         if self.flag_json {
             let headers = rdr.byte_headers()?.clone();
-            let records = rdr.byte_records().enumerate().filter_map(move |(i, r)| {
-                let should_include = if self.flag_invert {
-                    i < start || i >= end
-                } else {
-                    i >= start && i < end
-                };
-                if should_include {
-                    Some(r.unwrap())
-                } else {
-                    None
-                }
-            });
+            // collect into a Result so CSV parse errors propagate instead of panicking
+            let records = rdr
+                .byte_records()
+                .enumerate()
+                .filter(|(i, _)| self.flag_invert == (*i < start || *i >= end))
+                .map(|(_, r)| r)
+                .collect::<Result<Vec<_>, _>>()?;
             util::write_json(
                 self.flag_output.as_ref(),
                 self.flag_no_headers,
                 &headers,
-                records,
+                records.into_iter(),
             )
         } else {
             let mut wtr = self.wconfig().writer()?;
@@ -172,27 +182,34 @@ impl Args {
     }
 
     fn with_index(&self, mut indexed_file: Indexed<fs::File, fs::File>) -> CliResult<()> {
-        let (start, end) = self.range()?;
-        if end - start == 0 && !self.flag_invert {
+        let total_rows = util::count_rows(&self.rconfig())? as usize;
+        let (start_raw, end_raw) = self.range()?;
+        // clamp to row count so arithmetic on `total_rows - end` cannot underflow
+        // and `Indexed::seek` is never called past EOF
+        let start = start_raw.min(total_rows);
+        let end = end_raw.min(total_rows);
+        if end == start && !self.flag_invert {
             return Ok(());
         }
 
         if self.flag_json {
             let headers = indexed_file.byte_headers()?.clone();
-            let total_rows = util::count_rows(&self.rconfig())?;
-            let records = if self.flag_invert {
+            let records: Vec<csv::ByteRecord> = if self.flag_invert {
                 let mut records: Vec<csv::ByteRecord> =
-                    Vec::with_capacity(start + (total_rows as usize - end));
+                    Vec::with_capacity(start + (total_rows - end));
                 // Get records before start
-                indexed_file.seek(0)?;
-                for r in indexed_file.byte_records().take(start) {
-                    records.push(r.unwrap());
+                if start > 0 {
+                    indexed_file.seek(0)?;
+                    for r in indexed_file.byte_records().take(start) {
+                        records.push(r?);
+                    }
                 }
-
-                // Get records after end
-                indexed_file.seek(end as u64)?;
-                for r in indexed_file.byte_records().take(total_rows as usize - end) {
-                    records.push(r.unwrap());
+                // Get records after end (skip when end == total_rows; seek(total_rows) errors)
+                if end < total_rows {
+                    indexed_file.seek(end as u64)?;
+                    for r in indexed_file.byte_records().take(total_rows - end) {
+                        records.push(r?);
+                    }
                 }
                 records
             } else {
@@ -200,8 +217,7 @@ impl Args {
                 indexed_file
                     .byte_records()
                     .take(end - start)
-                    .map(|r| r.unwrap())
-                    .collect::<Vec<_>>()
+                    .collect::<Result<Vec<_>, _>>()?
             };
             util::write_json(
                 self.flag_output.as_ref(),
@@ -213,18 +229,18 @@ impl Args {
             let mut wtr = self.wconfig().writer()?;
             self.rconfig().write_headers(&mut *indexed_file, &mut wtr)?;
 
-            let total_rows = util::count_rows(&self.rconfig())? as usize;
             if self.flag_invert {
-                // Get records before start
-                indexed_file.seek(0)?;
-                for r in indexed_file.byte_records().take(start) {
-                    wtr.write_byte_record(&r?)?;
+                if start > 0 {
+                    indexed_file.seek(0)?;
+                    for r in indexed_file.byte_records().take(start) {
+                        wtr.write_byte_record(&r?)?;
+                    }
                 }
-
-                // Get records after end
-                indexed_file.seek(end as u64)?;
-                for r in indexed_file.byte_records().take(total_rows - end) {
-                    wtr.write_byte_record(&r?)?;
+                if end < total_rows {
+                    indexed_file.seek(end as u64)?;
+                    for r in indexed_file.byte_records().take(total_rows - end) {
+                        wtr.write_byte_record(&r?)?;
+                    }
                 }
             } else {
                 indexed_file.seek(start as u64)?;
@@ -237,27 +253,21 @@ impl Args {
     }
 
     fn range(&self) -> CliResult<(usize, usize)> {
-        let mut start = None;
-        if let Some(start_arg) = self.flag_start {
-            if start_arg < 0 {
-                start = Some(
-                    (util::count_rows(&self.rconfig())? as usize)
-                        .abs_diff(start_arg.unsigned_abs()),
-                );
-            } else {
-                start = Some(start_arg as usize);
-            }
-        }
-        let index = if let Some(flag_index) = self.flag_index {
-            if flag_index < 0 {
-                let index = (util::count_rows(&self.rconfig())? as usize)
-                    .abs_diff(flag_index.unsigned_abs());
-                Some(index)
-            } else {
-                Some(flag_index as usize)
-            }
-        } else {
-            None
+        let start = match self.flag_start {
+            // saturating_sub so |negative offset| > row count clamps to 0
+            // (i.e. "from the start") rather than past the end of the file
+            Some(s) if s < 0 => {
+                Some((util::count_rows(&self.rconfig())? as usize).saturating_sub(s.unsigned_abs()))
+            },
+            Some(s) => Some(s as usize),
+            None => None,
+        };
+        let index = match self.flag_index {
+            Some(i) if i < 0 => {
+                Some((util::count_rows(&self.rconfig())? as usize).saturating_sub(i.unsigned_abs()))
+            },
+            Some(i) => Some(i as usize),
+            None => None,
         };
         Ok(util::range(start, self.flag_end, self.flag_len, index)?)
     }

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -203,22 +203,29 @@ impl Args {
                 // invert needs two non-contiguous reads (before start, after end)
                 // and we can only hold one borrow on indexed_file at a time, so
                 // we materialize each segment before seeking to the next.
-                let mut records: Vec<csv::Result<csv::ByteRecord>> =
+                // Use `push(r?)` (not `extend`) so a parse error in segment 1
+                // aborts before segment 2 is read, preserving the all-or-nothing
+                // failure semantics this path had before the streaming refactor.
+                let mut records: Vec<csv::ByteRecord> =
                     Vec::with_capacity(start + (total_rows - end));
                 if start > 0 {
                     indexed_file.seek(0)?;
-                    records.extend(indexed_file.byte_records().take(start));
+                    for r in indexed_file.byte_records().take(start) {
+                        records.push(r?);
+                    }
                 }
                 // skip seek(total_rows) — it would error past EOF
                 if end < total_rows {
                     indexed_file.seek(end as u64)?;
-                    records.extend(indexed_file.byte_records().take(total_rows - end));
+                    for r in indexed_file.byte_records().take(total_rows - end) {
+                        records.push(r?);
+                    }
                 }
                 util::write_json(
                     self.flag_output.as_ref(),
                     self.flag_no_headers,
                     &headers,
-                    records.into_iter(),
+                    records.into_iter().map(Ok),
                 )
             } else {
                 // contiguous read — stream straight through
@@ -266,10 +273,10 @@ impl Args {
         let needs_count = matches!(self.flag_start, Some(s) if s < 0)
             || matches!(self.flag_index, Some(i) if i < 0);
         let total = if needs_count {
-            match precomputed_total {
-                Some(t) => Some(t),
-                None => Some(util::count_rows(&self.rconfig())? as usize),
-            }
+            Some(match precomputed_total {
+                Some(t) => t,
+                None => util::count_rows(&self.rconfig())? as usize,
+            })
         } else {
             None
         };

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -142,21 +142,21 @@ impl Args {
     fn no_index(&self) -> CliResult<()> {
         let mut rdr = self.rconfig().reader()?;
 
-        let (start, end) = self.range()?;
+        let (start, end) = self.range(None)?;
         if self.flag_json {
             let headers = rdr.byte_headers()?.clone();
-            // collect into a Result so CSV parse errors propagate instead of panicking
+            // stream records straight to write_json — parse errors propagate
+            // via the Result item type without buffering the whole slice
             let records = rdr
                 .byte_records()
                 .enumerate()
                 .filter(|(i, _)| self.flag_invert == (*i < start || *i >= end))
-                .map(|(_, r)| r)
-                .collect::<Result<Vec<_>, _>>()?;
+                .map(|(_, r)| r);
             util::write_json(
                 self.flag_output.as_ref(),
                 self.flag_no_headers,
                 &headers,
-                records.into_iter(),
+                records,
             )
         } else {
             let mut wtr = self.wconfig().writer()?;
@@ -173,7 +173,8 @@ impl Args {
 
     fn with_index(&self, mut indexed_file: Indexed<fs::File, fs::File>) -> CliResult<()> {
         let total_rows = util::count_rows(&self.rconfig())? as usize;
-        let (start_raw, end_raw) = self.range()?;
+        // reuse the precomputed total — avoids a second count_rows call inside range()
+        let (start_raw, end_raw) = self.range(Some(total_rows))?;
         // clamp to row count so arithmetic on `total_rows - end` cannot underflow
         // and `Indexed::seek` is never called past EOF
         let start = start_raw.min(total_rows);
@@ -187,7 +188,7 @@ impl Args {
                     self.flag_output.as_ref(),
                     self.flag_no_headers,
                     &headers,
-                    std::iter::empty(),
+                    std::iter::empty::<csv::Result<csv::ByteRecord>>(),
                 );
             }
             let mut wtr = self.wconfig().writer()?;
@@ -198,37 +199,38 @@ impl Args {
 
         if self.flag_json {
             let headers = indexed_file.byte_headers()?.clone();
-            let records: Vec<csv::ByteRecord> = if self.flag_invert {
-                let mut records: Vec<csv::ByteRecord> =
+            if self.flag_invert {
+                // invert needs two non-contiguous reads (before start, after end)
+                // and we can only hold one borrow on indexed_file at a time, so
+                // we materialize each segment before seeking to the next.
+                let mut records: Vec<csv::Result<csv::ByteRecord>> =
                     Vec::with_capacity(start + (total_rows - end));
-                // Get records before start
                 if start > 0 {
                     indexed_file.seek(0)?;
-                    for r in indexed_file.byte_records().take(start) {
-                        records.push(r?);
-                    }
+                    records.extend(indexed_file.byte_records().take(start));
                 }
-                // Get records after end (skip when end == total_rows; seek(total_rows) errors)
+                // skip seek(total_rows) — it would error past EOF
                 if end < total_rows {
                     indexed_file.seek(end as u64)?;
-                    for r in indexed_file.byte_records().take(total_rows - end) {
-                        records.push(r?);
-                    }
+                    records.extend(indexed_file.byte_records().take(total_rows - end));
                 }
-                records
+                util::write_json(
+                    self.flag_output.as_ref(),
+                    self.flag_no_headers,
+                    &headers,
+                    records.into_iter(),
+                )
             } else {
+                // contiguous read — stream straight through
                 indexed_file.seek(start as u64)?;
-                indexed_file
-                    .byte_records()
-                    .take(end - start)
-                    .collect::<Result<Vec<_>, _>>()?
-            };
-            util::write_json(
-                self.flag_output.as_ref(),
-                self.flag_no_headers,
-                &headers,
-                records.into_iter(),
-            )
+                let records = indexed_file.byte_records().take(end - start);
+                util::write_json(
+                    self.flag_output.as_ref(),
+                    self.flag_no_headers,
+                    &headers,
+                    records,
+                )
+            }
         } else {
             let mut wtr = self.wconfig().writer()?;
             self.rconfig().write_headers(&mut *indexed_file, &mut wtr)?;
@@ -256,14 +258,18 @@ impl Args {
         }
     }
 
-    fn range(&self) -> CliResult<(usize, usize)> {
+    fn range(&self, precomputed_total: Option<usize>) -> CliResult<(usize, usize)> {
         // util::range rejects mixing --index with --start/--end/--len, but we
         // still resolve both independently here. count_rows is only needed for
-        // negative offsets — fetch it at most once.
+        // negative offsets — fetch it at most once, or accept a precomputed
+        // value from with_index() so the indexed path doesn't double-count.
         let needs_count = matches!(self.flag_start, Some(s) if s < 0)
             || matches!(self.flag_index, Some(i) if i < 0);
         let total = if needs_count {
-            Some(util::count_rows(&self.rconfig())? as usize)
+            match precomputed_total {
+                Some(t) => Some(t),
+                None => Some(util::count_rows(&self.rconfig())? as usize),
+            }
         } else {
             None
         };

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -143,16 +143,6 @@ impl Args {
         let mut rdr = self.rconfig().reader()?;
 
         let (start, end) = self.range()?;
-        // empty slice with no inversion: nothing to do
-        if end == start && !self.flag_invert {
-            if !self.flag_json {
-                let mut wtr = self.wconfig().writer()?;
-                self.rconfig().write_headers(&mut rdr, &mut wtr)?;
-                wtr.flush()?;
-            }
-            return Ok(());
-        }
-
         if self.flag_json {
             let headers = rdr.byte_headers()?.clone();
             // collect into a Result so CSV parse errors propagate instead of panicking
@@ -188,7 +178,21 @@ impl Args {
         // and `Indexed::seek` is never called past EOF
         let start = start_raw.min(total_rows);
         let end = end_raw.min(total_rows);
+        // empty slice with no inversion: emit just headers ([] for JSON) so
+        // downstream parsers always see a well-formed document
         if end == start && !self.flag_invert {
+            if self.flag_json {
+                let headers = indexed_file.byte_headers()?.clone();
+                return util::write_json(
+                    self.flag_output.as_ref(),
+                    self.flag_no_headers,
+                    &headers,
+                    std::iter::empty(),
+                );
+            }
+            let mut wtr = self.wconfig().writer()?;
+            self.rconfig().write_headers(&mut *indexed_file, &mut wtr)?;
+            wtr.flush()?;
             return Ok(());
         }
 
@@ -253,19 +257,25 @@ impl Args {
     }
 
     fn range(&self) -> CliResult<(usize, usize)> {
+        // util::range rejects mixing --index with --start/--end/--len, but we
+        // still resolve both independently here. count_rows is only needed for
+        // negative offsets — fetch it at most once.
+        let needs_count = matches!(self.flag_start, Some(s) if s < 0)
+            || matches!(self.flag_index, Some(i) if i < 0);
+        let total = if needs_count {
+            Some(util::count_rows(&self.rconfig())? as usize)
+        } else {
+            None
+        };
+        // saturating_sub so |negative offset| > row count clamps to 0
+        // (i.e. "from the start") rather than past the end of the file
         let start = match self.flag_start {
-            // saturating_sub so |negative offset| > row count clamps to 0
-            // (i.e. "from the start") rather than past the end of the file
-            Some(s) if s < 0 => {
-                Some((util::count_rows(&self.rconfig())? as usize).saturating_sub(s.unsigned_abs()))
-            },
+            Some(s) if s < 0 => Some(total.unwrap().saturating_sub(s.unsigned_abs())),
             Some(s) => Some(s as usize),
             None => None,
         };
         let index = match self.flag_index {
-            Some(i) if i < 0 => {
-                Some((util::count_rows(&self.rconfig())? as usize).saturating_sub(i.unsigned_abs()))
-            },
+            Some(i) if i < 0 => Some(total.unwrap().saturating_sub(i.unsigned_abs())),
             Some(i) => Some(i as usize),
             None => None,
         };

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -268,14 +268,18 @@ impl Args {
             None
         };
         // saturating_sub so |negative offset| > row count clamps to 0
-        // (i.e. "from the start") rather than past the end of the file
+        // (i.e. "from the start") rather than past the end of the file.
+        // unwrap_or(0) keeps this panic-free even if the predicate above
+        // and the negative arms ever drift apart — non-negative offsets
+        // don't read the count.
+        let total = total.unwrap_or(0);
         let start = match self.flag_start {
-            Some(s) if s < 0 => Some(total.unwrap().saturating_sub(s.unsigned_abs())),
+            Some(s) if s < 0 => Some(total.saturating_sub(s.unsigned_abs())),
             Some(s) => Some(s as usize),
             None => None,
         };
         let index = match self.flag_index {
-            Some(i) if i < 0 => Some(total.unwrap().saturating_sub(i.unsigned_abs())),
+            Some(i) if i < 0 => Some(total.saturating_sub(i.unsigned_abs())),
             Some(i) => Some(i as usize),
             None => None,
         };

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -172,7 +172,9 @@ impl Args {
     }
 
     fn with_index(&self, mut indexed_file: Indexed<fs::File, fs::File>) -> CliResult<()> {
-        let total_rows = util::count_rows(&self.rconfig())? as usize;
+        // read the row count straight off the already-loaded index instead of
+        // going through util::count_rows, which would reopen the CSV/index
+        let total_rows = indexed_file.count() as usize;
         // reuse the precomputed total — avoids a second count_rows call inside range()
         let (start_raw, end_raw) = self.range(Some(total_rows))?;
         // clamp to row count so arithmetic on `total_rows - end` cannot underflow

--- a/src/util.rs
+++ b/src/util.rs
@@ -2505,12 +2505,16 @@ pub fn create_json_writer(
     Ok(writer)
 }
 
-/// iterate over the CSV ByteRecords and write them to the JSON file
+/// iterate over the CSV ByteRecords and write them to the JSON file.
+///
+/// Records are taken as `csv::Result<ByteRecord>` so callers can pass the
+/// raw `byte_records()` iterator and have parse errors propagate with `?`
+/// without buffering the entire slice in memory first.
 pub fn write_json(
     output: Option<&String>,
     no_headers: bool,
     headers: &csv::ByteRecord,
-    records: impl Iterator<Item = csv::ByteRecord>,
+    records: impl Iterator<Item = csv::Result<csv::ByteRecord>>,
 ) -> CliResult<()> {
     let mut json_wtr = create_json_writer(output, config::DEFAULT_WTR_BUFFER_CAPACITY * 4)?;
 
@@ -2538,6 +2542,7 @@ pub fn write_json(
     let mut json_string_val: serde_json::Value;
 
     for record in records {
+        let record = record?;
         if is_first {
             is_first = false;
         } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -2512,12 +2512,12 @@ pub fn create_json_writer(
 /// without buffering the entire slice in memory first.
 ///
 /// **Failure semantics:** because records stream straight to the writer,
-/// a CSV parse error mid-stream means the opening `[`, any prior records,
-/// and the trailing comma will already have been written before the error
-/// propagates — so the output (stdout or `output` file) may be a truncated,
-/// syntactically invalid JSON document. The closing `]` is only written
-/// after the loop completes cleanly. Callers that need all-or-nothing
-/// semantics must validate / collect records before invoking this.
+/// a CSV parse error mid-stream means the opening `[` and any prior records
+/// will already have been written before the error propagates. The closing
+/// `]` is only written after the loop completes cleanly, so the output
+/// (stdout or `output` file) may be a truncated, syntactically invalid
+/// JSON document on error. Callers that need all-or-nothing semantics must
+/// validate / collect records before invoking this.
 pub fn write_json(
     output: Option<&String>,
     no_headers: bool,

--- a/src/util.rs
+++ b/src/util.rs
@@ -2510,6 +2510,14 @@ pub fn create_json_writer(
 /// Records are taken as `csv::Result<ByteRecord>` so callers can pass the
 /// raw `byte_records()` iterator and have parse errors propagate with `?`
 /// without buffering the entire slice in memory first.
+///
+/// **Failure semantics:** because records stream straight to the writer,
+/// a CSV parse error mid-stream means the opening `[`, any prior records,
+/// and the trailing comma will already have been written before the error
+/// propagates — so the output (stdout or `output` file) may be a truncated,
+/// syntactically invalid JSON document. The closing `]` is only written
+/// after the loop completes cleanly. Callers that need all-or-nothing
+/// semantics must validate / collect records before invoking this.
 pub fn write_json(
     output: Option<&String>,
     no_headers: bool,

--- a/tests/test_slice.rs
+++ b/tests/test_slice.rs
@@ -613,6 +613,23 @@ fn slice_empty_json_with_index() {
     );
 }
 
+// Empty JSON slice with --no-headers + --json on the indexed path: confirms
+// the empty-slice short-circuit forwards flag_no_headers to write_json
+// the same way the non-empty path does.
+#[test]
+fn slice_empty_json_no_headers_with_index() {
+    test_slice(
+        "slice_empty_json_no_headers_with_index",
+        Some(5),
+        Some(5),
+        &[],
+        false,
+        true,
+        false,
+        true,
+    );
+}
+
 // Same clamping behavior for negative --index.
 #[test]
 fn slice_neg_index_clamps_to_zero() {

--- a/tests/test_slice.rs
+++ b/tests/test_slice.rs
@@ -583,6 +583,36 @@ fn slice_negative_start_clamps_to_zero() {
     );
 }
 
+// Empty non-invert JSON slice must still emit `[]` so downstream parsers
+// see a well-formed document, both with and without an index.
+#[test]
+fn slice_empty_json_no_index() {
+    test_slice(
+        "slice_empty_json_no_index",
+        Some(5),
+        Some(5),
+        &[],
+        true,
+        false,
+        false,
+        true,
+    );
+}
+
+#[test]
+fn slice_empty_json_with_index() {
+    test_slice(
+        "slice_empty_json_with_index",
+        Some(5),
+        Some(5),
+        &[],
+        true,
+        true,
+        false,
+        true,
+    );
+}
+
 // Same clamping behavior for negative --index.
 #[test]
 fn slice_neg_index_clamps_to_zero() {

--- a/tests/test_slice.rs
+++ b/tests/test_slice.rs
@@ -462,6 +462,140 @@ fn slice_invert_with_len() {
     );
 }
 
+// negative --start with no --end, indexed: previously errored at seek(usize::MAX)
+#[test]
+fn slice_invert_negative_with_index() {
+    test_slice_invert(
+        "slice_invert_negative_with_index",
+        Some(-2),
+        None,
+        &["a", "b", "c"],
+        true,
+        true,
+        false,
+        false,
+    );
+}
+
+// --start equals row count, indexed: previously underflowed total_rows-end and
+// errored at seek(usize::MAX). Slice 5..end on a 5-row file is empty, so invert
+// is the entire file.
+#[test]
+fn slice_invert_start_at_eof_with_index() {
+    test_slice_invert(
+        "slice_invert_start_at_eof_with_index",
+        Some(5),
+        None,
+        &["a", "b", "c", "d", "e"],
+        true,
+        true,
+        false,
+        false,
+    );
+}
+
+// --start past EOF, indexed: previously underflowed / errored.
+#[test]
+fn slice_invert_start_past_eof_with_index() {
+    test_slice_invert(
+        "slice_invert_start_past_eof_with_index",
+        Some(100),
+        None,
+        &["a", "b", "c", "d", "e"],
+        true,
+        true,
+        false,
+        false,
+    );
+}
+
+// --end past EOF, --invert, indexed: previously panicked on
+// `total_rows - end` subtract overflow in the "after end" loop. Slice covers
+// the whole file, so invert is empty.
+#[test]
+fn slice_invert_end_past_eof_with_index() {
+    test_slice_invert(
+        "slice_invert_end_past_eof_with_index",
+        Some(0),
+        Some(1000),
+        &[],
+        true,
+        true,
+        false,
+        false,
+    );
+}
+
+// JSON variant of the above (no-index): exercises the JSON record collector.
+#[test]
+fn slice_invert_end_past_eof_json() {
+    test_slice_invert(
+        "slice_invert_end_past_eof_json",
+        Some(0),
+        Some(1000),
+        &[],
+        true,
+        false,
+        false,
+        true,
+    );
+}
+
+// --end past EOF on the non-invert indexed path: should return all rows
+// up to EOF rather than erroring at seek().
+#[test]
+fn slice_end_past_eof_with_index() {
+    test_slice(
+        "slice_end_past_eof_with_index",
+        Some(0),
+        Some(1000),
+        &["a", "b", "c", "d", "e"],
+        true,
+        true,
+        false,
+        false,
+    );
+}
+
+// |negative --start| larger than row count must clamp to 0
+// (saturating_sub), not wrap to a position past the end of the file.
+#[test]
+fn slice_negative_start_clamps_to_zero() {
+    test_slice(
+        "slice_negative_start_clamps_to_zero",
+        Some(-100),
+        None,
+        &["a", "b", "c", "d", "e"],
+        true,
+        false,
+        false,
+        false,
+    );
+    test_slice(
+        "slice_negative_start_clamps_to_zero_with_index",
+        Some(-100),
+        None,
+        &["a", "b", "c", "d", "e"],
+        true,
+        true,
+        false,
+        false,
+    );
+}
+
+// Same clamping behavior for negative --index.
+#[test]
+fn slice_neg_index_clamps_to_zero() {
+    test_index("slice_neg_index_clamps_to_zero", -100, "a", true, false);
+    test_index(
+        "slice_neg_index_clamps_to_zero_with_index",
+        -100,
+        "a",
+        true,
+        true,
+    );
+}
+
 #[test]
 #[cfg(feature = "polars")]
 fn slice_from_parquet() {


### PR DESCRIPTION
## Summary

- Fix `r.unwrap()` panics on CSV parse errors in the JSON / indexed code paths — propagate via `?` instead.
- Fix `total_rows - end` subtract overflow in the `with_index` invert path by clamping `start`/`end` to `total_rows`; never call `Indexed::seek` past EOF.
- Use `saturating_sub` (instead of `abs_diff`) for negative `--start` / `--index` so an offset larger than the row count clamps to row 0 rather than positioning past the end of the file (which silently produced empty output).
- Replace `into_string().unwrap()` on the canonicalized input path with a typed `CliError` for non-UTF-8 paths.
- Restore `[]` JSON output for empty non-invert slices on both indexed and non-indexed paths so downstream parsers always see a well-formed document.
- Deduplicate `util::count_rows` in `range()`; use `unwrap_or(0)` so the panic-free invariant survives any future drift in the predicate.
- Fix off-by-one in two USAGE examples (`--end` is exclusive).

Adds 11 regression tests covering negative offsets larger than row count, `--start` at/past EOF with `--invert`, `--end` past EOF on both invert and non-invert indexed paths, negative `--index` clamping, and the empty-slice JSON contract (with and without headers, with and without an index).

Driven by three roborev review rounds (jobs 1680, 1684, 1685) — all closed.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo t slice -F all_features` — 141 passed, 0 failed
- [x] `cargo clippy --bin qsv -F all_features` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)