### PR TITLE
select: fix --sort round-trip bugs (quotes, non-UTF-8, duplicate names)

### DIFF
--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -148,9 +148,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         Selection::from_indices(idxs)
     } else if args.flag_sort {
         let mut idxs: Vec<usize> = rconfig.selection(&headers)?.iter().copied().collect();
-        // Sort by the raw header bytes — preserves non-UTF-8 bytes, embedded
-        // quotes, and duplicate names that a string round-trip would mangle.
-        idxs.sort_unstable_by(|&a, &b| headers[a].cmp(&headers[b]));
+        // Sort by the raw header bytes — preserves non-UTF-8 bytes and embedded
+        // quotes. Use the original column index as a deterministic tiebreaker
+        // so duplicate header names retain their left-to-right order.
+        idxs.sort_unstable_by(|&a, &b| headers[a].cmp(&headers[b]).then_with(|| a.cmp(&b)));
         Selection::from_indices(idxs)
     } else {
         rconfig.selection(&headers)?

--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -102,7 +102,7 @@ use serde::Deserialize;
 use crate::{
     CliResult,
     config::{Config, Delimiter},
-    select::SelectColumns,
+    select::{SelectColumns, Selection},
     util,
 };
 
@@ -135,7 +135,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let headers = rdr.byte_headers()?.clone();
     let sel = if args.flag_random {
-        // Use seed if it is provided when initializing the random number generator.
         let mut rng = match args.flag_seed {
             Some(seed) => {
                 // we add the DevSkim ignore comment here because we don't need to worry about
@@ -144,54 +143,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             },
             _ => rand::make_rng::<rand::rngs::StdRng>(),
         };
-
-        let initial_selection = rconfig.selection(&headers)?;
-
-        // make a vector of the column indices (1-indexed).
-        let mut shuffled_selection_vec: Vec<usize> =
-            initial_selection.iter().map(|&i| i + 1).collect();
-
-        shuffled_selection_vec.shuffle(&mut rng);
-
-        // Convert the shuffled indices into a comma-separated string.
-        let shuffled_selection_string = shuffled_selection_vec
-            .into_iter()
-            .map(|i| i.to_string())
-            .collect::<Vec<String>>()
-            .join(",");
-
-        // Parse the shuffled string into a SelectColumns object.
-        let shuffled_selection = SelectColumns::parse(&shuffled_selection_string)?;
-
-        rconfig
-            .clone()
-            .select(shuffled_selection)
-            .selection(&headers)?
+        let mut idxs: Vec<usize> = rconfig.selection(&headers)?.iter().copied().collect();
+        idxs.shuffle(&mut rng);
+        Selection::from_indices(idxs)
     } else if args.flag_sort {
-        // get the headers from the initial selection
-        let initial_selection = rconfig.selection(&headers)?;
-        let mut initial_headers_vec = initial_selection
-            .iter()
-            .map(|&i| &headers[i])
-            .collect::<Vec<&[u8]>>();
-
-        // sort the headers lexicographically
-        initial_headers_vec.sort_unstable();
-
-        // make a comma-separated string of the sorted, quoted headers
-        let sorted_selection_string = initial_headers_vec
-            .iter()
-            .map(|h| format!("\"{}\"", String::from_utf8_lossy(h)))
-            .collect::<Vec<String>>()
-            .join(",");
-
-        // Parse the sorted selection string into a SelectColumns object.
-        let sorted_selection = SelectColumns::parse(&sorted_selection_string)?;
-
-        rconfig
-            .clone()
-            .select(sorted_selection)
-            .selection(&headers)?
+        let mut idxs: Vec<usize> = rconfig.selection(&headers)?.iter().copied().collect();
+        // Sort by the raw header bytes — preserves non-UTF-8 bytes, embedded
+        // quotes, and duplicate names that a string round-trip would mangle.
+        idxs.sort_unstable_by(|&a, &b| headers[a].cmp(&headers[b]));
+        Selection::from_indices(idxs)
     } else {
         rconfig.selection(&headers)?
     };

--- a/tests/test_select.rs
+++ b/tests/test_select.rs
@@ -305,6 +305,75 @@ fn test_select_sort_subset() {
 }
 
 #[test]
+fn test_select_sort_embedded_quote_in_header() {
+    // Headers contain an embedded `"`; the prior implementation built a quoted
+    // selector string without escaping, which mangled the round-trip.
+    let wrk = Workdir::new("test_select_sort_embedded_quote_in_header");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec![r#"Say "hi""#, "Alpha", r#"Quote " in middle"#],
+            svec!["v1", "v2", "v3"],
+        ],
+    );
+    let mut cmd = wrk.command("select");
+    cmd.arg("1-").arg("--sort").arg("data.csv");
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    let expected = vec![
+        svec!["Alpha", r#"Quote " in middle"#, r#"Say "hi""#],
+        svec!["v2", "v3", "v1"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_select_sort_duplicate_header_names() {
+    // With duplicates, the prior round-trip resolved every quoted name to the
+    // first occurrence, silently dropping the second column. Sorting by index
+    // preserves both.
+    let wrk = Workdir::new("test_select_sort_duplicate_header_names");
+    wrk.create(
+        "data.csv",
+        vec![svec!["b", "a", "a", "b"], svec!["1", "2", "3", "4"]],
+    );
+    let mut cmd = wrk.command("select");
+    cmd.arg("1-").arg("--sort").arg("data.csv");
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    let expected = vec![svec!["a", "a", "b", "b"], svec!["2", "3", "1", "4"]];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_select_sort_non_utf8_headers() {
+    // Headers contain bytes that are not valid UTF-8 (Latin-1 encoded names).
+    // The prior implementation went through `String::from_utf8_lossy`, replacing
+    // those bytes with U+FFFD; the resolved selector then could not match the
+    // original header.
+    let wrk = Workdir::new("test_select_sort_non_utf8_headers");
+    let path = wrk.path("data.csv");
+    // Header row: "café" with é as Latin-1 (0xE9), then "apple", then 0xFF byte.
+    // CSV body: a,b,c
+    let bytes: Vec<u8> = b"caf\xE9,apple,\xFFbad\n1,2,3\n".to_vec();
+    std::fs::write(&path, &bytes).unwrap();
+
+    let mut cmd = wrk.command("select");
+    cmd.arg("1-").arg("--sort").arg("data.csv");
+    let out = wrk.output(&mut cmd);
+    assert!(
+        out.status.success(),
+        "select --sort failed on non-UTF-8 headers: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Lexicographic byte order: "apple" (0x61) < "café" (0x63) < "\xFFbad" (0xFF).
+    // Body columns are reordered accordingly: apple,café,\xFFbad → 2,1,3.
+    let expected: Vec<u8> = b"apple,caf\xE9,\xFFbad\n2,1,3\n".to_vec();
+    assert_eq!(out.stdout, expected);
+}
+
+#[test]
 fn test_select_random_seeded() {
     let wrk = Workdir::new("test_select_random_seeded");
     wrk.create("data.csv", unsorted_data(true));


### PR DESCRIPTION
## Summary
- Replace string round-trip in `--random` and `--sort` with direct `Selection::from_indices` construction
- Fix three latent `--sort` bugs caused by the string round-trip:
  - embedded `"` in header names was not CSV-escaped on the producer side (parser was hardened in #3772 but this caller never matched)
  - non-UTF-8 header bytes were corrupted by `String::from_utf8_lossy`, breaking the subsequent name lookup
  - duplicate header names silently resolved to the first occurrence, dropping later columns
- Add three regression tests for the cases above

## Test plan
- [x] `cargo test -F all_features` (2696 passed)
- [x] `cargo +nightly clippy -F all_features -- -W clippy::perf` (clean)
- [x] New tests fail on master and pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)