### PR TITLE
select: review-driven cleanup, fix '/' panic, quoted-name CSV-escape, empty-name silent fall-through, dead code

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -163,7 +163,8 @@ impl SelectorParser {
         }
         // First-occurrence index: matches the unquoted name fallback below,
         // which also defaults to the first occurrence when the header name
-        // is not numeric (see `IndexedName(name, 0)` in the `Err` arm).
+        // is not numeric (see `IndexedName(name, FIRST_OCCURRENCE)` in the
+        // `Err` arm).
         const FIRST_OCCURRENCE: usize = 0;
         Ok(if self.cur() == Some('[') {
             let idx = self.parse_index()?;

--- a/src/select.rs
+++ b/src/select.rs
@@ -57,11 +57,6 @@ impl SelectColumns {
         }
         Ok(Selection(map))
     }
-
-    #[allow(dead_code)]
-    pub const fn is_empty(&self) -> bool {
-        self.selectors.is_empty()
-    }
 }
 
 impl fmt::Debug for SelectColumns {
@@ -101,7 +96,9 @@ impl SelectorParser {
 
     fn parse(&mut self) -> Result<Vec<Selector>, String> {
         if (self.chars.first(), self.chars.last()) == (Some(&'/'), Some(&'/')) {
-            if self.chars.len() == 2 {
+            // A single '/' has first == last (same element) but isn't a valid
+            // regex delimiter — treat it (and the empty `//` form) as empty.
+            if self.chars.len() < 3 {
                 return fail_format!("Empty regex: {}", self.chars.iter().collect::<String>());
             }
             let re: String = self.chars[1..(self.chars.len() - 1)].iter().collect();
@@ -147,19 +144,25 @@ impl SelectorParser {
     }
 
     fn parse_one(&mut self) -> Result<OneSelector, String> {
-        let name = if self.cur() == Some('"') {
+        let (name, quoted) = if self.cur() == Some('"') {
             self.bump();
-            self.parse_quoted_name()?
+            (self.parse_quoted_name()?, true)
         } else {
             if self.cur() == Some('_') {
                 self.bump();
                 return Ok(OneSelector::End);
             }
-            self.parse_name()
+            (self.parse_name(), false)
         };
+        if name.is_empty() {
+            return fail!("Empty selector name.");
+        }
         Ok(if self.cur() == Some('[') {
             let idx = self.parse_index()?;
             OneSelector::IndexedName(name, idx)
+        } else if quoted {
+            // A quoted name is always a header name, never coerced to an index.
+            OneSelector::IndexedName(name, 0)
         } else {
             match FromStr::from_str(&name) {
                 Err(_) => OneSelector::IndexedName(name, 0),
@@ -190,8 +193,9 @@ impl SelectorParser {
                 Some('"') => {
                     self.bump();
                     if self.cur() == Some('"') {
+                        // CSV-style escape: a doubled "" inside a quoted name
+                        // represents a single literal " in the header value.
                         self.bump();
-                        name.push('"');
                         name.push('"');
                         continue;
                     }
@@ -278,15 +282,7 @@ impl Selector {
                 Ok(match i1.cmp(&i2) {
                     Ordering::Equal => vec![i1],
                     Ordering::Less => (i1..=i2).collect(),
-                    Ordering::Greater => {
-                        let mut inds = vec![];
-                        let mut i = i1 + 1;
-                        while i > i2 {
-                            i -= 1;
-                            inds.push(i);
-                        }
-                        inds
-                    },
+                    Ordering::Greater => (i2..=i1).rev().collect(),
                 })
             },
             Selector::Regex(ref re) => {
@@ -311,11 +307,12 @@ impl OneSelector {
     fn index(&self, first_record: &csv::ByteRecord, use_names: bool) -> Result<usize, String> {
         match *self {
             OneSelector::Start => Ok(0),
-            OneSelector::End => Ok(if first_record.is_empty() {
-                0
-            } else {
-                first_record.len() - 1
-            }),
+            OneSelector::End => {
+                if first_record.is_empty() {
+                    return fail!("Input is empty.");
+                }
+                Ok(first_record.len() - 1)
+            },
             OneSelector::Index(i) => {
                 if first_record.is_empty() {
                     return fail!("Input is empty.");

--- a/src/select.rs
+++ b/src/select.rs
@@ -155,17 +155,25 @@ impl SelectorParser {
             (self.parse_name(), false)
         };
         if name.is_empty() {
-            return fail!("Empty selector name.");
+            return if self.cur() == Some('[') {
+                fail!("Index '[...]' must be preceded by a column name.")
+            } else {
+                fail!("Empty selector name.")
+            };
         }
+        // First-occurrence index: matches the unquoted name fallback below,
+        // which also defaults to the first occurrence when the header name
+        // is not numeric (see `IndexedName(name, 0)` in the `Err` arm).
+        const FIRST_OCCURRENCE: usize = 0;
         Ok(if self.cur() == Some('[') {
             let idx = self.parse_index()?;
             OneSelector::IndexedName(name, idx)
         } else if quoted {
             // A quoted name is always a header name, never coerced to an index.
-            OneSelector::IndexedName(name, 0)
+            OneSelector::IndexedName(name, FIRST_OCCURRENCE)
         } else {
             match FromStr::from_str(&name) {
-                Err(_) => OneSelector::IndexedName(name, 0),
+                Err(_) => OneSelector::IndexedName(name, FIRST_OCCURRENCE),
                 Ok(idx) => OneSelector::Index(idx),
             }
         })

--- a/tests/test_select.rs
+++ b/tests/test_select.rs
@@ -203,6 +203,37 @@ select_test_err!(select_err_regex_nomatch, "/nomatch/");
 select_test_err!(select_err_regex_invalid, "/?/");
 select_test_err!(select_err_regex_empty, "//");
 select_test_err!(select_err_regex_triple_slash, "///");
+select_test_err!(select_err_empty_name_bracket, "[5]");
+select_test_err!(select_err_empty_name_leading_comma, ",h1");
+
+#[test]
+fn test_select_quoted_name_with_csv_escape() {
+    // A header value containing a literal `"` is written by the csv crate
+    // as `"foo""bar"` (CSV-style doubled-quote escape). The selector should
+    // accept the same `""` escape and match the un-escaped header value.
+    let wrk = Workdir::new("test_select_quoted_name_with_csv_escape");
+    let data = vec![svec![r#"foo"bar"#, "h2"], svec!["a", "b"]];
+    wrk.create("data.csv", data);
+    let mut cmd = wrk.command("select");
+    cmd.arg("--").arg(r#""foo""bar""#).arg("data.csv");
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec![r#"foo"bar"#], svec!["a"]];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_select_quoted_numeric_is_name_not_index() {
+    // Quoting a numeric selector means "the header literally named 1",
+    // not "column 1". With headers [foo, 1], `"1"` must pick column 2.
+    let wrk = Workdir::new("test_select_quoted_numeric_is_name_not_index");
+    let data = vec![svec!["foo", "1"], svec!["a", "b"]];
+    wrk.create("data.csv", data);
+    let mut cmd = wrk.command("select");
+    cmd.arg("--").arg(r#""1""#).arg("data.csv");
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["1"], svec!["b"]];
+    assert_eq!(got, expected);
+}
 
 fn unsorted_data(headers: bool) -> Vec<Vec<String>> {
     let mut rows = vec![

--- a/tests/test_select.rs
+++ b/tests/test_select.rs
@@ -203,6 +203,9 @@ select_test_err!(select_err_regex_nomatch, "/nomatch/");
 select_test_err!(select_err_regex_invalid, "/?/");
 select_test_err!(select_err_regex_empty, "//");
 select_test_err!(select_err_regex_triple_slash, "///");
+// Regression: a single `/` previously triggered a slice-OOB panic in the
+// regex-delimiter guard (`chars[1..0]`); now it must be a clean parse error.
+select_test_err!(select_err_regex_single_slash, "/");
 select_test_err!(select_err_empty_name_bracket, "[5]");
 select_test_err!(select_err_empty_name_leading_comma, ",h1");
 

--- a/tests/test_select.rs
+++ b/tests/test_select.rs
@@ -198,14 +198,13 @@ select_test_err!(select_err_idx_not_int_2, "h1[a]");
 select_test_err!(select_err_unclosed_quote, r#""h1"#);
 select_test_err!(select_err_unclosed_bracket, r#""h1"[1"#);
 select_test_err!(select_err_expected_end_of_field, "a-b-");
+// Regression: a single `/` previously triggered a slice-OOB panic in the
+// regex-delimiter guard (`chars[1..0]`); now it must be a clean parse error.
 select_test_err!(select_err_single_slash, "/");
 select_test_err!(select_err_regex_nomatch, "/nomatch/");
 select_test_err!(select_err_regex_invalid, "/?/");
 select_test_err!(select_err_regex_empty, "//");
 select_test_err!(select_err_regex_triple_slash, "///");
-// Regression: a single `/` previously triggered a slice-OOB panic in the
-// regex-delimiter guard (`chars[1..0]`); now it must be a clean parse error.
-select_test_err!(select_err_regex_single_slash, "/");
 select_test_err!(select_err_empty_name_bracket, "[5]");
 select_test_err!(select_err_empty_name_leading_comma, ",h1");
 


### PR DESCRIPTION
## Summary

Review-driven cleanup of `src/select.rs` — the column-selector parser used by 18+ commands (`frequency`, `stats`, `join`, `exclude`, `schema`, `fetch`, `pseudo`, …). Fixes a panic, two silent-mismatch bugs, and an asymmetry in empty-input handling; deletes dead code; simplifies a clever loop.

### Bug fixes

- **Panic on `qsv <cmd> --select /`**: a single `/` satisfies `first == last == '/'` (same element), bypasses the `len() == 2` empty-regex guard, and slices `chars[1..0]` → panic *\"slice index starts at 1 but ends at 0\"*. Guard tightened to `len() < 3`; now returns `Empty regex: /`.
- **Quoted-name CSV-style escape doubled**: `parse_quoted_name` was pushing two `\"` chars for a `\"\"` escape. The csv crate hands us un-escaped header values (`\"foo\"\"bar\"` → `foo\"bar`), so the doubled form never matched. Now collapses to a single `\"` per CSV semantics.
- **Quoted numeric coerced to index**: `\"1\"` was matched against `FromStr<usize>` and became `Index(1)` instead of `IndexedName(\"1\", 0)`. Quoting now always means \"header name,\" never \"column index.\"
- **Empty selector names silently created `IndexedName(\"\", _)`**: inputs like `,foo` or `[5]` would build a selector that could never match. Now raise an explicit `Empty selector name.` parse error.
- **`OneSelector::End` silently returned 0 on empty input** while `OneSelector::Index` errored. Now both error with `Input is empty.`

### Cleanup

- Delete dead `SelectColumns::is_empty()` (`#[allow(dead_code)]`, no callers).
- Replace `while i > i2 { i -= 1; … }` reverse-range loop (with theoretical `i1 + 1` overflow) with `(i2..=i1).rev().collect()`.

### Behavior change to flag

Quoting a numeric selector now means \"the header literally named N,\" not \"column N.\" This was the original parser bug — but it is technically a user-visible change for anyone who happened to wrap a column number in quotes.

## Test plan

- [x] `cargo test --test tests test_select -F all_features` — 70 pass (including 4 new tests + existing `select_err_single_slash` and `select_err_regex_triple_slash` regressions).
- [x] `cargo test --test tests` for `test_join` (135), `test_exclude` (16), `test_frequency` (160), `test_partition` (13), `test_search` (75), `test_pseudo` (6) — all pass on `all_features`.
- [x] `cargo +nightly clippy --bin qsv -F all_features -- -W clippy::perf` clean.
- [x] `cargo +nightly fmt` applied.
- [x] Manual repro: `printf 'a,b\n1,2\n' | qsv select / -` now prints `Empty regex: /` instead of panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)