### PR TITLE
dedup: review-driven cleanup, allocation-free ignore-case, edge-case fixes

### DIFF
--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -128,9 +128,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut rdr = rconfig.reader()?;
     let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
+    // Use rconfig.write_headers so the dupes writer correctly skips header
+    // emission under --no-headers (where byte_headers() returns the first
+    // data row) and avoids writing an empty record when there are no headers.
     let mut dupewtr = if args.flag_dupes_output.is_some() {
         let mut w = Config::new(args.flag_dupes_output.as_ref()).writer()?;
-        w.write_byte_record(rdr.byte_headers()?)?;
+        rconfig.write_headers(&mut rdr, &mut w)?;
         Some(w)
     } else {
         None
@@ -166,8 +169,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 match comparison {
                     Ordering::Equal => {
                         dupe_count += 1;
+                        // Write the row being DROPPED to dupes (next_record),
+                        // not the survivor (record). The streaming path keeps
+                        // the first occurrence of a run, so for runs longer
+                        // than 2 the dropped rows are next_record on each
+                        // iteration. Writing &record here instead would emit
+                        // the survivor N-1 times — and with --select, miss
+                        // the actual dropped rows entirely.
                         if let Some(ref mut w) = dupewtr {
-                            w.write_byte_record(&record)?;
+                            w.write_byte_record(&next_record)?;
                         }
                     },
                     Ordering::Less => {

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -69,9 +69,11 @@ Common options:
     -q, --quiet                Do not print duplicate count to stderr.
     --memcheck                 Check if there is enough memory to load the entire
                                CSV into memory using CONSERVATIVE heuristics.
+                               Has no effect when --sorted is set, as that path
+                               streams the input and never loads it into memory.
 "#;
 
-use std::cmp;
+use std::cmp::Ordering;
 
 use csv::ByteRecord;
 use rayon::slice::ParallelSliceMut;
@@ -126,13 +128,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut rdr = rconfig.reader()?;
     let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
-    let dupes_output = args.flag_dupes_output.is_some();
-    let mut dupewtr = Config::new(args.flag_dupes_output.as_ref()).writer()?;
+    let mut dupewtr = if args.flag_dupes_output.is_some() {
+        let mut w = Config::new(args.flag_dupes_output.as_ref()).writer()?;
+        w.write_byte_record(rdr.byte_headers()?)?;
+        Some(w)
+    } else {
+        None
+    };
 
     let headers = rdr.byte_headers()?;
-    if dupes_output {
-        dupewtr.write_byte_record(headers)?;
-    }
     let sel = rconfig.selection(headers)?;
 
     rconfig.write_headers(&mut rdr, &mut wtr)?;
@@ -142,7 +146,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let mut record = ByteRecord::new();
         let mut next_record = ByteRecord::new();
 
-        rdr.read_byte_record(&mut record)?;
+        if !rdr.read_byte_record(&mut record)? {
+            // empty input — nothing to dedup, header (if any) was already written above
+            wtr.flush()?;
+            if let Some(mut w) = dupewtr {
+                w.flush()?;
+            }
+            return Ok(());
+        }
         loop {
             let more_records = rdr.read_byte_record(&mut next_record)?;
             if !more_records {
@@ -157,17 +168,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 ComparisonMode::IgnoreCase => iter_cmp_ignore_case(a, b),
             };
             match comparison {
-                cmp::Ordering::Equal => {
+                Ordering::Equal => {
                     dupe_count += 1;
-                    if dupes_output {
-                        dupewtr.write_byte_record(&record)?;
+                    if let Some(ref mut w) = dupewtr {
+                        w.write_byte_record(&record)?;
                     }
                 },
-                cmp::Ordering::Less => {
+                Ordering::Less => {
                     wtr.write_byte_record(&record)?;
-                    record.clone_from(&next_record);
+                    std::mem::swap(&mut record, &mut next_record);
                 },
-                cmp::Ordering::Greater => {
+                Ordering::Greater => {
                     return fail_clierror!(
                         r#"Aborting! Input not sorted! Current record is greater than Next record.
   Compare mode: {compare_mode:?};  Select columns index/es (0-based): {sel:?}
@@ -211,49 +222,37 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             },
         }
 
-        for (current, current_record) in all.iter().enumerate() {
-            let a = sel.select(current_record);
-            if let Some(next_record) = all.get(current + 1) {
-                let b = sel.select(next_record);
-                match compare_mode {
-                    ComparisonMode::Normal => {
-                        if iter_cmp(a, b) == cmp::Ordering::Equal {
+        // Hoist comparison dispatch out of the row loop: pick the cmp once,
+        // then run a single tight loop. Each branch monomorphizes the body.
+        macro_rules! scan_dedup {
+            ($cmp:expr) => {{
+                let mut iter = all.iter();
+                if let Some(mut prev) = iter.next() {
+                    for current in iter {
+                        if $cmp(sel.select(prev), sel.select(current)) == Ordering::Equal {
                             dupe_count += 1;
-                            if dupes_output {
-                                dupewtr.write_byte_record(current_record)?;
+                            if let Some(ref mut w) = dupewtr {
+                                w.write_byte_record(prev)?;
                             }
                         } else {
-                            wtr.write_byte_record(current_record)?;
+                            wtr.write_byte_record(prev)?;
                         }
-                    },
-                    ComparisonMode::Numeric => {
-                        if iter_cmp_num(a, b) == cmp::Ordering::Equal {
-                            dupe_count += 1;
-                            if dupes_output {
-                                dupewtr.write_byte_record(current_record)?;
-                            }
-                        } else {
-                            wtr.write_byte_record(current_record)?;
-                        }
-                    },
-                    ComparisonMode::IgnoreCase => {
-                        if iter_cmp_ignore_case(a, b) == cmp::Ordering::Equal {
-                            dupe_count += 1;
-                            if dupes_output {
-                                dupewtr.write_byte_record(current_record)?;
-                            }
-                        } else {
-                            wtr.write_byte_record(current_record)?;
-                        }
-                    },
+                        prev = current;
+                    }
+                    wtr.write_byte_record(prev)?;
                 }
-            } else {
-                wtr.write_byte_record(current_record)?;
-            }
+            }};
+        }
+        match compare_mode {
+            ComparisonMode::Normal => scan_dedup!(iter_cmp),
+            ComparisonMode::Numeric => scan_dedup!(iter_cmp_num),
+            ComparisonMode::IgnoreCase => scan_dedup!(iter_cmp_ignore_case),
         }
     }
 
-    dupewtr.flush()?;
+    if let Some(mut w) = dupewtr {
+        w.flush()?;
+    }
     wtr.flush()?;
 
     if args.flag_quiet {
@@ -271,20 +270,25 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     Ok(())
 }
 
-/// Try comparing `a` and `b` ignoring the case
+/// Try comparing `a` and `b` ignoring the case.
+///
+/// Cells that are pure ASCII compare via a zero-allocation byte-wise lowercase
+/// fold (the common case). Non-ASCII cells fall back to allocating a
+/// lowercased `String`. Cells that are not valid UTF-8 fall back to a raw
+/// byte comparison so a deterministic order is still produced.
 #[inline]
-pub fn iter_cmp_ignore_case<'a, L, R>(mut a: L, mut b: R) -> cmp::Ordering
+pub fn iter_cmp_ignore_case<'a, L, R>(mut a: L, mut b: R) -> Ordering
 where
     L: Iterator<Item = &'a [u8]>,
     R: Iterator<Item = &'a [u8]>,
 {
     loop {
-        match (next_no_case(&mut a), next_no_case(&mut b)) {
-            (None, None) => return cmp::Ordering::Equal,
-            (None, _) => return cmp::Ordering::Less,
-            (_, None) => return cmp::Ordering::Greater,
-            (Some(x), Some(y)) => match x.cmp(&y) {
-                cmp::Ordering::Equal => (),
+        match (a.next(), b.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, _) => return Ordering::Less,
+            (_, None) => return Ordering::Greater,
+            (Some(x), Some(y)) => match cmp_ignore_case(x, y) {
+                Ordering::Equal => (),
                 non_eq => return non_eq,
             },
         }
@@ -292,11 +296,21 @@ where
 }
 
 #[inline]
-fn next_no_case<'a, X>(xs: &mut X) -> Option<String>
-where
-    X: Iterator<Item = &'a [u8]>,
-{
-    xs.next()
-        .and_then(|bytes| simdutf8::basic::from_utf8(bytes).ok())
-        .map(str::to_lowercase)
+fn cmp_ignore_case(a: &[u8], b: &[u8]) -> Ordering {
+    // ASCII fast path: zero-allocation byte-wise lowercase compare.
+    if a.is_ascii() && b.is_ascii() {
+        return a
+            .iter()
+            .map(u8::to_ascii_lowercase)
+            .cmp(b.iter().map(u8::to_ascii_lowercase));
+    }
+    // Unicode slow path: allocate lowercased Strings.
+    match (
+        simdutf8::basic::from_utf8(a).ok(),
+        simdutf8::basic::from_utf8(b).ok(),
+    ) {
+        (Some(sa), Some(sb)) => sa.to_lowercase().cmp(&sb.to_lowercase()),
+        // Invalid UTF-8 on either side: fall back to raw byte comparison.
+        _ => a.cmp(b),
+    }
 }

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -146,47 +146,44 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let mut record = ByteRecord::new();
         let mut next_record = ByteRecord::new();
 
-        if !rdr.read_byte_record(&mut record)? {
-            // empty input — nothing to dedup, header (if any) was already written above
-            wtr.flush()?;
-            if let Some(mut w) = dupewtr {
-                w.flush()?;
-            }
-            return Ok(());
-        }
-        loop {
-            let more_records = rdr.read_byte_record(&mut next_record)?;
-            if !more_records {
-                wtr.write_byte_record(&record)?;
-                break;
-            }
-            let a = sel.select(&record);
-            let b = sel.select(&next_record);
-            let comparison = match compare_mode {
-                ComparisonMode::Normal => iter_cmp(a, b),
-                ComparisonMode::Numeric => iter_cmp_num(a, b),
-                ComparisonMode::IgnoreCase => iter_cmp_ignore_case(a, b),
-            };
-            match comparison {
-                Ordering::Equal => {
-                    dupe_count += 1;
-                    if let Some(ref mut w) = dupewtr {
-                        w.write_byte_record(&record)?;
-                    }
-                },
-                Ordering::Less => {
+        // Only enter the streaming loop if there is at least one data row;
+        // otherwise fall through to the flush + duplicate-count print block
+        // so empty input behaves identically to the in-memory path.
+        if rdr.read_byte_record(&mut record)? {
+            loop {
+                let more_records = rdr.read_byte_record(&mut next_record)?;
+                if !more_records {
                     wtr.write_byte_record(&record)?;
-                    std::mem::swap(&mut record, &mut next_record);
-                },
-                Ordering::Greater => {
-                    return fail_clierror!(
-                        r#"Aborting! Input not sorted! Current record is greater than Next record.
+                    break;
+                }
+                let a = sel.select(&record);
+                let b = sel.select(&next_record);
+                let comparison = match compare_mode {
+                    ComparisonMode::Normal => iter_cmp(a, b),
+                    ComparisonMode::Numeric => iter_cmp_num(a, b),
+                    ComparisonMode::IgnoreCase => iter_cmp_ignore_case(a, b),
+                };
+                match comparison {
+                    Ordering::Equal => {
+                        dupe_count += 1;
+                        if let Some(ref mut w) = dupewtr {
+                            w.write_byte_record(&record)?;
+                        }
+                    },
+                    Ordering::Less => {
+                        wtr.write_byte_record(&record)?;
+                        std::mem::swap(&mut record, &mut next_record);
+                    },
+                    Ordering::Greater => {
+                        return fail_clierror!(
+                            r#"Aborting! Input not sorted! Current record is greater than Next record.
   Compare mode: {compare_mode:?};  Select columns index/es (0-based): {sel:?}
   Current: {record:?}
      Next: {next_record:?}
 "#
-                    );
-                },
+                        );
+                    },
+                }
             }
         }
     } else {

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -248,21 +248,25 @@ fn dedup_alreadysorted_nocase() {
 fn dedup_sorted_empty() {
     // Regression: --sorted on empty input must not emit a stray empty row,
     // and must still print the duplicate count to stderr (parity with the
-    // in-memory path).
+    // in-memory path). Capture stdout and stderr from a single invocation
+    // so the assertions describe one run of the command.
     let wrk = Workdir::new("dedup_sorted_empty");
     wrk.create("in.csv", vec![svec!["N", "S"]]);
 
     let mut cmd = wrk.command("dedup");
     cmd.arg("--sorted").arg("in.csv");
+    let output = wrk.output(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    let expected = vec![svec!["N", "S"]];
-    assert_eq!(got, expected);
+    // safety: test output is expected to be valid UTF-8 CSV data.
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let expected_stdout = "N,S\n";
+    assert_eq!(stdout.replace("\r\n", "\n"), expected_stdout);
 
     // dedup emits only the dupe count to stderr (just the number, no prose),
     // so assert exact equality on the trimmed output to actually catch a
     // regression that drops or reformats the line.
-    let stderr = wrk.output_stderr(&mut cmd);
+    // safety: test stderr is expected to be valid UTF-8 text output.
+    let stderr = String::from_utf8(output.stderr).unwrap();
     assert_eq!(stderr.trim(), "0", "got stderr: {stderr:?}");
 }
 
@@ -282,6 +286,69 @@ fn dedup_sorted_empty_dupes_output() {
     let dupes: String = wrk.from_str(&wrk.path("dupes.csv"));
     let expected_header = "N,S\n";
     assert_eq!(dupes.replace("\r\n", "\n"), expected_header);
+}
+
+
+#[test]
+fn dedup_sorted_select_dupes_output_run_of_three() {
+    // Regression for Copilot review on PR 3754: with --sorted + --select +
+    // --dupes-output, a run of three rows that are equal-on-selection but
+    // differ on non-selected columns must write the actual dropped rows
+    // to the dupes file (next_record on each Equal step), not the survivor
+    // row repeated. Previously the streaming Equal branch wrote &record
+    // (the survivor) every iteration, so a 3-row run produced two copies
+    // of the survivor and dropped the actually-removed rows from view.
+    let wrk = Workdir::new("dedup_sorted_select_dupes_output_run_of_three");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["key", "val"],
+            svec!["1", "a"],
+            svec!["1", "b"],
+            svec!["1", "c"],
+            svec!["2", "d"],
+        ],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--sorted")
+        .args(["--select", "key"])
+        .args(["--dupes-output", "dupes.csv"])
+        .arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["key", "val"], svec!["1", "a"], svec!["2", "d"]];
+    assert_eq!(got, expected);
+
+    let dupes: String = wrk.from_str(&wrk.path("dupes.csv"));
+    let expected_dupes = "key,val\n1,b\n1,c\n";
+    assert_eq!(dupes.replace("\r\n", "\n"), expected_dupes);
+}
+
+#[test]
+fn dedup_no_headers_dupes_output() {
+    // Regression for Copilot review on PR 3754: with --no-headers, the
+    // dupes file must not contain a phantom "header" line — previously
+    // the dupes writer was seeded with rdr.byte_headers() unconditionally,
+    // which under --no-headers returns the first DATA row, producing a
+    // dupes file that started with that row even though it wasn't a
+    // duplicate. Use rconfig.write_headers, which already respects the
+    // no-headers flag.
+    let wrk = Workdir::new("dedup_no_headers_dupes_output");
+    wrk.create(
+        "in.csv",
+        vec![svec!["10"], svec!["20"], svec!["20"], svec!["30"]],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--no-headers")
+        .args(["--dupes-output", "dupes.csv"])
+        .arg("in.csv");
+    wrk.output(&mut cmd);
+
+    let dupes: String = wrk.from_str(&wrk.path("dupes.csv"));
+    let expected_dupes = "20\n";
+    assert_eq!(dupes.replace("\r\n", "\n"), expected_dupes);
 }
 
 #[test]

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -288,7 +288,6 @@ fn dedup_sorted_empty_dupes_output() {
     assert_eq!(dupes.replace("\r\n", "\n"), expected_header);
 }
 
-
 #[test]
 fn dedup_sorted_select_dupes_output_run_of_three() {
     // Regression for Copilot review on PR 3754: with --sorted + --select +

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -246,7 +246,9 @@ fn dedup_alreadysorted_nocase() {
 
 #[test]
 fn dedup_sorted_empty() {
-    // Regression: --sorted on empty input must not emit a stray empty row.
+    // Regression: --sorted on empty input must not emit a stray empty row,
+    // and must still print the duplicate count to stderr (parity with the
+    // in-memory path).
     let wrk = Workdir::new("dedup_sorted_empty");
     wrk.create("in.csv", vec![svec!["N", "S"]]);
 
@@ -256,6 +258,59 @@ fn dedup_sorted_empty() {
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![svec!["N", "S"]];
     assert_eq!(got, expected);
+
+    let stderr = wrk.output_stderr(&mut cmd);
+    assert!(
+        stderr.contains("0"),
+        "expected duplicate count of 0 on stderr, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn dedup_sorted_empty_dupes_output() {
+    // --sorted + --dupes-output on empty input: both the main output and the
+    // dupes file should contain only the header, with no stray rows.
+    let wrk = Workdir::new("dedup_sorted_empty_dupes_output");
+    wrk.create("in.csv", vec![svec!["N", "S"]]);
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--sorted")
+        .args(["--dupes-output", "dupes.csv"])
+        .arg("in.csv");
+    wrk.output(&mut cmd);
+
+    let dupes: String = wrk.from_str(&wrk.path("dupes.csv"));
+    let expected_header = "N,S\n";
+    assert_eq!(dupes.replace("\r\n", "\n"), expected_header);
+}
+
+#[test]
+fn dedup_dupes_output_run_of_three() {
+    // In-memory path: a run of 3 identical rows must produce 2 rows in the
+    // dupes file (the duplicates) and 1 survivor in the main output.
+    // Exercises the scan_dedup! macro's prev-write-on-equal branch.
+    let wrk = Workdir::new("dedup_dupes_output_run_of_three");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["N", "S"],
+            svec!["1", "a"],
+            svec!["1", "a"],
+            svec!["1", "a"],
+            svec!["2", "b"],
+        ],
+    );
+
+    let mut cmd = wrk.command("dedup");
+    cmd.args(["--dupes-output", "dupes.csv"]).arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["N", "S"], svec!["1", "a"], svec!["2", "b"]];
+    assert_eq!(got, expected);
+
+    let dupes: String = wrk.from_str(&wrk.path("dupes.csv"));
+    let expected_dupes = "N,S\n1,a\n1,a\n";
+    assert_eq!(dupes.replace("\r\n", "\n"), expected_dupes);
 }
 
 #[test]

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -259,11 +259,11 @@ fn dedup_sorted_empty() {
     let expected = vec![svec!["N", "S"]];
     assert_eq!(got, expected);
 
+    // dedup emits only the dupe count to stderr (just the number, no prose),
+    // so assert exact equality on the trimmed output to actually catch a
+    // regression that drops or reformats the line.
     let stderr = wrk.output_stderr(&mut cmd);
-    assert!(
-        stderr.contains("0"),
-        "expected duplicate count of 0 on stderr, got: {stderr:?}"
-    );
+    assert_eq!(stderr.trim(), "0", "got stderr: {stderr:?}");
 }
 
 #[test]

--- a/tests/test_dedup.rs
+++ b/tests/test_dedup.rs
@@ -245,6 +245,20 @@ fn dedup_alreadysorted_nocase() {
 }
 
 #[test]
+fn dedup_sorted_empty() {
+    // Regression: --sorted on empty input must not emit a stray empty row.
+    let wrk = Workdir::new("dedup_sorted_empty");
+    wrk.create("in.csv", vec![svec!["N", "S"]]);
+
+    let mut cmd = wrk.command("dedup");
+    cmd.arg("--sorted").arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["N", "S"]];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn dedup_not_sorted() {
     let wrk = Workdir::new("dedup__not_sorted");
     wrk.create(


### PR DESCRIPTION
## Summary

Review-driven cleanup of `src/cmd/dedup.rs` (continues the recent `count` / `util` / `datefmt` series).

- **Empty-input bug**: `--sorted` on a header-only file no longer emits a stray empty data row (still prints the dupe count to stderr to keep parity with the in-memory path).
- **`dupewtr` is now `Option<Writer>`**: only constructed and flushed when `--dupes-output` is set; no phantom stdout writer otherwise.
- **ASCII fast path in `iter_cmp_ignore_case`**: pure-ASCII cells now compare via a zero-allocation byte-wise lowercase fold; non-ASCII keeps the allocating fallback; invalid UTF-8 falls back to raw byte order (deterministic) instead of being treated as a missing cell.
- **Hoisted comparison dispatch in the in-memory scan loop**: picks the comparison function once per run, then runs a single tight monomorphized loop, mirroring the existing `par_sort_by` structure.
- `std::mem::swap` instead of `clone_from` in the streaming sorted loop.
- `use std::cmp::Ordering;` throughout.
- USAGE: note `--memcheck` has no effect under `--sorted`.

Reviewed by roborev (#1707, #1708) — both findings addressed in follow-up commits in this branch.

## Test plan
- [x] `cargo test -F all_features dedup` — 21/21 pass (3 new: `dedup_sorted_empty`, `dedup_sorted_empty_dupes_output`, `dedup_dupes_output_run_of_three`)
- [x] `cargo test -F all_features sort` — 78/78 pass (consumes `iter_cmp_ignore_case`)
- [x] `cargo +nightly clippy --bin qsv -F all_features -- -W clippy::perf` — clean
- [x] `cargo +nightly fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)