### PR TITLE
exclude: review-driven cleanup, stdin support and memcheck

### DIFF
--- a/docs/help/exclude.md
+++ b/docs/help/exclude.md
@@ -25,6 +25,8 @@ separating them with a comma. Specify a range of columns with `-`. Both
 columns1 and columns2 must specify exactly the same number of columns.
 (See 'qsv select --help' for the full syntax.)
 
+Either <input1> or <input2> can be set to `-` to read from stdin, but not both.
+
 
 <a name="examples"></a>
 
@@ -75,6 +77,12 @@ qsv exclude -v id records.csv id previously-processed.csv -o intersection.csv
 qsv exclude --ignore-case id records.csv id previously-processed.csv
 ```
 
+> Read records.csv from stdin
+
+```console
+cat records.csv | qsv exclude id - id previously-processed.csv
+```
+
 > Chain exclude with sort to create a new sorted records file without previously processed records
 
 ```console
@@ -108,7 +116,7 @@ qsv exclude --help
 | &nbsp;Argument&nbsp; | Description |
 |----------|-------------|
 | &nbsp;`<input1>`&nbsp; | is the file from which data will be removed. |
-| &nbsp;`<input2>`&nbsp; | is the file containing the data to be removed from <input1> e.g. 'qsv exclude id records.csv id previously-processed.csv' |
+| &nbsp;`<input2>`&nbsp; | is the file containing the data to be removed from <input1> e.g. 'qsv exclude id records.csv id previously-processed.csv' Either input may be set to `-` to read from stdin, but not both. |
 
 <a name="exclude-options"></a>
 
@@ -129,6 +137,7 @@ qsv exclude --help
 | &nbsp;`‑o,`<br>`‑‑output`&nbsp; | string | Write output to <file> instead of stdout. |  |
 | &nbsp;`‑n,`<br>`‑‑no‑headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
 | &nbsp;`‑d,`<br>`‑‑delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
+| &nbsp;`‑‑memcheck`&nbsp; | flag | Check if there is enough memory to load <input2> into memory using CONSERVATIVE heuristics. |  |
 
 ---
 **Source:** [`src/cmd/exclude.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/exclude.rs)

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -81,7 +81,7 @@ Common options:
                            into memory using CONSERVATIVE heuristics.
 "#;
 
-use std::{io, path::Path, str};
+use std::{io, path::Path};
 
 use foldhash::{HashSet, HashSetExt};
 use serde::Deserialize;

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -13,6 +13,8 @@ separating them with a comma. Specify a range of columns with `-`. Both
 columns1 and columns2 must specify exactly the same number of columns.
 (See 'qsv select --help' for the full syntax.)
 
+Either <input1> or <input2> can be set to `-` to read from stdin, but not both.
+
 Examples:
 
   # Remove all records in previously-processed.csv from records.csv
@@ -39,6 +41,9 @@ Examples:
   # Do a case insensitive exclusion on the id column
   qsv exclude --ignore-case id records.csv id previously-processed.csv
 
+  # Read records.csv from stdin
+  cat records.csv | qsv exclude id - id previously-processed.csv
+
   # Chain exclude with sort to create a new sorted records file without previously processed records
   qsv exclude id records.csv id previously-processed.csv | \
       qsv sort > new-sorted-records.csv
@@ -57,10 +62,11 @@ input arguments:
     <input1> is the file from which data will be removed.
     <input2> is the file containing the data to be removed from <input1>
      e.g. 'qsv exclude id records.csv id previously-processed.csv'
+    Either input may be set to `-` to read from stdin, but not both.
 
 exclude options:
     -i, --ignore-case      When set, matching is done case insensitively.
-    -v, --invert     When set, matching rows will be the only ones included,
+    -v, --invert           When set, matching rows will be the only ones included,
                            forming set intersection, instead of the ones discarded.
 
 Common options:
@@ -71,22 +77,24 @@ Common options:
                            sliced, etc.)
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
+    --memcheck             Check if there is enough memory to load <input2>
+                           into memory using CONSERVATIVE heuristics.
 "#;
 
-use std::{collections::hash_map::Entry, fs, io, str};
+use std::{io, path::Path, str};
 
-use byteorder::{BigEndian, WriteBytesExt};
-use foldhash::{HashMap, HashMapExt};
+use foldhash::{HashSet, HashSetExt};
 use serde::Deserialize;
 
 use crate::{
     CliResult,
-    config::{Config, Delimiter},
-    index::Indexed,
+    config::{Config, Delimiter, SeekRead},
     select::{SelectColumns, Selection},
     util,
     util::ByteString,
 };
+
+const VALUE_SET_INITIAL_CAPACITY: usize = 10_000;
 
 #[derive(Deserialize)]
 struct Args {
@@ -99,16 +107,23 @@ struct Args {
     flag_no_headers:  bool,
     flag_ignore_case: bool,
     flag_delimiter:   Option<Delimiter>,
+    flag_memcheck:    bool,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
+    if args.arg_input1 == "-" && args.arg_input2 == "-" {
+        return fail_incorrectusage_clierror!(
+            "Only one of <input1> or <input2> may be set to `-` to read from stdin."
+        );
+    }
+
     let mut state = args.new_io_state()?;
     state.write_headers()?;
     state.exclude(args.flag_invert)
 }
 
-struct IoState<R, W: io::Write> {
+struct IoState<R: io::Read, W: io::Write> {
     wtr:        csv::Writer<W>,
     rdr1:       csv::Reader<R>,
     sel1:       Selection,
@@ -118,7 +133,7 @@ struct IoState<R, W: io::Write> {
     casei:      bool,
 }
 
-impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
+impl<R: io::Read, W: io::Write> IoState<R, W> {
     fn write_headers(&mut self) -> CliResult<()> {
         if !self.no_headers {
             let headers = self.rdr1.byte_headers()?.clone();
@@ -128,25 +143,13 @@ impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
     }
 
     fn exclude(mut self, invert: bool) -> CliResult<()> {
-        // amortize allocations
-        #[allow(unused_assignments)]
-        let mut curr_row = csv::ByteRecord::new();
-
-        let validx = ValueIndex::new(self.rdr2, &self.sel2, self.casei)?;
-        for row in self.rdr1.byte_records() {
-            curr_row = row?;
-            let key = get_row_key(&self.sel1, &curr_row, self.casei);
-            match validx.values.get(&key) {
-                Some(_rows) => {
-                    if invert {
-                        self.wtr.write_record(curr_row.iter())?;
-                    }
-                },
-                _ => {
-                    if !invert {
-                        self.wtr.write_record(curr_row.iter())?;
-                    }
-                },
+        let values = build_value_set(self.rdr2, &self.sel2, self.casei)?;
+        let mut row = csv::ByteRecord::new();
+        while self.rdr1.read_byte_record(&mut row)? {
+            let key = get_row_key(&self.sel1, &row, self.casei);
+            let matched = values.contains(&key);
+            if matched == invert {
+                self.wtr.write_record(row.iter())?;
             }
         }
         Ok(())
@@ -154,7 +157,9 @@ impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
 }
 
 impl Args {
-    fn new_io_state(&self) -> CliResult<IoState<fs::File, Box<dyn io::Write + 'static>>> {
+    fn new_io_state(
+        &self,
+    ) -> CliResult<IoState<Box<dyn SeekRead + 'static>, Box<dyn io::Write + 'static>>> {
         let rconf1 = Config::new(Some(self.arg_input1.clone()).as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers_flag(self.flag_no_headers)
@@ -164,8 +169,13 @@ impl Args {
             .no_headers_flag(self.flag_no_headers)
             .select(self.arg_columns2.clone());
 
-        let mut rdr1 = rconf1.reader_file()?;
-        let mut rdr2 = rconf2.reader_file()?;
+        // input2 is fully loaded into memory; guard against OOM.
+        if let Some(path) = rconf2.path.as_ref() {
+            util::mem_file_check(Path::new(path), false, self.flag_memcheck)?;
+        }
+
+        let mut rdr1 = rconf1.reader_file_stdin()?;
+        let mut rdr2 = rconf2.reader_file_stdin()?;
         let (sel1, sel2) = self.get_selections(&rconf1, &mut rdr1, &rconf2, &mut rdr2)?;
         Ok(IoState {
             wtr: Config::new(self.flag_output.as_ref()).writer()?,
@@ -202,89 +212,17 @@ impl Args {
     }
 }
 
-#[allow(dead_code)]
-struct ValueIndex<R> {
-    // This maps tuples of values to corresponding rows.
-    values:   HashMap<Vec<ByteString>, Vec<usize>>,
-    idx:      Indexed<R, io::Cursor<Vec<u8>>>,
-    num_rows: usize,
-}
-
-impl<R: io::Read + io::Seek> ValueIndex<R> {
-    fn new(mut rdr: csv::Reader<R>, sel: &Selection, casei: bool) -> CliResult<ValueIndex<R>> {
-        let mut val_idx = HashMap::with_capacity(10000);
-        let mut row_idx = io::Cursor::new(Vec::with_capacity(8 * 10000));
-        let (mut rowi, mut count) = (0_usize, 0_usize);
-
-        // This logic is kind of tricky. Basically, we want to include
-        // the header row in the line index (because that's what csv::index
-        // does), but we don't want to include header values in the ValueIndex.
-        if rdr.has_headers() {
-            // ... so if there are headers, we make sure that we've parsed
-            // them, and write the offset of the header row to the index.
-            rdr.byte_headers()?;
-            row_idx.write_u64::<BigEndian>(0)?;
-            count += 1;
-        } else {
-            // ... and if there are no headers, we seek to the beginning and
-            // index everything.
-            let mut pos = csv::Position::new();
-            pos.set_byte(0);
-            rdr.seek(pos)?;
-        }
-
-        let mut row = csv::ByteRecord::new();
-        while rdr.read_byte_record(&mut row)? {
-            // This is a bit hokey. We're doing this manually instead of using
-            // the `csv-index` crate directly so that we can create both
-            // indexes in one pass.
-            row_idx.write_u64::<BigEndian>(row.position().unwrap().byte())?;
-
-            let fields: Vec<_> = sel
-                .select(&row)
-                .map(|v| util::transform(v, casei))
-                .collect();
-            match val_idx.entry(fields) {
-                Entry::Vacant(v) => {
-                    let mut rows = Vec::with_capacity(4);
-                    rows.push(rowi);
-                    v.insert(rows);
-                },
-                Entry::Occupied(mut v) => {
-                    v.get_mut().push(rowi);
-                },
-            }
-            rowi += 1;
-            count += 1;
-        }
-
-        row_idx.write_u64::<BigEndian>(count as u64)?;
-        let idx = Indexed::open(rdr, io::Cursor::new(row_idx.into_inner()))?;
-        Ok(ValueIndex {
-            values: val_idx,
-            idx,
-            num_rows: rowi,
-        })
+fn build_value_set<R: io::Read>(
+    mut rdr: csv::Reader<R>,
+    sel: &Selection,
+    casei: bool,
+) -> CliResult<HashSet<Vec<ByteString>>> {
+    let mut values: HashSet<Vec<ByteString>> = HashSet::with_capacity(VALUE_SET_INITIAL_CAPACITY);
+    let mut row = csv::ByteRecord::new();
+    while rdr.read_byte_record(&mut row)? {
+        values.insert(get_row_key(sel, &row, casei));
     }
-}
-
-use std::fmt;
-
-impl<R> fmt::Debug for ValueIndex<R> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Sort the values by order of first appearance.
-        let mut kvs = self.values.iter().collect::<Vec<_>>();
-        kvs.sort_by(|&(_, v1), &(_, v2)| v1[0].cmp(&v2[0]));
-        for (keys, rows) in kvs {
-            // This is just for debugging, so assume Unicode for now.
-            let keys = keys
-                .iter()
-                .map(|k| String::from_utf8(k.clone()).unwrap())
-                .collect::<Vec<_>>();
-            writeln!(f, "({}) => {rows:?}", keys.join(", "))?;
-        }
-        Ok(())
-    }
+    Ok(values)
 }
 
 #[inline]

--- a/tests/test_exclude.rs
+++ b/tests/test_exclude.rs
@@ -162,6 +162,124 @@ fn exclude_utf8_issue778_positions_aliases() {
 }
 
 #[test]
+fn exclude_column_range() {
+    let wrk = Workdir::new("exclude_column_range");
+
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["a", "b", "c", "d"],
+            svec!["1", "2", "3", "alpha"],
+            svec!["4", "5", "6", "beta"],
+            svec!["7", "8", "9", "gamma"],
+        ],
+    );
+
+    wrk.create(
+        "skip.csv",
+        vec![
+            svec!["a", "b", "c", "d"],
+            svec!["1", "2", "3", "z"],
+            svec!["7", "8", "9", "z"],
+        ],
+    );
+
+    let mut cmd = wrk.command("exclude");
+    cmd.arg("a-c").arg("data.csv").arg("a-c").arg("skip.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "a,b,c,d\n4,5,6,beta";
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn exclude_delimiter_tab() {
+    let wrk = Workdir::new("exclude_delimiter_tab");
+
+    wrk.create_with_delim(
+        "data.tsv",
+        vec![
+            svec!["id", "name"],
+            svec!["1", "alice"],
+            svec!["2", "bob"],
+            svec!["3", "carol"],
+        ],
+        b'\t',
+    );
+
+    wrk.create_with_delim(
+        "skip.tsv",
+        vec![svec!["id", "name"], svec!["2", "bob"]],
+        b'\t',
+    );
+
+    let mut cmd = wrk.command("exclude");
+    cmd.args(&["-d", "\\t"])
+        .arg("id")
+        .arg("data.tsv")
+        .arg("id")
+        .arg("skip.tsv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "id,name\n1,alice\n3,carol";
+
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn exclude_stdin_input1() {
+    use std::io::Write;
+
+    let wrk = Workdir::new("exclude_stdin_input1");
+
+    wrk.create("skip.csv", vec![svec!["id"], svec!["2"], svec!["4"]]);
+
+    let stdin_data = "id\n1\n2\n3\n4\n5\n";
+
+    let mut cmd = wrk.command("exclude");
+    cmd.arg("id").arg("-").arg("id").arg("skip.csv");
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    std::thread::spawn(move || {
+        stdin.write_all(stdin_data.as_bytes()).unwrap();
+    });
+
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+
+    let got = String::from_utf8_lossy(&output.stdout);
+    let expected = "id\n1\n3\n5\n";
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn exclude_both_stdin_errors() {
+    let wrk = Workdir::new("exclude_both_stdin_errors");
+
+    let mut cmd = wrk.command("exclude");
+    cmd.arg("id").arg("-").arg("id").arg("-");
+
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn exclude_mismatched_columns_errors() {
+    let wrk = Workdir::new("exclude_mismatched_columns_errors");
+
+    wrk.create("data.csv", vec![svec!["a", "b"], svec!["1", "2"]]);
+    wrk.create("skip.csv", vec![svec!["a", "b"], svec!["1", "2"]]);
+
+    let mut cmd = wrk.command("exclude");
+    cmd.arg("a,b").arg("data.csv").arg("a").arg("skip.csv");
+
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
 fn exclude_1497_empty_fields() {
     let wrk = Workdir::new("exclude_1497_empty_fields");
 


### PR DESCRIPTION
## Summary

Continues the recent sweep of review-driven cleanups on individual qsv subcommands (slice #3748, fetch/fetchpost #3747, schema #3746, frequency #3745).

- **Strip dead `ValueIndex` machinery.** The random-access row-position index (`idx`, `num_rows`, byte-offset buffer, `Indexed::open`, the header-vs-no-headers seek branch, the unused `Vec<usize>` row tracker) was decorated `#[allow(dead_code)]` and never read by `exclude`. Collapsed to a plain `HashSet<Vec<ByteString>>` and dropped the `byteorder`/`crate::index::Indexed` deps from this file. Also removes the only `.unwrap()` in the hot path (`row.position().unwrap()`).
- **Stdin support.** Switched both inputs from `reader_file()` to `reader_file_stdin()` so either `<input1>` or `<input2>` can be `-`. Errors out cleanly if both are stdin.
- **`--memcheck` flag.** `<input2>` is fully loaded into memory; added a `--memcheck` flag and `util::mem_file_check` guard, matching the dedup convention.
- **Polish.** Named `VALUE_SET_INITIAL_CAPACITY` const, `get_row_key` helper used at both sites, `read_byte_record` loop replaces the `#[allow(unused_assignments)]` pattern, match block collapsed to `if matched == invert`.
- **Tests.** Added column-range, tab delimiter, stdin, both-stdin error, and mismatched-column-count coverage (6 → 11 tests).

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo t exclude -F all_features` (11/11 pass)
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings`
- [x] `qsv --generate-help-md` regenerated `docs/help/exclude.md`
- [x] Manual: `printf 'id\n1\n2\n3\n' | qsv exclude id - id <(printf 'id\n2\n')` prints id=1,3

🤖 Generated with [Claude Code](https://claude.com/claude-code)