### PR TITLE
sort: review-driven cleanup, fix --numeric --natural --unique inconsistency

### DIFF
--- a/docs/help/dedup.md
+++ b/docs/help/dedup.md
@@ -102,7 +102,7 @@ qsv dedup --help
 | &nbsp;`‑n,`<br>`‑‑no‑headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. That is, it will be sorted with the rest of the rows. Otherwise, the first row will always appear as the header row in the output. |  |
 | &nbsp;`‑d,`<br>`‑‑delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | &nbsp;`‑q,`<br>`‑‑quiet`&nbsp; | flag | Do not print duplicate count to stderr. |  |
-| &nbsp;`‑‑memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. |  |
+| &nbsp;`‑‑memcheck`&nbsp; | flag | Check if there is enough memory to load the entire CSV into memory using CONSERVATIVE heuristics. Has no effect when --sorted is set, as that path streams the input and never loads it into memory. |  |
 
 ---
 **Source:** [`src/cmd/dedup.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/dedup.rs)

--- a/docs/help/sort.md
+++ b/docs/help/sort.md
@@ -39,7 +39,7 @@ qsv sort --help
 | &nbsp;`‑N,`<br>`‑‑numeric`&nbsp; | flag | Compare according to string numerical value |  |
 | &nbsp;`‑‑natural`&nbsp; | flag | Compare strings using natural sort order (treats numbers within strings as actual numbers, e.g. "data1.txt", "data2.txt", "data10.txt", as opposed to "data1.txt", "data10.txt", "data2.txt" when sorting lexicographically) <https://en.wikipedia.org/wiki/Natural_sort_order> When combined with --numeric, --natural takes precedence. |  |
 | &nbsp;`‑R,`<br>`‑‑reverse`&nbsp; | flag | Reverse order |  |
-| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Has no effect under --numeric (numbers are case-less). |  |
+| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Has no effect when numeric comparison is used (numbers are case-less). |  |
 | &nbsp;`‑u,`<br>`‑‑unique`&nbsp; | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. The same comparison mode used to sort the input is also used here, so unique-equality always agrees with the sort. |  |
 
 <a name="random-sorting-options"></a>

--- a/docs/help/sort.md
+++ b/docs/help/sort.md
@@ -39,7 +39,7 @@ qsv sort --help
 | &nbsp;`‑N,`<br>`‑‑numeric`&nbsp; | flag | Compare according to string numerical value |  |
 | &nbsp;`‑‑natural`&nbsp; | flag | Compare strings using natural sort order (treats numbers within strings as actual numbers, e.g. "data1.txt", "data2.txt", "data10.txt", as opposed to "data1.txt", "data10.txt", "data2.txt" when sorting lexicographically) <https://en.wikipedia.org/wiki/Natural_sort_order> When combined with --numeric, --natural takes precedence. |  |
 | &nbsp;`‑R,`<br>`‑‑reverse`&nbsp; | flag | Reverse order |  |
-| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Has no effect when numeric comparison is used (numbers are case-less). |  |
+| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Has no effect when numeric comparison is selected (i.e. when --numeric is used without --natural). |  |
 | &nbsp;`‑u,`<br>`‑‑unique`&nbsp; | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. The same comparison mode used to sort the input is also used here, so unique-equality always agrees with the sort. |  |
 
 <a name="random-sorting-options"></a>
@@ -48,7 +48,7 @@ qsv sort --help
 
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
-| &nbsp;`‑‑random`&nbsp; | flag | Randomize (scramble) the data by row. When set, the comparison flags (numeric, natural, reverse, ignore-case) are ignored for the shuffle itself, but still apply to unique-filtering if --unique is also set. |  |
+| &nbsp;`‑‑random`&nbsp; | flag | Randomize (scramble) the data by row. When set, the numeric, natural, and ignore-case comparison flags still apply to unique-filtering (if --unique is also set). The reverse flag has no effect on unique-filter equality and is ignored for the shuffle itself. |  |
 | &nbsp;`‑‑seed`&nbsp; | string | Random Number Generator (RNG) seed to use if --random is set |  |
 | &nbsp;`‑‑rng`&nbsp; | string | The RNG algorithm to use if --random is set. | `standard` |
 | &nbsp;`‑j,`<br>`‑‑jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |

--- a/docs/help/sort.md
+++ b/docs/help/sort.md
@@ -37,10 +37,10 @@ qsv sort --help
 |--------|------|-------------|--------|
 | &nbsp;`‑s,`<br>`‑‑select`&nbsp; | string | Select a subset of columns to sort. See 'qsv select --help' for the format details. |  |
 | &nbsp;`‑N,`<br>`‑‑numeric`&nbsp; | flag | Compare according to string numerical value |  |
-| &nbsp;`‑‑natural`&nbsp; | flag | Compare strings using natural sort order (treats numbers within strings as actual numbers, e.g. "data1.txt", "data2.txt", "data10.txt", as opposed to "data1.txt", "data10.txt", "data2.txt" when sorting lexicographically) <https://en.wikipedia.org/wiki/Natural_sort_order> |  |
+| &nbsp;`‑‑natural`&nbsp; | flag | Compare strings using natural sort order (treats numbers within strings as actual numbers, e.g. "data1.txt", "data2.txt", "data10.txt", as opposed to "data1.txt", "data10.txt", "data2.txt" when sorting lexicographically) <https://en.wikipedia.org/wiki/Natural_sort_order> When combined with --numeric, --natural takes precedence. |  |
 | &nbsp;`‑R,`<br>`‑‑reverse`&nbsp; | flag | Reverse order |  |
-| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case |  |
-| &nbsp;`‑u,`<br>`‑‑unique`&nbsp; | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. |  |
+| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Has no effect under --numeric (numbers are case-less). |  |
+| &nbsp;`‑u,`<br>`‑‑unique`&nbsp; | flag | When set, identical consecutive lines will be dropped to keep only one line per sorted value. The same comparison mode used to sort the input is also used here, so unique-equality always agrees with the sort. |  |
 
 <a name="random-sorting-options"></a>
 
@@ -48,7 +48,7 @@ qsv sort --help
 
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
-| &nbsp;`‑‑random`&nbsp; | flag | Randomize (scramble) the data by row |  |
+| &nbsp;`‑‑random`&nbsp; | flag | Randomize (scramble) the data by row. When set, the comparison flags (numeric, natural, reverse, ignore-case) are ignored for the shuffle itself, but still apply to unique-filtering if --unique is also set. |  |
 | &nbsp;`‑‑seed`&nbsp; | string | Random Number Generator (RNG) seed to use if --random is set |  |
 | &nbsp;`‑‑rng`&nbsp; | string | The RNG algorithm to use if --random is set. | `standard` |
 | &nbsp;`‑j,`<br>`‑‑jobs`&nbsp; | string | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -81,7 +81,7 @@ use serde::Deserialize;
 
 use crate::{
     CliResult,
-    cmd::sort::{iter_cmp, iter_cmp_num},
+    cmd::sort::{iter_cmp, iter_cmp_ignore_case, iter_cmp_num},
     config::{Config, Delimiter},
     select::SelectColumns,
     util,
@@ -275,49 +275,4 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     Ok(())
-}
-
-/// Try comparing `a` and `b` ignoring the case.
-///
-/// Cells that are pure ASCII compare via a zero-allocation byte-wise lowercase
-/// fold (the common case). Non-ASCII cells fall back to allocating a
-/// lowercased `String`. Cells that are not valid UTF-8 fall back to a raw
-/// byte comparison so a deterministic order is still produced.
-#[inline]
-pub fn iter_cmp_ignore_case<'a, L, R>(mut a: L, mut b: R) -> Ordering
-where
-    L: Iterator<Item = &'a [u8]>,
-    R: Iterator<Item = &'a [u8]>,
-{
-    loop {
-        match (a.next(), b.next()) {
-            (None, None) => return Ordering::Equal,
-            (None, _) => return Ordering::Less,
-            (_, None) => return Ordering::Greater,
-            (Some(x), Some(y)) => match cmp_ignore_case(x, y) {
-                Ordering::Equal => (),
-                non_eq => return non_eq,
-            },
-        }
-    }
-}
-
-#[inline]
-fn cmp_ignore_case(a: &[u8], b: &[u8]) -> Ordering {
-    // ASCII fast path: zero-allocation byte-wise lowercase compare.
-    if a.is_ascii() && b.is_ascii() {
-        return a
-            .iter()
-            .map(u8::to_ascii_lowercase)
-            .cmp(b.iter().map(u8::to_ascii_lowercase));
-    }
-    // Unicode slow path: allocate lowercased Strings.
-    match (
-        simdutf8::basic::from_utf8(a).ok(),
-        simdutf8::basic::from_utf8(b).ok(),
-    ) {
-        (Some(sa), Some(sb)) => sa.to_lowercase().cmp(&sb.to_lowercase()),
-        // Invalid UTF-8 on either side: fall back to raw byte comparison.
-        _ => a.cmp(b),
-    }
 }

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -33,10 +33,12 @@ sort options:
 
                             RANDOM SORTING OPTIONS:
     --random                Randomize (scramble) the data by row.
-                            When set, the comparison flags (numeric,
-                            natural, reverse, ignore-case) are ignored
-                            for the shuffle itself, but still apply to
-                            unique-filtering if --unique is also set.
+                            When set, the numeric, natural, and
+                            ignore-case comparison flags still apply
+                            to unique-filtering (if --unique is also
+                            set). The reverse flag has no effect on
+                            unique-filter equality and is ignored for
+                            the shuffle itself.
     --seed <number>         Random Number Generator (RNG) seed to use if --random is set
     --rng <kind>            The RNG algorithm to use if --random is set.
                             Three RNGs are supported:

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -21,13 +21,21 @@ sort options:
                             "data1.txt", "data10.txt", "data2.txt" when sorting
                             lexicographically)
                             https://en.wikipedia.org/wiki/Natural_sort_order
+                            When combined with --numeric, --natural takes precedence.
     -R, --reverse           Reverse order
-    -i, --ignore-case       Compare strings disregarding case
+    -i, --ignore-case       Compare strings disregarding case.
+                            Has no effect under --numeric (numbers are case-less).
     -u, --unique            When set, identical consecutive lines will be dropped
-                            to keep only one line per sorted value.
+                            to keep only one line per sorted value. The same
+                            comparison mode used to sort the input is also used
+                            here, so unique-equality always agrees with the sort.
 
                             RANDOM SORTING OPTIONS:
-    --random                Randomize (scramble) the data by row
+    --random                Randomize (scramble) the data by row.
+                            When set, the comparison flags (numeric,
+                            natural, reverse, ignore-case) are ignored
+                            for the shuffle itself, but still apply to
+                            unique-filtering if --unique is also set.
     --seed <number>         Random Number Generator (RNG) seed to use if --random is set
     --rng <kind>            The RNG algorithm to use if --random is set.
                             Three RNGs are supported:
@@ -39,7 +47,7 @@ sort options:
                               Recommended by eSTREAM (https://www.ecrypt.eu.org/stream/).
                               2.1 GB/s throughput though slow initialization.
                             [default: standard]
-    
+
 
     -j, --jobs <arg>        The number of jobs to run in parallel.
                             When not set, the number of jobs is set to the
@@ -49,7 +57,7 @@ sort options:
                             (i.e. the order of identical values is not guaranteed
                             to be preserved). It has the added side benefit that the
                             sort will also be in-place (i.e. does not allocate),
-                            which is useful for sorting large files that will 
+                            which is useful for sorting large files that will
                             otherwise NOT fit in memory using the default allocating
                             stable sort.
 
@@ -67,10 +75,9 @@ Common options:
                             Ignored if --random or --faster is set.
 "#;
 
-use std::{cmp, str::FromStr};
+use std::{cmp::Ordering, str::FromStr};
 
-// use fastrand; //DevSkim: ignore DS148264
-use rand::{RngExt, SeedableRng, rngs::StdRng, seq::SliceRandom};
+use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use rand_hc::Hc128Rng;
 use rand_xoshiro::Xoshiro256Plus;
 use rayon::slice::ParallelSliceMut;
@@ -81,7 +88,6 @@ use strum_macros::EnumString;
 use self::Number::{Float, Int};
 use crate::{
     CliResult,
-    cmd::dedup::iter_cmp_ignore_case,
     config::{Config, Delimiter},
     select::SelectColumns,
     util,
@@ -115,6 +121,19 @@ enum RngKind {
     Cryptosecure,
 }
 
+/// Selected once at startup based on the comparison flags. Drives both the
+/// sort dispatch and the `--unique` filter so they always agree on equality.
+/// Precedence: `--natural` > `--numeric` > `--ignore-case` > lex.
+/// `--ignore-case` only applies under lex and natural; numeric ignores it.
+#[derive(Clone, Copy)]
+enum SortMode {
+    Lex,
+    LexIgnoreCase,
+    Natural,
+    NaturalIgnoreCase,
+    Numeric,
+}
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
     let numeric = args.flag_numeric;
@@ -122,6 +141,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let reverse = args.flag_reverse;
     let random = args.flag_random;
     let faster = args.flag_faster;
+    let ignore_case = args.flag_ignore_case;
+    let seed = args.flag_seed;
+
     let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers_flag(args.flag_no_headers)
@@ -134,265 +156,136 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         );
     };
 
-    // we're loading the entire file into memory, we need to check avail memory
-    if let Some(path) = rconfig.path.clone() {
-        // we only check if we're doing a stable sort and its not --random
-        // coz with --faster option, the sort algorithm sorts in-place (non-allocating)
-        if !faster && !random {
-            util::mem_file_check(&path, false, args.flag_memcheck)?;
-        }
+    // we're loading the entire file into memory, we need to check avail memory.
+    // we only check if we're doing a stable sort and its not --random,
+    // because --faster sorts in-place (non-allocating) and --random shuffles.
+    if let Some(path) = rconfig.path.clone()
+        && !faster
+        && !random
+    {
+        util::mem_file_check(&path, false, args.flag_memcheck)?;
     }
 
     let mut rdr = rconfig.reader()?;
-
     let headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;
 
     util::njobs(args.flag_jobs);
 
-    // Seeding RNG
-    let seed = args.flag_seed;
-
-    let ignore_case = args.flag_ignore_case;
-
     let mut all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;
-    // Tuple ordering and boolean flag meanings:
-    // numeric: Sort numerically
-    // natural: Sort in natural order https://en.wikipedia.org/wiki/Natural_sort_order
-    // reverse: Sort in reverse order
-    // random: Sort randomly
-    // faster: Use faster parallel "unstable" sorting algorithm by using
-    //   non-allocating, par_sort_unstable_by
-    //   https://docs.rs/rayon/latest/rayon/slice/trait.ParallelSliceMut.html#method.par_sort_unstable_by
-    // if all flags are false (the default), then we do a stable parallel, lexicographical sort
-    match (numeric, natural, reverse, random, faster) {
-        // --random sort
-        (_, _, _, true, _) => {
-            match rng_kind {
-                RngKind::Standard => {
-                    if let Some(val) = seed {
-                        let mut rng = StdRng::seed_from_u64(val); //DevSkim: ignore DS148264
-                        all.shuffle(&mut rng); //DevSkim: ignore DS148264
+
+    // Pick the comparison mode once. The same mode drives the sort and the
+    // --unique filter, so unique-equality always agrees with what the sort
+    // grouped (previously --unique used its own if/else chain that silently
+    // disagreed with the sort under e.g. --numeric --natural).
+    let mode = if natural {
+        if ignore_case {
+            SortMode::NaturalIgnoreCase
+        } else {
+            SortMode::Natural
+        }
+    } else if numeric {
+        SortMode::Numeric
+    } else if ignore_case {
+        SortMode::LexIgnoreCase
+    } else {
+        SortMode::Lex
+    };
+
+    if random {
+        match rng_kind {
+            RngKind::Standard => {
+                if let Some(val) = seed {
+                    let mut rng = StdRng::seed_from_u64(val); //DevSkim: ignore DS148264
+                    all.shuffle(&mut rng); //DevSkim: ignore DS148264
+                } else {
+                    let mut rng = ::rand::rng();
+                    all.shuffle(&mut rng); //DevSkim: ignore DS148264
+                }
+            },
+            RngKind::Faster => {
+                let mut rng = match seed {
+                    None => rand::make_rng::<Xoshiro256Plus>(),
+                    Some(sd) => Xoshiro256Plus::seed_from_u64(sd), // DevSkim: ignore DS148264
+                };
+                SliceRandom::shuffle(&mut *all, &mut rng); //DevSkim: ignore DS148264
+            },
+            RngKind::Cryptosecure => {
+                // Build seed_32 only when --seed is provided. The previous
+                // implementation pre-generated a 32-byte buffer from the
+                // process RNG and then threw it away on the unseeded path,
+                // wasting entropy and a syscall on every random sort.
+                let mut rng: Hc128Rng = match seed {
+                    None => rand::make_rng::<Hc128Rng>(),
+                    Some(sd) => {
+                        let mut seed_32 = [0u8; 32];
+                        seed_32[..8].copy_from_slice(&sd.to_le_bytes());
+                        Hc128Rng::from_seed(seed_32)
+                    },
+                };
+                SliceRandom::shuffle(&mut *all, &mut rng);
+            },
+        }
+    } else {
+        // Hoist comparison dispatch out of the closure: each branch
+        // monomorphizes with a single comparison function known at compile
+        // time. This collapses the previous 16-arm tuple match (which
+        // re-evaluated `if ignore_case` per row) into one macro plus a
+        // 5-arm `match mode`.
+        macro_rules! do_sort {
+            ($cmp:expr) => {{
+                if reverse {
+                    if faster {
+                        all.par_sort_unstable_by(|r1, r2| $cmp(sel.select(r2), sel.select(r1)));
                     } else {
-                        let mut rng = ::rand::rng();
-                        all.shuffle(&mut rng); //DevSkim: ignore DS148264
+                        all.par_sort_by(|r1, r2| $cmp(sel.select(r2), sel.select(r1)));
                     }
-                },
-                RngKind::Faster => {
-                    let mut rng = match args.flag_seed {
-                        None => rand::make_rng::<Xoshiro256Plus>(),
-                        Some(sd) => Xoshiro256Plus::seed_from_u64(sd), // DevSkim: ignore DS148264
-                    };
-                    SliceRandom::shuffle(&mut *all, &mut rng); //DevSkim: ignore DS148264
-                },
-                RngKind::Cryptosecure => {
-                    let seed_32 = match args.flag_seed {
-                        None => rand::rng().random::<[u8; 32]>(),
-                        Some(seed) => {
-                            let seed_u8 = seed.to_le_bytes();
-                            let mut seed_32 = [0u8; 32];
-                            seed_32[..8].copy_from_slice(&seed_u8);
-                            seed_32
-                        },
-                    };
-                    let mut rng: Hc128Rng = match args.flag_seed {
-                        None => rand::make_rng::<Hc128Rng>(),
-                        Some(_) => Hc128Rng::from_seed(seed_32),
-                    };
-                    SliceRandom::shuffle(&mut *all, &mut rng);
-                },
-            }
-        },
-
-        // default stable parallel sort
-        (false, false, false, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_ignore_case(a, b)
-            } else {
-                iter_cmp(a, b)
-            }
-        }),
-        // default --faster unstable, non-allocating parallel sort
-        (false, false, false, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_ignore_case(a, b)
-            } else {
-                iter_cmp(a, b)
-            }
-        }),
-
-        // --natural stable parallel natural sort
-        (false, true, false, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(a, b)
-            } else {
-                iter_cmp_natural(a, b)
-            }
-        }),
-        // --natural --faster unstable, non-allocating parallel natural sort
-        (false, true, false, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(a, b)
-            } else {
-                iter_cmp_natural(a, b)
-            }
-        }),
-
-        // --numeric stable parallel numeric sort
-        (true, false, false, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            iter_cmp_num(a, b)
-        }),
-        // --numeric --faster unstable, non-allocating, parallel numeric sort
-        (true, false, false, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            iter_cmp_num(a, b)
-        }),
-
-        // --reverse stable parallel sort
-        (false, false, true, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_ignore_case(b, a)
-            } else {
-                iter_cmp(b, a)
-            }
-        }),
-        // --reverse --faster unstable parallel sort
-        (false, false, true, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_ignore_case(b, a)
-            } else {
-                iter_cmp(b, a)
-            }
-        }),
-
-        // --natural --reverse stable parallel natural sort
-        (false, true, true, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(b, a)
-            } else {
-                iter_cmp_natural(b, a)
-            }
-        }),
-        // --natural --reverse --faster unstable parallel natural sort
-        (false, true, true, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(b, a)
-            } else {
-                iter_cmp_natural(b, a)
-            }
-        }),
-
-        // --numeric --reverse stable sort
-        (true, false, true, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            iter_cmp_num(b, a)
-        }),
-        // --numeric --reverse --faster unstable sort
-        (true, false, true, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            iter_cmp_num(b, a)
-        }),
-
-        // --numeric --natural stable sort (natural takes precedence over numeric)
-        (true, true, false, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(a, b)
-            } else {
-                iter_cmp_natural(a, b)
-            }
-        }),
-        // --numeric --natural --faster unstable sort
-        (true, true, false, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(a, b)
-            } else {
-                iter_cmp_natural(a, b)
-            }
-        }),
-
-        // --numeric --natural --reverse stable sort
-        (true, true, true, false, false) => all.par_sort_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(b, a)
-            } else {
-                iter_cmp_natural(b, a)
-            }
-        }),
-        // --numeric --natural --reverse --faster unstable sort
-        (true, true, true, false, true) => all.par_sort_unstable_by(|r1, r2| {
-            let a = sel.select(r1);
-            let b = sel.select(r2);
-            if ignore_case {
-                iter_cmp_natural_ignore_case(b, a)
-            } else {
-                iter_cmp_natural(b, a)
-            }
-        }),
+                } else if faster {
+                    all.par_sort_unstable_by(|r1, r2| $cmp(sel.select(r1), sel.select(r2)));
+                } else {
+                    all.par_sort_by(|r1, r2| $cmp(sel.select(r1), sel.select(r2)));
+                }
+            }};
+        }
+        match mode {
+            SortMode::Lex => do_sort!(iter_cmp),
+            SortMode::LexIgnoreCase => do_sort!(iter_cmp_ignore_case),
+            SortMode::Natural => do_sort!(iter_cmp_natural),
+            SortMode::NaturalIgnoreCase => do_sort!(iter_cmp_natural_ignore_case),
+            SortMode::Numeric => do_sort!(iter_cmp_num),
+        }
     }
 
     let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
-    let mut prev: Option<csv::ByteRecord> = None;
     rconfig.write_headers(&mut rdr, &mut wtr)?;
     if args.flag_unique {
-        for r in all {
-            match prev {
-                Some(other_r) => {
-                    let comparison = if numeric {
-                        iter_cmp_num(sel.select(&r), sel.select(&other_r))
-                    } else if natural {
-                        if ignore_case {
-                            iter_cmp_natural_ignore_case(sel.select(&r), sel.select(&other_r))
-                        } else {
-                            iter_cmp_natural(sel.select(&r), sel.select(&other_r))
+        // Use the same `mode` as the sort so unique-equality always matches
+        // what the sort grouped as adjacent.
+        macro_rules! unique_filter {
+            ($cmp:expr) => {{
+                let mut iter = all.iter();
+                if let Some(first) = iter.next() {
+                    wtr.write_byte_record(first)?;
+                    let mut prev = first;
+                    for current in iter {
+                        if $cmp(sel.select(prev), sel.select(current)) != Ordering::Equal {
+                            wtr.write_byte_record(current)?;
                         }
-                    } else if ignore_case {
-                        iter_cmp_ignore_case(sel.select(&r), sel.select(&other_r))
-                    } else {
-                        iter_cmp(sel.select(&r), sel.select(&other_r))
-                    };
-                    match comparison {
-                        cmp::Ordering::Equal => (),
-                        _ => {
-                            wtr.write_byte_record(&r)?;
-                        },
+                        prev = current;
                     }
-                },
-                None => {
-                    wtr.write_byte_record(&r)?;
-                },
-            }
-            prev = Some(r);
+                }
+            }};
+        }
+        match mode {
+            SortMode::Lex => unique_filter!(iter_cmp),
+            SortMode::LexIgnoreCase => unique_filter!(iter_cmp_ignore_case),
+            SortMode::Natural => unique_filter!(iter_cmp_natural),
+            SortMode::NaturalIgnoreCase => unique_filter!(iter_cmp_natural_ignore_case),
+            SortMode::Numeric => unique_filter!(iter_cmp_num),
         }
     } else {
-        for r in all {
-            wtr.write_byte_record(&r)?;
+        for r in &all {
+            wtr.write_byte_record(r)?;
         }
     }
     Ok(wtr.flush()?)
@@ -400,7 +293,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
 /// Order `a` and `b` lexicographically using `Ord`
 #[inline]
-pub fn iter_cmp<A, L, R>(mut a: L, mut b: R) -> cmp::Ordering
+pub fn iter_cmp<A, L, R>(mut a: L, mut b: R) -> Ordering
 where
     A: Ord,
     L: Iterator<Item = A>,
@@ -408,11 +301,11 @@ where
 {
     loop {
         match (a.next(), b.next()) {
-            (None, None) => return cmp::Ordering::Equal,
-            (None, _) => return cmp::Ordering::Less,
-            (_, None) => return cmp::Ordering::Greater,
+            (None, None) => return Ordering::Equal,
+            (None, _) => return Ordering::Less,
+            (_, None) => return Ordering::Greater,
             (Some(x), Some(y)) => match x.cmp(&y) {
-                cmp::Ordering::Equal => (),
+                Ordering::Equal => (),
                 non_eq => return non_eq,
             },
         }
@@ -421,42 +314,81 @@ where
 
 /// Try parsing `a` and `b` as numbers when ordering
 #[inline]
-pub fn iter_cmp_num<'a, L, R>(mut a: L, mut b: R) -> cmp::Ordering
+pub fn iter_cmp_num<'a, L, R>(mut a: L, mut b: R) -> Ordering
 where
     L: Iterator<Item = &'a [u8]>,
     R: Iterator<Item = &'a [u8]>,
 {
     loop {
         match (next_num(&mut a), next_num(&mut b)) {
-            (None, None) => return cmp::Ordering::Equal,
-            (None, _) => return cmp::Ordering::Less,
-            (_, None) => return cmp::Ordering::Greater,
+            (None, None) => return Ordering::Equal,
+            (None, _) => return Ordering::Less,
+            (_, None) => return Ordering::Greater,
             (Some(x), Some(y)) => match compare_num(x, y) {
-                cmp::Ordering::Equal => (),
+                Ordering::Equal => (),
                 non_eq => return non_eq,
             },
         }
     }
 }
 
-/// Order `a` and `b` using natural sort order
+/// Compare two cell-iterators ignoring case.
+///
+/// Cells that are pure ASCII compare via a zero-allocation byte-wise lowercase
+/// fold (the common case). Non-ASCII cells fall back to allocating a
+/// lowercased `String`. Cells that are not valid UTF-8 fall back to a raw
+/// byte comparison so a deterministic order is still produced.
 #[inline]
-pub fn iter_cmp_natural<'a, L, R>(mut a: L, mut b: R) -> cmp::Ordering
+pub fn iter_cmp_ignore_case<'a, L, R>(mut a: L, mut b: R) -> Ordering
 where
     L: Iterator<Item = &'a [u8]>,
     R: Iterator<Item = &'a [u8]>,
 {
     loop {
         match (a.next(), b.next()) {
-            (None, None) => return cmp::Ordering::Equal,
-            (None, _) => return cmp::Ordering::Less,
-            (_, None) => return cmp::Ordering::Greater,
-            (Some(x), Some(y)) => {
-                let comparison = compare_natural_strings(x, y);
-                match comparison {
-                    cmp::Ordering::Equal => (),
-                    non_eq => return non_eq,
-                }
+            (None, None) => return Ordering::Equal,
+            (None, _) => return Ordering::Less,
+            (_, None) => return Ordering::Greater,
+            (Some(x), Some(y)) => match cmp_ignore_case(x, y) {
+                Ordering::Equal => (),
+                non_eq => return non_eq,
+            },
+        }
+    }
+}
+
+#[inline]
+fn cmp_ignore_case(a: &[u8], b: &[u8]) -> Ordering {
+    // ASCII fast path: zero-allocation byte-wise lowercase compare.
+    if a.is_ascii() && b.is_ascii() {
+        return a
+            .iter()
+            .map(u8::to_ascii_lowercase)
+            .cmp(b.iter().map(u8::to_ascii_lowercase));
+    }
+    // Unicode slow path: allocate lowercased Strings.
+    match (from_utf8(a).ok(), from_utf8(b).ok()) {
+        (Some(sa), Some(sb)) => sa.to_lowercase().cmp(&sb.to_lowercase()),
+        // Invalid UTF-8 on either side: fall back to raw byte comparison.
+        _ => a.cmp(b),
+    }
+}
+
+/// Order `a` and `b` using natural sort order
+#[inline]
+pub fn iter_cmp_natural<'a, L, R>(mut a: L, mut b: R) -> Ordering
+where
+    L: Iterator<Item = &'a [u8]>,
+    R: Iterator<Item = &'a [u8]>,
+{
+    loop {
+        match (a.next(), b.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, _) => return Ordering::Less,
+            (_, None) => return Ordering::Greater,
+            (Some(x), Some(y)) => match compare_natural_bytes(x, y, false) {
+                Ordering::Equal => (),
+                non_eq => return non_eq,
             },
         }
     }
@@ -464,22 +396,19 @@ where
 
 /// Order `a` and `b` using natural sort order, ignoring case
 #[inline]
-pub fn iter_cmp_natural_ignore_case<'a, L, R>(mut a: L, mut b: R) -> cmp::Ordering
+pub fn iter_cmp_natural_ignore_case<'a, L, R>(mut a: L, mut b: R) -> Ordering
 where
     L: Iterator<Item = &'a [u8]>,
     R: Iterator<Item = &'a [u8]>,
 {
     loop {
         match (a.next(), b.next()) {
-            (None, None) => return cmp::Ordering::Equal,
-            (None, _) => return cmp::Ordering::Less,
-            (_, None) => return cmp::Ordering::Greater,
-            (Some(x), Some(y)) => {
-                let comparison = compare_natural_strings_ignore_case(x, y);
-                match comparison {
-                    cmp::Ordering::Equal => (),
-                    non_eq => return non_eq,
-                }
+            (None, None) => return Ordering::Equal,
+            (None, _) => return Ordering::Less,
+            (_, None) => return Ordering::Greater,
+            (Some(x), Some(y)) => match compare_natural_bytes(x, y, true) {
+                Ordering::Equal => (),
+                non_eq => return non_eq,
             },
         }
     }
@@ -492,7 +421,7 @@ enum Number {
 }
 
 #[inline]
-fn compare_num(n1: Number, n2: Number) -> cmp::Ordering {
+fn compare_num(n1: Number, n2: Number) -> Ordering {
     match (n1, n2) {
         (Int(i1), Int(i2)) => i1.cmp(&i2),
         #[allow(clippy::cast_precision_loss)]
@@ -507,8 +436,8 @@ fn compare_num(n1: Number, n2: Number) -> cmp::Ordering {
 // This function is part of a performance-critical hot path. Inlining it
 // avoids the overhead of a function call, improving performance.
 #[inline(always)]
-fn compare_float(f1: f64, f2: f64) -> cmp::Ordering {
-    f1.partial_cmp(&f2).unwrap_or(cmp::Ordering::Equal)
+fn compare_float(f1: f64, f2: f64) -> Ordering {
+    f1.partial_cmp(&f2).unwrap_or(Ordering::Equal)
 }
 
 #[inline]
@@ -533,17 +462,7 @@ where
 }
 
 #[inline]
-fn compare_natural_strings(a: &[u8], b: &[u8]) -> cmp::Ordering {
-    compare_natural_bytes(a, b, false)
-}
-
-#[inline]
-fn compare_natural_strings_ignore_case(a: &[u8], b: &[u8]) -> cmp::Ordering {
-    compare_natural_bytes(a, b, true)
-}
-
-#[inline]
-fn compare_natural_bytes(a: &[u8], b: &[u8], ignore_case: bool) -> cmp::Ordering {
+fn compare_natural_bytes(a: &[u8], b: &[u8], ignore_case: bool) -> Ordering {
     let mut a_pos = 0;
     let mut b_pos = 0;
 
@@ -571,7 +490,7 @@ fn compare_natural_bytes(a: &[u8], b: &[u8], ignore_case: bool) -> cmp::Ordering
             (b_num, b_end) = collect_number_from_bytes(b, b_pos);
 
             num_comparison = a_num.cmp(&b_num);
-            if num_comparison != cmp::Ordering::Equal {
+            if num_comparison != Ordering::Equal {
                 return num_comparison;
             }
 
@@ -579,10 +498,10 @@ fn compare_natural_bytes(a: &[u8], b: &[u8], ignore_case: bool) -> cmp::Ordering
             b_pos = b_end;
         } else if a_byte.is_ascii_digit() {
             // Digits come before non-digits
-            return cmp::Ordering::Less;
+            return Ordering::Less;
         } else if b_byte.is_ascii_digit() {
             // Digits come before non-digits
-            return cmp::Ordering::Greater;
+            return Ordering::Greater;
         } else {
             // Both are non-digits, compare normally
             a_char = if ignore_case {
@@ -597,7 +516,7 @@ fn compare_natural_bytes(a: &[u8], b: &[u8], ignore_case: bool) -> cmp::Ordering
             };
 
             char_comparison = a_char.cmp(&b_char);
-            if char_comparison != cmp::Ordering::Equal {
+            if char_comparison != Ordering::Equal {
                 return char_comparison;
             }
             a_pos += 1;

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -24,7 +24,8 @@ sort options:
                             When combined with --numeric, --natural takes precedence.
     -R, --reverse           Reverse order
     -i, --ignore-case       Compare strings disregarding case.
-                            Has no effect under --numeric (numbers are case-less).
+                            Has no effect when numeric comparison is selected
+                            (i.e. when --numeric is used without --natural).
     -u, --unique            When set, identical consecutive lines will be dropped
                             to keep only one line per sorted value. The same
                             comparison mode used to sort the input is also used

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -63,7 +63,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CliResult,
-    cmd::{dedup, sort::iter_cmp},
+    cmd::sort::{iter_cmp, iter_cmp_ignore_case},
     config::{Config, Delimiter},
     select::SelectColumns,
     util,
@@ -150,7 +150,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let a = sel.select(&record);
         let b = sel.select(&next_record);
         let comparison = if ignore_case {
-            dedup::iter_cmp_ignore_case(a, b)
+            iter_cmp_ignore_case(a, b)
         } else {
             iter_cmp(a, b)
         };

--- a/tests/test_sort.rs
+++ b/tests/test_sort.rs
@@ -415,6 +415,44 @@ fn sort_uniq_faster() {
 }
 
 #[test]
+fn sort_uniq_numeric_natural() {
+    // Regression: --numeric --natural --unique must use the same comparison
+    // mode for BOTH the sort and the unique-filter. --natural takes
+    // precedence over --numeric for the sort, and previously the
+    // unique-filter silently disagreed by re-evaluating the flags with
+    // numeric-first precedence — dropping records the natural sort had
+    // intentionally kept distinct.
+    //
+    // Under natural compare: "1" < "01" < "2" < "02" (same numeric value,
+    // shorter string sorts first). Under numeric compare those four are
+    // pairwise equal, so the buggy unique-filter would drop "01" and "02".
+    let wrk = Workdir::new("sort_uniq_numeric_natural");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["data"],
+            svec!["02"],
+            svec!["1"],
+            svec!["2"],
+            svec!["01"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sort");
+    cmd.args(["-N", "--natural", "-u"]).arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["data"],
+        svec!["1"],
+        svec!["01"],
+        svec!["2"],
+        svec!["02"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn sort_random() {
     let wrk = Workdir::new("sort_random");
     wrk.create(


### PR DESCRIPTION
## Summary

Review-driven cleanup of \`src/cmd/sort.rs\` — continues the recent series.

**Stacked on #3754** (dedup cleanup). This branch's base will auto-retarget to \`master\` once #3754 merges. Please merge that first.

### Correctness
- **\`--numeric --natural --unique\` inconsistency**: sort honored the documented "natural takes precedence over numeric" rule, but the unique-filter independently dispatched with numeric-first precedence and silently dropped records the natural sort had kept distinct. Both paths now share a single \`SortMode\` value. New \`sort_uniq_numeric_natural\` regression test locks this in.
- **Wasted entropy in \`RngKind::Cryptosecure\`**: previously \`seed_32\` was generated from the process RNG even when \`--seed\` was absent and then discarded. Now built only when needed.

### Refactor
- 16-arm tuple match → 5-variant \`SortMode\` enum + \`do_sort!\` macro. Per-row \`if ignore_case\` checks hoisted out of the sort closures.
- Same \`SortMode\` + \`unique_filter!\` macro for the \`--unique\` loop.
- Moved \`iter_cmp_ignore_case\` (and \`cmp_ignore_case\` helper) from \`dedup.rs\` to \`sort.rs\`, alongside \`iter_cmp\` / \`iter_cmp_num\` / \`iter_cmp_natural*\`. Updated \`dedup.rs\` and \`sortcheck.rs\` imports.
- Inlined the trivial \`compare_natural_strings*\` shims.
- \`use std::cmp::Ordering;\` throughout.

**Net diff**: 260 insertions, 348 deletions.

## Test plan
- [x] \`cargo test -F all_features sort\` — 80/80 pass (1 new)
- [x] \`cargo test -F all_features dedup\` — 21/21 pass
- [x] \`cargo +nightly clippy --bin qsv -F all_features -- -W clippy::perf\` — clean
- [x] \`cargo +nightly fmt --check\` — clean
- [x] Manual: \`printf 'data\\n02\\n1\\n2\\n01\\n' | qsv sort -N --natural -u\` → \`1, 01, 2, 02\` (was \`1, 2\` before fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)