### PR TITLE
sortcheck: review-driven cleanup, add --numeric/--natural, allocation-free streaming loop

### DIFF
--- a/docs/help/sortcheck.md
+++ b/docs/help/sortcheck.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/sortcheck.rs](https://github.com/dathere/qsv/blob/master/src/cmd/sortcheck.rs)** | [👆](TableOfContents.md#legend "has powerful column selector support. See `select` for syntax.")
 
 <a name="nav"></a>
-[Description](#description) | [Usage](#usage) | [Sort Options](#sort-options) | [Common Options](#common-options)
+[Description](#description) | [Examples](#examples) | [Usage](#usage) | [Sort Options](#sort-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -22,17 +22,50 @@ first before deduping. However, if you know a CSV is sorted beforehand, you can 
 `dedup` with the --sorted option, and it will skip loading entire CSV into memory to sort
 it first. It will just immediately dedupe on a streaming basis.
 
-`sort` also requires loading the entire CSV into memory. For simple "sorts" (not numeric,
-reverse, unique & random sorts), particularly of very large CSV files that will not fit in memory,
-`extsort` - a multi-threaded streaming sort that is exponentially faster and can work with
-arbitrarily large files, can be used instead.
+`sort` also requires loading the entire CSV into memory. For very large CSV files that will
+not fit in memory, `extsort` - a multi-threaded streaming sort that can work with arbitrarily
+large files - can be used instead.
+
+Use --numeric or --natural to verify the file matches the order produced by `sort --numeric`
+or `sort --natural` before piping into a downstream command (e.g. `dedup --numeric --sorted`).
+When multiple comparison flags are set, --natural takes precedence over --numeric, which takes
+precedence over --ignore-case (matching `sort` and `dedup` semantics).
 
 Simply put, sortcheck allows you to make informed choices on how to compose pipelines that
 require sorted data.
 
 Returns exit code 0 if a CSV is sorted, and exit code 1 otherwise.
 
-For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_sortcheck.rs>.
+
+<a name="examples"></a>
+
+## Examples [↩](#nav)
+
+> Check if file.csv is lexicographically sorted on all columns:
+
+```console
+qsv sortcheck file.csv
+```
+
+> Check column "name" only, ignoring case:
+
+```console
+qsv sortcheck --select name --ignore-case file.csv
+```
+
+> Verify file.csv is sorted numerically before piping into `dedup --numeric --sorted`:
+
+```console
+qsv sortcheck --numeric file.csv && qsv dedup --numeric --sorted file.csv
+```
+
+> Check natural order (e.g. item1, item2, item10) and emit JSON stats:
+
+```console
+qsv sortcheck --natural --json file.csv
+```
+
+For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_sortcheck.rs).
 
 
 <a name="usage"></a>
@@ -51,7 +84,9 @@ qsv sortcheck --help
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
 | &nbsp;`‑s,`<br>`‑‑select`&nbsp; | string | Select a subset of columns to check for sort. See 'qsv select --help' for the format details. |  |
-| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case |  |
+| &nbsp;`‑N,`<br>`‑‑numeric`&nbsp; | flag | Compare according to string numerical value. |  |
+| &nbsp;`‑‑natural`&nbsp; | flag | Compare using natural sort order (e.g. item1 < item2 < item10). Takes precedence over --numeric. Composes with --ignore-case. |  |
+| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Ignored when --numeric is set (numeric comparison is case-insensitive by definition). |  |
 | &nbsp;`‑‑all`&nbsp; | flag | Check all records. Do not stop/short-circuit the check on the first unsorted record. |  |
 | &nbsp;`‑‑json`&nbsp; | flag | Return results in JSON format, scanning --all records. The JSON result has the following properties - sorted (boolean), record_count (number), unsorted_breaks (number) & dupe_count (number). Unsorted breaks count the number of times two consecutive rows are unsorted (i.e. n row > n+1 row). Dupe count is the number of times two consecutive rows are equal. Note that dupe count does not apply if the file is not sorted and is set to -1. |  |
 | &nbsp;`‑‑pretty‑json`&nbsp; | flag | Same as --json but in pretty JSON format. |  |

--- a/docs/help/sortcheck.md
+++ b/docs/help/sortcheck.md
@@ -86,7 +86,7 @@ qsv sortcheck --help
 | &nbsp;`‑s,`<br>`‑‑select`&nbsp; | string | Select a subset of columns to check for sort. See 'qsv select --help' for the format details. |  |
 | &nbsp;`‑N,`<br>`‑‑numeric`&nbsp; | flag | Compare according to string numerical value. |  |
 | &nbsp;`‑‑natural`&nbsp; | flag | Compare using natural sort order (e.g. item1 < item2 < item10). Takes precedence over --numeric. Composes with --ignore-case. |  |
-| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Ignored when --numeric is set (numeric comparison is case-insensitive by definition). |  |
+| &nbsp;`‑i,`<br>`‑‑ignore‑case`&nbsp; | flag | Compare strings disregarding case. Ignored under pure numeric comparison (i.e. --numeric without --natural), since numeric comparison is case-insensitive by definition. |  |
 | &nbsp;`‑‑all`&nbsp; | flag | Check all records. Do not stop/short-circuit the check on the first unsorted record. |  |
 | &nbsp;`‑‑json`&nbsp; | flag | Return results in JSON format, scanning --all records. The JSON result has the following properties - sorted (boolean), record_count (number), unsorted_breaks (number) & dupe_count (number). Unsorted breaks count the number of times two consecutive rows are unsorted (i.e. n row > n+1 row). Dupe count is the number of times two consecutive rows are equal. Note that dupe count does not apply if the file is not sorted and is set to -1. |  |
 | &nbsp;`‑‑pretty‑json`&nbsp; | flag | Same as --json but in pretty JSON format. |  |

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -10,15 +10,33 @@ first before deduping. However, if you know a CSV is sorted beforehand, you can 
 `dedup` with the --sorted option, and it will skip loading entire CSV into memory to sort
 it first. It will just immediately dedupe on a streaming basis.
 
-`sort` also requires loading the entire CSV into memory. For simple "sorts" (not numeric,
-reverse, unique & random sorts), particularly of very large CSV files that will not fit in memory,
-`extsort` - a multi-threaded streaming sort that is exponentially faster and can work with 
-arbitrarily large files, can be used instead.
+`sort` also requires loading the entire CSV into memory. For very large CSV files that will
+not fit in memory, `extsort` - a multi-threaded streaming sort that can work with arbitrarily
+large files - can be used instead.
+
+Use --numeric or --natural to verify the file matches the order produced by `sort --numeric`
+or `sort --natural` before piping into a downstream command (e.g. `dedup --numeric --sorted`).
+When multiple comparison flags are set, --natural takes precedence over --numeric, which takes
+precedence over --ignore-case (matching `sort` and `dedup` semantics).
 
 Simply put, sortcheck allows you to make informed choices on how to compose pipelines that
 require sorted data.
 
 Returns exit code 0 if a CSV is sorted, and exit code 1 otherwise.
+
+Examples:
+
+  # Check if file.csv is lexicographically sorted on all columns:
+  qsv sortcheck file.csv
+
+  # Check column "name" only, ignoring case:
+  qsv sortcheck --select name --ignore-case file.csv
+
+  # Verify file.csv is sorted numerically before piping into `dedup --numeric --sorted`:
+  qsv sortcheck --numeric file.csv && qsv dedup --numeric --sorted file.csv
+
+  # Check natural order (e.g. item1, item2, item10) and emit JSON stats:
+  qsv sortcheck --natural --json file.csv
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_sortcheck.rs.
 
@@ -29,12 +47,16 @@ Usage:
 sort options:
     -s, --select <arg>      Select a subset of columns to check for sort.
                             See 'qsv select --help' for the format details.
-    -i, --ignore-case       Compare strings disregarding case
-    --all                   Check all records. Do not stop/short-circuit the check 
+    -N, --numeric           Compare according to string numerical value.
+    --natural               Compare using natural sort order (e.g. item1 < item2 < item10).
+                            Takes precedence over --numeric. Composes with --ignore-case.
+    -i, --ignore-case       Compare strings disregarding case. Ignored when --numeric is set
+                            (numeric comparison is case-insensitive by definition).
+    --all                   Check all records. Do not stop/short-circuit the check
                             on the first unsorted record.
-    --json                  Return results in JSON format, scanning --all records. 
-                            The JSON result has the following properties - 
-                            sorted (boolean), record_count (number), 
+    --json                  Return results in JSON format, scanning --all records.
+                            The JSON result has the following properties -
+                            sorted (boolean), record_count (number),
                             unsorted_breaks (number) & dupe_count (number).
                             Unsorted breaks count the number of times two consecutive
                             rows are unsorted (i.e. n row > n+1 row).
@@ -54,7 +76,7 @@ Common options:
     -p, --progressbar       Show progress bars. Not valid for stdin.
 "#;
 
-use std::cmp;
+use std::cmp::Ordering;
 
 use csv::ByteRecord;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
@@ -63,17 +85,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CliResult,
-    cmd::sort::{iter_cmp, iter_cmp_ignore_case},
+    cmd::sort::{
+        iter_cmp, iter_cmp_ignore_case, iter_cmp_natural, iter_cmp_natural_ignore_case,
+        iter_cmp_num,
+    },
     config::{Config, Delimiter},
     select::SelectColumns,
     util,
 };
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct Args {
     arg_input:        Option<String>,
     flag_select:      SelectColumns,
+    flag_numeric:     bool,
+    flag_natural:     bool,
     flag_ignore_case: bool,
     flag_all:         bool,
     flag_no_headers:  bool,
@@ -91,9 +117,36 @@ struct SortCheckStruct {
     dupe_count:      i64,
 }
 
+// Mirrors `SortMode` in `cmd/sort.rs` so sortcheck verifies the same ordering
+// the user would get from `sort` / `dedup`.
+enum ComparisonMode {
+    Lex,
+    LexIgnoreCase,
+    Numeric,
+    Natural,
+    NaturalIgnoreCase,
+}
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let ignore_case = args.flag_ignore_case;
+
+    // Resolution order matches `sort` and `dedup`: --natural beats --numeric
+    // beats --ignore-case. Done once before the loop so the dispatch `match`
+    // monomorphizes to a single comparator per row.
+    let compare_mode = if args.flag_natural {
+        if args.flag_ignore_case {
+            ComparisonMode::NaturalIgnoreCase
+        } else {
+            ComparisonMode::Natural
+        }
+    } else if args.flag_numeric {
+        ComparisonMode::Numeric
+    } else if args.flag_ignore_case {
+        ComparisonMode::LexIgnoreCase
+    } else {
+        ComparisonMode::Lex
+    };
+
     let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers_flag(args.flag_no_headers)
@@ -127,7 +180,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         record_count = 0;
     }
 
-    let do_json = args.flag_json | args.flag_pretty_json;
+    let do_json = args.flag_json || args.flag_pretty_json;
 
     let mut record = ByteRecord::new();
     let mut next_record = ByteRecord::new();
@@ -149,24 +202,29 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
         let a = sel.select(&record);
         let b = sel.select(&next_record);
-        let comparison = if ignore_case {
-            iter_cmp_ignore_case(a, b)
-        } else {
-            iter_cmp(a, b)
+        let comparison = match compare_mode {
+            ComparisonMode::Lex => iter_cmp(a, b),
+            ComparisonMode::LexIgnoreCase => iter_cmp_ignore_case(a, b),
+            ComparisonMode::Numeric => iter_cmp_num(a, b),
+            ComparisonMode::Natural => iter_cmp_natural(a, b),
+            ComparisonMode::NaturalIgnoreCase => iter_cmp_natural_ignore_case(a, b),
         };
 
         match comparison {
-            cmp::Ordering::Equal => {
+            Ordering::Equal => {
                 dupe_count += 1;
             },
-            cmp::Ordering::Less => {
-                record.clone_from(&next_record);
+            Ordering::Less => {
+                // Allocation-free buffer rotation: next_record will be
+                // overwritten by the next read_byte_record, so swapping is
+                // safe and avoids the clone_from copy.
+                std::mem::swap(&mut record, &mut next_record);
             },
-            cmp::Ordering::Greater => {
+            Ordering::Greater => {
                 sorted = false;
                 if args.flag_all || do_json {
                     unsorted_breaks += 1;
-                    record.clone_from(&next_record);
+                    std::mem::swap(&mut record, &mut next_record);
                 } else {
                     break;
                 }
@@ -201,6 +259,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     if do_json {
+        // `do_json` forces a full scan in the Greater arm above, so when
+        // record_count was not pre-computed via count_rows (no --progressbar
+        // / datapusher_plus build), scan_ctr equals the total record count.
         let sortcheck_struct = SortCheckStruct {
             sorted,
             record_count: if record_count == 0 {
@@ -209,7 +270,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 record_count
             },
             unsorted_breaks,
-            dupe_count: if sorted { dupe_count as i64 } else { -1 },
+            // -1 signals "not applicable" when the file is unsorted.
+            // try_from is defensive; in practice u64 dupe counts never
+            // exceed i64::MAX on real CSVs.
+            dupe_count: if sorted {
+                i64::try_from(dupe_count).unwrap_or(i64::MAX)
+            } else {
+                -1
+            },
         };
         // it's OK to have unwrap here as we know sortcheck_struct is valid json
         if args.flag_pretty_json {

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -50,8 +50,9 @@ sort options:
     -N, --numeric           Compare according to string numerical value.
     --natural               Compare using natural sort order (e.g. item1 < item2 < item10).
                             Takes precedence over --numeric. Composes with --ignore-case.
-    -i, --ignore-case       Compare strings disregarding case. Ignored when --numeric is set
-                            (numeric comparison is case-insensitive by definition).
+    -i, --ignore-case       Compare strings disregarding case. Ignored under pure
+                            numeric comparison (i.e. --numeric without --natural),
+                            since numeric comparison is case-insensitive by definition.
     --all                   Check all records. Do not stop/short-circuit the check
                             on the first unsorted record.
     --json                  Return results in JSON format, scanning --all records.
@@ -119,6 +120,7 @@ struct SortCheckStruct {
 
 // Mirrors `SortMode` in `cmd/sort.rs` so sortcheck verifies the same ordering
 // the user would get from `sort` / `dedup`.
+#[derive(Clone, Copy)]
 enum ComparisonMode {
     Lex,
     LexIgnoreCase,
@@ -189,48 +191,51 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut dupe_count: u64 = 0;
     let mut unsorted_breaks: u64 = 0;
 
-    rdr.read_byte_record(&mut record)?;
-    loop {
-        #[cfg(any(feature = "feature_capable", feature = "lite"))]
-        if show_progress {
-            progress.inc(1);
-        }
-        scan_ctr += 1;
-        let more_records = rdr.read_byte_record(&mut next_record)?;
-        if !more_records {
-            break;
-        }
-        let a = sel.select(&record);
-        let b = sel.select(&next_record);
-        let comparison = match compare_mode {
-            ComparisonMode::Lex => iter_cmp(a, b),
-            ComparisonMode::LexIgnoreCase => iter_cmp_ignore_case(a, b),
-            ComparisonMode::Numeric => iter_cmp_num(a, b),
-            ComparisonMode::Natural => iter_cmp_natural(a, b),
-            ComparisonMode::NaturalIgnoreCase => iter_cmp_natural_ignore_case(a, b),
-        };
+    // Skip the loop entirely on empty input (header-only CSV) so scan_ctr
+    // correctly stays at 0 and JSON `record_count` reports 0 data records.
+    if rdr.read_byte_record(&mut record)? {
+        loop {
+            #[cfg(any(feature = "feature_capable", feature = "lite"))]
+            if show_progress {
+                progress.inc(1);
+            }
+            scan_ctr += 1;
+            let more_records = rdr.read_byte_record(&mut next_record)?;
+            if !more_records {
+                break;
+            }
+            let a = sel.select(&record);
+            let b = sel.select(&next_record);
+            let comparison = match compare_mode {
+                ComparisonMode::Lex => iter_cmp(a, b),
+                ComparisonMode::LexIgnoreCase => iter_cmp_ignore_case(a, b),
+                ComparisonMode::Numeric => iter_cmp_num(a, b),
+                ComparisonMode::Natural => iter_cmp_natural(a, b),
+                ComparisonMode::NaturalIgnoreCase => iter_cmp_natural_ignore_case(a, b),
+            };
 
-        match comparison {
-            Ordering::Equal => {
-                dupe_count += 1;
-            },
-            Ordering::Less => {
-                // Allocation-free buffer rotation: next_record will be
-                // overwritten by the next read_byte_record, so swapping is
-                // safe and avoids the clone_from copy.
-                std::mem::swap(&mut record, &mut next_record);
-            },
-            Ordering::Greater => {
-                sorted = false;
-                if args.flag_all || do_json {
-                    unsorted_breaks += 1;
+            match comparison {
+                Ordering::Equal => {
+                    dupe_count += 1;
+                },
+                Ordering::Less => {
+                    // Allocation-free buffer rotation: next_record will be
+                    // overwritten by the next read_byte_record, so swapping is
+                    // safe and avoids the clone_from copy.
                     std::mem::swap(&mut record, &mut next_record);
-                } else {
-                    break;
-                }
-            },
-        }
-    } // end loop
+                },
+                Ordering::Greater => {
+                    sorted = false;
+                    if args.flag_all || do_json {
+                        unsorted_breaks += 1;
+                        std::mem::swap(&mut record, &mut next_record);
+                    } else {
+                        break;
+                    }
+                },
+            }
+        } // end inner loop
+    } // end empty-input guard
 
     #[cfg(any(feature = "feature_capable", feature = "lite"))]
     if show_progress {
@@ -259,16 +264,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 
     if do_json {
-        // `do_json` forces a full scan in the Greater arm above, so when
-        // record_count was not pre-computed via count_rows (no --progressbar
-        // / datapusher_plus build), scan_ctr equals the total record count.
+        // `do_json` forces a full scan in the Greater arm above, so scan_ctr
+        // is always the authoritative count of data records (and is correctly
+        // 0 for header-only input thanks to the empty-input guard above).
         let sortcheck_struct = SortCheckStruct {
             sorted,
-            record_count: if record_count == 0 {
-                scan_ctr
-            } else {
-                record_count
-            },
+            record_count: scan_ctr,
             unsorted_breaks,
             // -1 signals "not applicable" when the file is unsorted.
             // try_from is defensive; in practice u64 dupe counts never

--- a/tests/test_sortcheck.rs
+++ b/tests/test_sortcheck.rs
@@ -192,6 +192,205 @@ fn sortcheck_simple_json() {
 }
 
 #[test]
+fn sortcheck_ignore_case_sorted() {
+    let wrk = Workdir::new("sortcheck_ignore_case_sorted");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["name"],
+            svec!["alpha"],
+            svec!["Beta"],
+            svec!["gamma"],
+            svec!["Delta"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--ignore-case").arg("in.csv");
+
+    wrk.assert_err(&mut cmd);
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("in.csv");
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn sortcheck_ignore_case_actually_sorted() {
+    let wrk = Workdir::new("sortcheck_ignore_case_actually_sorted");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["name"],
+            svec!["alpha"],
+            svec!["Beta"],
+            svec!["Charlie"],
+            svec!["delta"],
+        ],
+    );
+
+    // Lex sort sees uppercase < lowercase, so this is NOT sorted lex.
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("in.csv");
+    wrk.assert_err(&mut cmd);
+
+    // But it IS sorted ignoring case.
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--ignore-case").arg("in.csv");
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn sortcheck_empty() {
+    let wrk = Workdir::new("sortcheck_empty");
+    wrk.create("in.csv", vec![svec!["col1", "col2"]]);
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("in.csv");
+    wrk.assert_success(&mut cmd);
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--json").arg("in.csv");
+    let output = cmd.output().unwrap();
+    let got_stdout = std::str::from_utf8(&output.stdout).unwrap_or_default();
+    assert_eq!(
+        got_stdout,
+        "{\"sorted\":true,\"record_count\":1,\"unsorted_breaks\":0,\"dupe_count\":0}\n"
+    );
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn sortcheck_single_row() {
+    let wrk = Workdir::new("sortcheck_single_row");
+    wrk.create("in.csv", vec![svec!["col1"], svec!["only"]]);
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("in.csv");
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn sortcheck_numeric_sorted() {
+    let wrk = Workdir::new("sortcheck_numeric_sorted");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["n"],
+            svec!["2"],
+            svec!["10"],
+            svec!["30"],
+            svec!["200"],
+        ],
+    );
+
+    // Lex sees "10" < "2", so the file is NOT sorted lex.
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("in.csv");
+    wrk.assert_err(&mut cmd);
+
+    // But it IS sorted numerically.
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--numeric").arg("in.csv");
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn sortcheck_numeric_unsorted() {
+    let wrk = Workdir::new("sortcheck_numeric_unsorted");
+    wrk.create(
+        "in.csv",
+        vec![svec!["n"], svec!["2"], svec!["30"], svec!["10"]],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--numeric").arg("in.csv");
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn sortcheck_natural_sorted() {
+    let wrk = Workdir::new("sortcheck_natural_sorted");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["item"],
+            svec!["item1"],
+            svec!["item2"],
+            svec!["item10"],
+            svec!["item20"],
+        ],
+    );
+
+    // Lex sees "item10" < "item2", so the file is NOT sorted lex.
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("in.csv");
+    wrk.assert_err(&mut cmd);
+
+    // But it IS sorted naturally.
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--natural").arg("in.csv");
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn sortcheck_natural_unsorted() {
+    let wrk = Workdir::new("sortcheck_natural_unsorted");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["item"],
+            svec!["item1"],
+            svec!["item10"],
+            svec!["item2"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--natural").arg("in.csv");
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn sortcheck_natural_ignore_case() {
+    let wrk = Workdir::new("sortcheck_natural_ignore_case");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["item"],
+            svec!["Item1"],
+            svec!["item2"],
+            svec!["ITEM10"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--natural").arg("--ignore-case").arg("in.csv");
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn sortcheck_natural_overrides_numeric() {
+    // Mirrors sort/dedup precedence: --natural beats --numeric. A file that
+    // is sorted naturally but NOT numerically should pass when both flags
+    // are set.
+    let wrk = Workdir::new("sortcheck_natural_overrides_numeric");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["item"],
+            svec!["item1"],
+            svec!["item2"],
+            svec!["item10"],
+        ],
+    );
+
+    let mut cmd = wrk.command("sortcheck");
+    cmd.arg("--natural").arg("--numeric").arg("in.csv");
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
 fn sortcheck_simple_all_json_progressbar() {
     let wrk = Workdir::new("sortcheck_simple_all_json_progressbar");
     wrk.create(

--- a/tests/test_sortcheck.rs
+++ b/tests/test_sortcheck.rs
@@ -192,8 +192,8 @@ fn sortcheck_simple_json() {
 }
 
 #[test]
-fn sortcheck_ignore_case_sorted() {
-    let wrk = Workdir::new("sortcheck_ignore_case_sorted");
+fn sortcheck_ignore_case_notsorted() {
+    let wrk = Workdir::new("sortcheck_ignore_case_notsorted");
     wrk.create(
         "in.csv",
         vec![
@@ -255,7 +255,7 @@ fn sortcheck_empty() {
     let got_stdout = std::str::from_utf8(&output.stdout).unwrap_or_default();
     assert_eq!(
         got_stdout,
-        "{\"sorted\":true,\"record_count\":1,\"unsorted_breaks\":0,\"dupe_count\":0}\n"
+        "{\"sorted\":true,\"record_count\":0,\"unsorted_breaks\":0,\"dupe_count\":0}\n"
     );
     wrk.assert_success(&mut cmd);
 }


### PR DESCRIPTION
## Summary

Brings `sortcheck` in line with the recent review-driven cleanups for `sort` (#3755), `dedup` (#3754), `datefmt` (#3753), and `util` (#3752), and closes a real feature gap.

- **Feature**: `sortcheck` previously only supported lex / `--ignore-case`, so users could not pre-verify a CSV before piping into `sort --numeric`, `sort --natural`, or `dedup --numeric --sorted`. Adds `--numeric` (`-N`) and `--natural`, reusing `iter_cmp_num`, `iter_cmp_natural`, and `iter_cmp_natural_ignore_case` already exported from `cmd/sort.rs` — no new comparators.
- **Resolution**: flags resolve into a `ComparisonMode` enum once before the loop, with the same precedence as `sort`/`dedup`: `--natural` > `--numeric` > `--ignore-case`. Dispatch is a single `match` per row that monomorphizes to one comparator.
- **Allocation hygiene**: `record.clone_from(&next_record)` → `std::mem::swap(...)` on both `Less` and `Greater` arms — zero-copy buffer rotation, matching dedup #3754.
- **Misc cleanup**:
  - `args.flag_json | args.flag_pretty_json` → `||` (idiomatic logical OR).
  - `dupe_count as i64` → `i64::try_from(...).unwrap_or(i64::MAX)` with a comment on why `-1` signals "not applicable".
  - Dropped stale `#[allow(dead_code)]` on `Args`.
  - Comment on the `do_json`-forces-full-scan invariant that makes `scan_ctr` equivalent to `record_count` in the JSON path.
- **Docs**: USAGE updated with the new flags + precedence + an Examples block; the extsort paragraph tightened (`sort` itself is now multi-threaded). `docs/help/sortcheck.md` regenerated via `qsv --generate-help-md`.

## Test plan

- [x] `cargo test sortcheck -F all_features` — **19/19 pass** (10 new + 9 existing).
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` — clean.
- [x] `cargo build --bin qsv -F all_features` — clean.
- [x] Help-doc regeneration verified: `docs/help/sortcheck.md` reflects the new flags.
- New tests added: `--ignore-case` sorted/unsorted (incl. a real lex-vs-ignore-case discriminator), empty input, single-row input, `--numeric` sorted/unsorted, `--natural` sorted/unsorted, `--natural` + `--ignore-case` composition, and a precedence test confirming `--natural` overrides `--numeric`.
- [ ] Manual smoke after merge:
  - `printf 'n\n10\n2\n30\n' | qsv sortcheck -n` → exit 1 (lex unsorted)
  - `printf 'n\n2\n10\n30\n' | qsv sortcheck -n --numeric` → exit 0
  - `printf 'n\nitem1\nitem2\nitem10\n' | qsv sortcheck -n --natural --json` → sorted JSON, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)