### PR TITLE
search/searchset: parallel memory streaming, --quick fixes, USAGE alignment

### DIFF
--- a/docs/help/search.md
+++ b/docs/help/search.md
@@ -19,8 +19,9 @@ then the row is written to the output, and the number of matches to stderr.
 The columns to search can be limited with the '--select' flag (but the full row
 is still written to the output if there is a match).
 
-Returns exitcode 0 when matches are found, returning number of matches to stderr.
+Returns exitcode 0 when matches are found.
 Returns exitcode 1 when no match is found, unless the '--not-one' flag is used.
+Use --count to also write the number of matches to stderr (suppressed by --quiet and --json).
 
 When --quick is enabled, no output is produced and exitcode 0 is returned on
 the first match.
@@ -113,13 +114,13 @@ qsv search --help
 | &nbsp;`‑s,`<br>`‑‑select`&nbsp; | string | Select the columns to search. See 'qsv select -h' for the full syntax. |  |
 | &nbsp;`‑v,`<br>`‑‑invert‑match`&nbsp; | flag | Select only rows that did not match |  |
 | &nbsp;`‑u,`<br>`‑‑unicode`&nbsp; | flag | Enable unicode support. When enabled, character classes will match all unicode word characters instead of only ASCII word characters. Decreases performance. |  |
-| &nbsp;`‑f,`<br>`‑‑flag`&nbsp; | string | If given, the command will not filter rows but will instead flag the found rows in a new column named <column>, with the row numbers of the matched rows and 0 for the non-matched rows. If column is named M, only the M column will be written to the output, and only matched rows are returned. |  |
+| &nbsp;`‑f,`<br>`‑‑flag`&nbsp; | string | If given, the command will not filter rows but will instead flag every row in a new column named <column>, set to the row number for matched rows and "0" for non-matched rows. SPECIAL: if <column> is exactly "M", only matched rows are returned AND only the M column is written (all other columns are dropped). To use a literal column name "M" without this behavior, rename it afterward (e.g., with `qsv rename`). |  |
 | &nbsp;`‑Q,`<br>`‑‑quick`&nbsp; | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. |  |
-| &nbsp;`‑‑preview‑match`&nbsp; | string | Preview the first N matches or all the matches found in N milliseconds, whichever occurs first. Returns the preview to stderr. Output is still written to stdout or --output as usual. Only applicable when CSV is NOT indexed, as it's read sequentially. Forces a sequential search, even if the CSV is indexed. |  |
-| &nbsp;`‑c,`<br>`‑‑count`&nbsp; | flag | Return number of matches to stderr. |  |
+| &nbsp;`‑‑preview‑match`&nbsp; | string | Preview the first N matches OR all matches found within N milliseconds, whichever occurs first. NOTE: the same numeric value is used for BOTH the match count AND the millisecond timeout - choose a value where one bound effectively dominates (e.g., a small count for "first N" preview, or a large count for "all within N ms"). Returns the preview to stderr; output is still written to stdout or --output as usual. Forces a sequential search, even if the CSV is indexed. |  |
+| &nbsp;`‑c,`<br>`‑‑count`&nbsp; | flag | Write the number of matches to stderr. Suppressed by --quiet and --json. |  |
 | &nbsp;`‑‑size‑limit`&nbsp; | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
 | &nbsp;`‑‑dfa‑size‑limit`&nbsp; | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
-| &nbsp;`‑‑json`&nbsp; | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). Automatically sets --quiet. |  |
+| &nbsp;`‑‑json`&nbsp; | flag | Output the result as JSON. Fields are written as key-value pairs. The key is the column name. The value is the field value. The output is a JSON array. If --no-headers is set, then the keys are the column indices (zero-based). Automatically sets --quiet (also suppresses --count). |  |
 | &nbsp;`‑‑not‑one`&nbsp; | flag | Use exit code 0 instead of 1 for no match found. |  |
 | &nbsp;`‑j,`<br>`‑‑jobs`&nbsp; | string | The number of jobs to run in parallel when the given CSV data has an index. Note that a file handle is opened for each job. When not set, defaults to the number of CPUs detected. |  |
 
@@ -133,8 +134,8 @@ qsv search --help
 | &nbsp;`‑o,`<br>`‑‑output`&nbsp; | string | Write output to <file> instead of stdout. |  |
 | &nbsp;`‑n,`<br>`‑‑no‑headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
 | &nbsp;`‑d,`<br>`‑‑delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
-| &nbsp;`‑p,`<br>`‑‑progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. Only applicable when CSV is NOT indexed. |  |
-| &nbsp;`‑q,`<br>`‑‑quiet`&nbsp; | flag | Do not return number of matches to stderr. |  |
+| &nbsp;`‑p,`<br>`‑‑progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. Disabled when running parallel search (i.e., when the CSV is indexed and --jobs > 1). Sequential search on an indexed CSV (--jobs 1) still shows the progress bar. |  |
+| &nbsp;`‑q,`<br>`‑‑quiet`&nbsp; | flag | Do not write the match count (--count) or the first match row number reported by --quick to stderr. |  |
 
 ---
 **Source:** [`src/cmd/search.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/search.rs)

--- a/docs/help/searchset.md
+++ b/docs/help/searchset.md
@@ -28,8 +28,10 @@ then the row is written to the output, and the number of matches to stderr.
 The columns to search can be limited with the '--select' flag (but the full row
 is still written to the output if there is a match).
 
-Returns exitcode 0 when matches are found, returning number of matches to stderr.
+Returns exitcode 0 when matches are found.
 Returns exitcode 1 when no match is found, unless the '--not-one' flag is used.
+Use --count to also write the number of matches to stderr (suppressed by --quiet).
+With --json, a JSON summary is always written to stderr instead.
 
 When --quick is enabled, no output is produced and exitcode 0 is returned on
 the first match.
@@ -73,7 +75,7 @@ qsv searchset --help
 | &nbsp;`‑‑flag‑matches‑only`&nbsp; | flag | When --flag is enabled, only rows that match are sent to output. Rows that do not match are filtered. |  |
 | &nbsp;`‑‑unmatched‑output`&nbsp; | string | When --flag-matches-only is enabled, output the rows that did not match to <file>. |  |
 | &nbsp;`‑Q,`<br>`‑‑quick`&nbsp; | flag | Return on first match with an exitcode of 0, returning the row number of the first match to stderr. Return exit code 1 if no match is found. No output is produced. Ignored if --json is enabled. |  |
-| &nbsp;`‑c,`<br>`‑‑count`&nbsp; | flag | Return number of matches to stderr. Ignored if --json is enabled. |  |
+| &nbsp;`‑c,`<br>`‑‑count`&nbsp; | flag | Write the number of matches to stderr. Suppressed by --quiet. Ignored if --json is enabled. |  |
 | &nbsp;`‑j,`<br>`‑‑json`&nbsp; | flag | Return number of matches, number of rows with matches, and number of rows to stderr in JSON format. |  |
 | &nbsp;`‑‑size‑limit`&nbsp; | string | Set the approximate size limit (MB) of the compiled regular expression. If the compiled expression exceeds this number, then a compilation error is returned. Modify this only if you're getting regular expression compilation errors. | `50` |
 | &nbsp;`‑‑dfa‑size‑limit`&nbsp; | string | Set the approximate size of the cache (MB) used by the regular expression engine's Discrete Finite Automata. Modify this only if you're getting regular expression compilation errors. | `10` |
@@ -91,7 +93,7 @@ qsv searchset --help
 | &nbsp;`‑n,`<br>`‑‑no‑headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. (i.e., They are not searched, analyzed, sliced, etc.) |  |
 | &nbsp;`‑d,`<br>`‑‑delimiter`&nbsp; | string | The field delimiter for reading CSV data. Must be a single character. (default: ,) |  |
 | &nbsp;`‑p,`<br>`‑‑progressbar`&nbsp; | flag | Show progress bars. Not valid for stdin. |  |
-| &nbsp;`‑q,`<br>`‑‑quiet`&nbsp; | flag | Do not return number of matches to stderr. |  |
+| &nbsp;`‑q,`<br>`‑‑quiet`&nbsp; | flag | Do not write the match count (--count) or the first match row number reported by --quick to stderr. Does not suppress the --json summary. |  |
 
 ---
 **Source:** [`src/cmd/searchset.rs`](https://github.com/dathere/qsv/blob/master/src/cmd/searchset.rs)

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -7,8 +7,9 @@ then the row is written to the output, and the number of matches to stderr.
 The columns to search can be limited with the '--select' flag (but the full row
 is still written to the output if there is a match).
 
-Returns exitcode 0 when matches are found, returning number of matches to stderr.
+Returns exitcode 0 when matches are found.
 Returns exitcode 1 when no match is found, unless the '--not-one' flag is used.
+Use --count to also write the number of matches to stderr (suppressed by --quiet and --json).
 
 When --quick is enabled, no output is produced and exitcode 0 is returned on 
 the first match.
@@ -68,21 +69,30 @@ search options:
                            will match all unicode word characters instead of only
                            ASCII word characters. Decreases performance.
     -f, --flag <column>    If given, the command will not filter rows
-                           but will instead flag the found rows in a new
-                           column named <column>, with the row numbers
-                           of the matched rows and 0 for the non-matched rows.
-                           If column is named M, only the M column will be written
-                           to the output, and only matched rows are returned.
+                           but will instead flag every row in a new column
+                           named <column>, set to the row number for matched
+                           rows and "0" for non-matched rows.
+                           SPECIAL: if <column> is exactly "M", only matched
+                           rows are returned AND only the M column is written
+                           (all other columns are dropped). To use a literal
+                           column name "M" without this behavior, rename it
+                           afterward (e.g., with `qsv rename`).
     -Q, --quick            Return on first match with an exitcode of 0, returning
                            the row number of the first match to stderr.
                            Return exit code 1 if no match is found.
                            No output is produced.
-    --preview-match <arg>  Preview the first N matches or all the matches found in
-                           N milliseconds, whichever occurs first. Returns the preview to
-                           stderr. Output is still written to stdout or --output as usual.
-                           Only applicable when CSV is NOT indexed, as it's read sequentially.
+    --preview-match <arg>  Preview the first N matches OR all matches found
+                           within N milliseconds, whichever occurs first.
+                           NOTE: the same numeric value is used for BOTH the
+                           match count AND the millisecond timeout - choose a
+                           value where one bound effectively dominates (e.g.,
+                           a small count for "first N" preview, or a large
+                           count for "all within N ms").
+                           Returns the preview to stderr; output is still
+                           written to stdout or --output as usual.
                            Forces a sequential search, even if the CSV is indexed.
-    -c, --count            Return number of matches to stderr.
+    -c, --count            Write the number of matches to stderr.
+                           Suppressed by --quiet and --json.
     --size-limit <mb>      Set the approximate size limit (MB) of the compiled
                            regular expression. If the compiled expression exceeds this 
                            number, then a compilation error is returned.
@@ -97,7 +107,7 @@ search options:
                            The value is the field value. The output is a
                            JSON array. If --no-headers is set, then
                            the keys are the column indices (zero-based).
-                           Automatically sets --quiet.
+                           Automatically sets --quiet (also suppresses --count).
     --not-one              Use exit code 0 instead of 1 for no match found.
     -j, --jobs <arg>       The number of jobs to run in parallel when the given CSV data has
                            an index. Note that a file handle is opened for each job.
@@ -112,8 +122,12 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
-                           Only applicable when CSV is NOT indexed.
-    -q, --quiet            Do not return number of matches to stderr.
+                           Disabled when running parallel search (i.e., when
+                           the CSV is indexed and --jobs > 1). Sequential
+                           search on an indexed CSV (--jobs 1) still shows
+                           the progress bar.
+    -q, --quiet            Do not write the match count (--count) or the
+                           first match row number reported by --quick to stderr.
 "#;
 
 use std::{
@@ -228,17 +242,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
 }
 
-/// Check if preview collection should continue
-/// Returns true if still within both N matches and N milliseconds
+/// Check if preview collection should continue.
+/// Returns true if still within both N matches and N milliseconds.
+/// Caller is responsible for gating on `preview_limit > 0`.
 #[inline]
 fn should_collect_preview(
     preview_count: usize,
     start_time: std::time::Instant,
     preview_limit: usize,
 ) -> bool {
-    if preview_limit == 0 {
-        return false;
-    }
     preview_count < preview_limit && start_time.elapsed().as_millis() < preview_limit as u128
 }
 
@@ -604,11 +616,15 @@ impl Args {
         let pool = ThreadPool::new(njobs);
         let (send, recv) = crossbeam_channel::bounded::<CliResult<ChunkOutput>>(nchunks);
 
+        // Share Args across workers via Arc to avoid a per-worker clone
+        // of SelectColumns and other inner allocations.
+        let args = Arc::new(self.clone());
+
         // Spawn search jobs
         for chunk_index in 0..nchunks {
             let (send, args, sel, pattern, match_found_flag) = (
                 send.clone(),
-                self.clone(),
+                Arc::clone(&args),
                 sel.clone(),
                 Arc::clone(&pattern),
                 Arc::clone(&match_found),

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -562,9 +562,10 @@ impl Args {
             self.write_preview(&preview_records, &headers, row_ctr, elapsed_ms)?;
         }
 
-        // Handle quick mode separately
+        // Handle quick mode separately. --json implies --quiet per USAGE,
+        // so the row-number print is also suppressed when --json is set.
         if self.flag_quick {
-            if !self.flag_quiet {
+            if !(self.flag_quiet || self.flag_json) {
                 eprintln!("{row_ctr}");
             }
             info!("quick search first match at {row_ctr}");
@@ -741,7 +742,9 @@ impl Args {
                 }
             }
             if let Some((_, row)) = earliest {
-                if !self.flag_quiet {
+                // --json implies --quiet per USAGE, so suppress the row print
+                // when --json is set.
+                if !(self.flag_quiet || self.flag_json) {
                     eprintln!("{row}");
                 }
                 info!("quick search first match at {row}");

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -117,6 +117,7 @@ Common options:
 "#;
 
 use std::{
+    collections::BTreeMap,
     fs,
     sync::{
         Arc,
@@ -167,11 +168,24 @@ struct Args {
     flag_jobs:           Option<usize>,
 }
 
-// SearchResult holds information about a search result for parallel processing
+// SearchResult holds a record that needs to be written to output.
+// In filter mode (no --flag), only matched records are produced.
+// In flag mode (--flag), every record is produced so the flag column can be set.
 struct SearchResult {
     row_number: u64,
     record:     csv::ByteRecord,
     matched:    bool,
+}
+
+// ChunkOutput is what each parallel worker sends back over the channel.
+// In --quick mode, `records` is empty and only `first_match_row` is populated.
+// In normal mode, `first_match_row` is None; `records` holds the rows the worker
+// has decided need to be written, and `match_count` is the worker's tally.
+struct ChunkOutput {
+    chunk_index:     usize,
+    records:         Vec<SearchResult>,
+    match_count:     u64,
+    first_match_row: Option<u64>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -471,7 +485,9 @@ impl Args {
         let preview_start = std::time::Instant::now();
         let mut collecting_preview = preview_limit > 0;
 
-        if flag_json {
+        // skip the opening '[' in quick mode since we return early
+        // without writing any records and would never write the closing ']'
+        if flag_json && !flag_quick {
             json_wtr.write_all(b"[")?;
         }
 
@@ -578,15 +594,18 @@ impl Args {
         let flag_quick = self.flag_quick;
         let flag_no_headers = self.flag_no_headers;
 
-        // Atomic flag for early termination in quick mode
+        // Best-effort flag for early termination in --quick mode.
+        // Workers check this between records to stop processing once any thread
+        // has reported a match. The receiver still waits for all chunks to
+        // determine the earliest matching row.
         let match_found = Arc::new(AtomicBool::new(false));
 
         // Create thread pool and channel
         let pool = ThreadPool::new(njobs);
-        let (send, recv) = crossbeam_channel::bounded(nchunks);
+        let (send, recv) = crossbeam_channel::bounded::<CliResult<ChunkOutput>>(nchunks);
 
         // Spawn search jobs
-        for i in 0..nchunks {
+        for chunk_index in 0..nchunks {
             let (send, args, sel, pattern, match_found_flag) = (
                 send.clone(),
                 self.clone(),
@@ -595,58 +614,104 @@ impl Args {
                 Arc::clone(&match_found),
             );
             pool.execute(move || {
-                // safety: we know the file is indexed and seekable
-                let mut idx = args.rconfig().indexed().unwrap().unwrap();
-                idx.seek((i * chunk_size) as u64).unwrap();
-                let it = idx.byte_records().take(chunk_size);
+                let result: CliResult<ChunkOutput> = (|| {
+                    let mut idx = args
+                        .rconfig()
+                        .indexed()?
+                        .ok_or_else(|| CliError::Other("CSV index unavailable".to_string()))?;
+                    idx.seek((chunk_index * chunk_size) as u64)?;
+                    let it = idx.byte_records().take(chunk_size);
+                    let start_row = (chunk_index * chunk_size) as u64 + 1;
 
-                let mut results = Vec::with_capacity(chunk_size);
-
-                // 1-based row numbering
-                for (row_number, record) in ((i * chunk_size) as u64 + 1..).zip(it.flatten()) {
-                    // Early exit for quick mode if match already found by another thread
-                    if flag_quick && match_found_flag.load(Ordering::Relaxed) {
-                        break;
+                    if flag_quick {
+                        // --quick: only track the earliest match in this chunk.
+                        // No record allocation; stop as soon as we find one.
+                        for (row_number, record_result) in (start_row..).zip(it) {
+                            if match_found_flag.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            let record = record_result?;
+                            let matched = if invert_match {
+                                !sel.select(&record).any(|f| pattern.is_match(f))
+                            } else {
+                                sel.select(&record).any(|f| pattern.is_match(f))
+                            };
+                            if matched {
+                                match_found_flag.store(true, Ordering::Relaxed);
+                                return Ok(ChunkOutput {
+                                    chunk_index,
+                                    records: Vec::new(),
+                                    match_count: 1,
+                                    first_match_row: Some(row_number),
+                                });
+                            }
+                        }
+                        return Ok(ChunkOutput {
+                            chunk_index,
+                            records: Vec::new(),
+                            match_count: 0,
+                            first_match_row: None,
+                        });
                     }
 
-                    let matched = if invert_match {
-                        !sel.select(&record).any(|f| pattern.is_match(f))
-                    } else {
-                        sel.select(&record).any(|f| pattern.is_match(f))
-                    };
-
-                    // Set flag if we found a match in quick mode
-                    if flag_quick && matched {
-                        match_found_flag.store(true, Ordering::Relaxed);
+                    // Normal mode: only retain records we actually need to write.
+                    // In flag mode (flag_flag), every row is needed so the flag column
+                    // can be populated. In filter mode, only matched rows are needed.
+                    let mut records: Vec<SearchResult> = Vec::new();
+                    let mut match_count: u64 = 0;
+                    for (row_number, record_result) in (start_row..).zip(it) {
+                        let record = record_result?;
+                        let matched = if invert_match {
+                            !sel.select(&record).any(|f| pattern.is_match(f))
+                        } else {
+                            sel.select(&record).any(|f| pattern.is_match(f))
+                        };
+                        if matched {
+                            match_count += 1;
+                        }
+                        if flag_flag || matched {
+                            records.push(SearchResult {
+                                row_number,
+                                record,
+                                matched,
+                            });
+                        }
                     }
-
-                    results.push(SearchResult {
-                        row_number,
-                        record,
-                        matched,
-                    });
-                }
-                send.send(results).unwrap();
+                    Ok(ChunkOutput {
+                        chunk_index,
+                        records,
+                        match_count,
+                        first_match_row: None,
+                    })
+                })();
+                // If the receiver has already been dropped (e.g., main thread
+                // returned early on another worker's error), discard quietly.
+                let _ = send.send(result);
             });
         }
         drop(send);
 
-        // Collect all results from all chunks
-        let mut all_chunks: Vec<Vec<SearchResult>> = Vec::with_capacity(nchunks);
-        for chunk_results in &recv {
-            all_chunks.push(chunk_results);
-        }
-
-        // Sort chunks by first row_number to maintain original order
-        all_chunks.sort_unstable_by_key(|chunk| chunk.first().map_or(0, |r| r.row_number));
-
-        // Handle --quick mode: find earliest match
+        // --quick mode: collect each worker's earliest-match-in-chunk and
+        // pick the lowest chunk_index that reported Some(row).
         if self.flag_quick {
-            if let Some(first_match) = all_chunks.iter().flatten().find(|r| r.matched) {
-                if !self.flag_quiet {
-                    eprintln!("{}", first_match.row_number);
+            let mut earliest: Option<(usize, u64)> = None;
+            for chunk_msg in &recv {
+                let chunk = chunk_msg?;
+                if let Some(row) = chunk.first_match_row {
+                    match earliest {
+                        None => earliest = Some((chunk.chunk_index, row)),
+                        Some((idx, _)) if chunk.chunk_index < idx => {
+                            earliest = Some((chunk.chunk_index, row));
+                        },
+                        _ => {},
+                    }
                 }
-                info!("quick search first match at {}", first_match.row_number);
+            }
+            if let Some((_, row)) = earliest {
+                if !self.flag_quiet {
+                    eprintln!("{row}");
+                }
+                info!("quick search first match at {row}");
                 return Ok(());
             }
             // No match found
@@ -674,30 +739,37 @@ impl Args {
             json_wtr.write_all(b"[")?;
         }
 
-        for chunk in all_chunks {
-            for result in chunk {
-                let mut record = result.record;
-                let matched = result.matched;
+        // Stream chunks in row order as they arrive. Out-of-order chunks
+        // are buffered in `pending` until their predecessor lands; this caps
+        // memory at roughly the number of in-flight workers worth of rows
+        // rather than the whole file.
+        let mut pending: BTreeMap<usize, ChunkOutput> = BTreeMap::new();
+        let mut next_chunk: usize = 0;
 
-                if matched {
-                    match_ctr += 1;
+        for chunk_msg in &recv {
+            let chunk = chunk_msg?;
+            pending.insert(chunk.chunk_index, chunk);
+
+            while let Some(chunk) = pending.remove(&next_chunk) {
+                match_ctr += chunk.match_count;
+                for result in chunk.records {
+                    let mut record = result.record;
+                    write_result_record(
+                        &mut record,
+                        result.row_number,
+                        result.matched,
+                        flag_flag,
+                        flag_json,
+                        flag_no_headers,
+                        matches_only,
+                        &headers,
+                        &mut wtr,
+                        &mut json_wtr,
+                        &mut is_first,
+                        &mut matched_rows,
+                    )?;
                 }
-
-                // Use helper to write record if needed
-                write_result_record(
-                    &mut record,
-                    result.row_number,
-                    matched,
-                    flag_flag,
-                    flag_json,
-                    flag_no_headers,
-                    matches_only,
-                    &headers,
-                    &mut wtr,
-                    &mut json_wtr,
-                    &mut is_first,
-                    &mut matched_rows,
-                )?;
+                next_chunk += 1;
             }
         }
 

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -135,7 +135,7 @@ use std::{
     fs,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -606,11 +606,13 @@ impl Args {
         let flag_quick = self.flag_quick;
         let flag_no_headers = self.flag_no_headers;
 
-        // Best-effort flag for early termination in --quick mode.
-        // Workers check this between records to stop processing once any thread
-        // has reported a match. The receiver still waits for all chunks to
-        // determine the earliest matching row.
-        let match_found = Arc::new(AtomicBool::new(false));
+        // Lowest chunk_index that has reported a match in --quick mode (or
+        // usize::MAX if none yet). A chunk can stop scanning only when a
+        // STRICTLY LOWER-indexed chunk has matched - if its own or a
+        // higher-indexed chunk has matched, this chunk may still contain an
+        // earlier match in row order and must keep going. This preserves the
+        // sequential "first match in row order" semantic under parallelism.
+        let lowest_match_chunk = Arc::new(AtomicUsize::new(usize::MAX));
 
         // Create thread pool and channel
         let pool = ThreadPool::new(njobs);
@@ -622,12 +624,12 @@ impl Args {
 
         // Spawn search jobs
         for chunk_index in 0..nchunks {
-            let (send, args, sel, pattern, match_found_flag) = (
+            let (send, args, sel, pattern, lowest_match) = (
                 send.clone(),
                 Arc::clone(&args),
                 sel.clone(),
                 Arc::clone(&pattern),
-                Arc::clone(&match_found),
+                Arc::clone(&lowest_match_chunk),
             );
             pool.execute(move || {
                 let result: CliResult<ChunkOutput> = (|| {
@@ -642,8 +644,10 @@ impl Args {
                     if flag_quick {
                         // --quick: only track the earliest match in this chunk.
                         // No record allocation; stop as soon as we find one.
+                        // Skip the rest of the chunk if a strictly lower-indexed
+                        // chunk has already matched (no earlier row possible here).
                         for (row_number, record_result) in (start_row..).zip(it) {
-                            if match_found_flag.load(Ordering::Relaxed) {
+                            if lowest_match.load(Ordering::Relaxed) < chunk_index {
                                 break;
                             }
                             let record = record_result?;
@@ -653,7 +657,20 @@ impl Args {
                                 sel.select(&record).any(|f| pattern.is_match(f))
                             };
                             if matched {
-                                match_found_flag.store(true, Ordering::Relaxed);
+                                // Publish this chunk as the lowest matching chunk
+                                // (only if it's strictly lower than the current value).
+                                let mut current = lowest_match.load(Ordering::Relaxed);
+                                while chunk_index < current {
+                                    match lowest_match.compare_exchange_weak(
+                                        current,
+                                        chunk_index,
+                                        Ordering::Relaxed,
+                                        Ordering::Relaxed,
+                                    ) {
+                                        Ok(_) => break,
+                                        Err(c) => current = c,
+                                    }
+                                }
                                 return Ok(ChunkOutput {
                                     chunk_index,
                                     records: Vec::new(),

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -16,8 +16,10 @@ then the row is written to the output, and the number of matches to stderr.
 The columns to search can be limited with the '--select' flag (but the full row
 is still written to the output if there is a match).
 
-Returns exitcode 0 when matches are found, returning number of matches to stderr.
+Returns exitcode 0 when matches are found.
 Returns exitcode 1 when no match is found, unless the '--not-one' flag is used.
+Use --count to also write the number of matches to stderr (suppressed by --quiet).
+With --json, a JSON summary is always written to stderr instead.
 
 When --quick is enabled, no output is produced and exitcode 0 is returned on 
 the first match.
@@ -66,8 +68,8 @@ searchset options:
                                the row number of the first match to stderr.
                                Return exit code 1 if no match is found.
                                No output is produced. Ignored if --json is enabled.
-    -c, --count                Return number of matches to stderr.
-                               Ignored if --json is enabled.
+    -c, --count                Write the number of matches to stderr.
+                               Suppressed by --quiet. Ignored if --json is enabled.
     -j, --json                 Return number of matches, number of rows with matches,
                                and number of rows to stderr in JSON format.
     --size-limit <mb>          Set the approximate size limit (MB) of the compiled
@@ -93,15 +95,18 @@ Common options:
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character. (default: ,)
     -p, --progressbar          Show progress bars. Not valid for stdin.
-    -q, --quiet                Do not return number of matches to stderr.
+    -q, --quiet                Do not write the match count (--count) or the
+                               first match row number reported by --quick to stderr.
+                               Does not suppress the --json summary.
 "#;
 
 use std::{
+    collections::BTreeMap,
     fs::{self, File},
     io::{self, BufRead, BufReader},
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -150,12 +155,26 @@ struct Args {
     flag_jobs:              Option<usize>,
 }
 
-// SearchSetResult holds information about a search result for parallel processing
+// SearchSetResult holds a record that needs to be written by the main thread.
+// In filter mode, only matched rows are produced. In flag mode, every row is
+// produced (for the flag column). When --flag-matches-only is set without
+// --unmatched-output, non-matched rows are dropped in the worker.
 struct SearchSetResult {
     row_number: u64,
     record:     csv::ByteRecord,
     matched:    bool,
     match_list: Vec<usize>, // indices of matched regexes (1-based)
+}
+
+// ChunkOutput is what each parallel worker sends back over the channel.
+// In --quick mode, `results` is empty and only `first_match_row` is populated.
+// In normal mode, `first_match_row` is None; `results` holds the rows the worker
+// retained for writing, and `match_row_count` is the worker's tally of matched rows.
+struct ChunkOutput {
+    chunk_index:     usize,
+    results:         Vec<SearchSetResult>,
+    match_row_count: u64,
+    first_match_row: Option<u64>,
 }
 
 fn read_regexset(filename: &str, literal: bool, exact: bool) -> io::Result<Vec<String>> {
@@ -435,95 +454,170 @@ impl Args {
             true
         });
 
-        // Wrap pattern and regex_labels in Arc for sharing across threads
+        // Decide whether non-matched rows must be retained by workers:
+        //   - flag mode without --flag-matches-only: every row is written to the main output (with
+        //     the flag column), so non-matched are needed.
+        //   - flag mode with --flag-matches-only AND --unmatched-output: non-matched rows are
+        //     routed to the unmatched writer.
+        //   - all other cases (filter mode, or matches-only without unmatched-output): non-matched
+        //     rows are discarded — drop them in the worker.
+        let has_unmatched_output = self.flag_unmatched_output.is_some();
+        let needs_unmatched =
+            do_match_list && (!self.flag_flag_matches_only || has_unmatched_output);
+
         let pattern = Arc::new(pattern);
-        let regex_labels = Arc::new(regex_labels.to_vec());
         let invert_match = self.flag_invert_match;
         let flag_quick = self.flag_quick;
 
-        // Atomic flag for early termination in quick mode
-        let match_found = Arc::new(AtomicBool::new(false));
+        // Lowest chunk_index that has reported a match in --quick mode (or
+        // usize::MAX if none yet). A chunk can stop scanning only when a
+        // STRICTLY LOWER-indexed chunk has matched - if its own or a
+        // higher-indexed chunk has matched, this chunk may still contain an
+        // earlier match in row order and must keep going. This preserves the
+        // sequential "first match in row order" semantic under parallelism.
+        let lowest_match_chunk = Arc::new(AtomicUsize::new(usize::MAX));
 
         // Create thread pool and channel
         let pool = ThreadPool::new(njobs);
-        let (send, recv) = crossbeam_channel::bounded(nchunks);
+        let (send, recv) = crossbeam_channel::bounded::<CliResult<ChunkOutput>>(nchunks);
+
+        // Share Args across workers via Arc to avoid a per-worker clone
+        // of SelectColumns and other inner allocations.
+        let args = Arc::new(self.clone());
 
         // Spawn search jobs
-        for i in 0..nchunks {
-            let (send, args, sel, pattern, match_found_flag) = (
+        for chunk_index in 0..nchunks {
+            let (send, args, sel, pattern, lowest_match) = (
                 send.clone(),
-                self.clone(),
+                Arc::clone(&args),
                 sel.clone(),
                 Arc::clone(&pattern),
-                Arc::clone(&match_found),
+                Arc::clone(&lowest_match_chunk),
             );
             pool.execute(move || {
-                // safety: we know the file is indexed and seekable
-                let mut idx = args.rconfig().indexed().unwrap().unwrap();
-                idx.seek((i * chunk_size) as u64).unwrap();
-                let it = idx.byte_records().take(chunk_size);
+                let result: CliResult<ChunkOutput> = (|| {
+                    let mut idx = args
+                        .rconfig()
+                        .indexed()?
+                        .ok_or_else(|| CliError::Other("CSV index unavailable".to_string()))?;
+                    idx.seek((chunk_index * chunk_size) as u64)?;
+                    let it = idx.byte_records().take(chunk_size);
+                    let start_row = (chunk_index * chunk_size) as u64 + 1;
 
-                let mut results = Vec::with_capacity(chunk_size);
-
-                // 1-based row numbering
-                for (row_number, record) in ((i * chunk_size) as u64 + 1..).zip(it.flatten()) {
-                    // Early exit for quick mode if match already found by another thread
-                    if flag_quick && match_found_flag.load(Ordering::Relaxed) {
-                        break;
-                    }
-
-                    let mut match_list = Vec::with_capacity(pattern.len());
-
-                    // Check if any field matches
-                    let row_matched = sel.select(&record).any(|f| {
-                        let is_match = pattern.is_match(f);
-                        if is_match && do_match_list {
-                            for m in pattern.matches(f) {
-                                match_list.push(m + 1); // 1-based for human readability
+                    if flag_quick {
+                        // --quick: only track the earliest match in this chunk.
+                        // No record allocation; stop as soon as we find one.
+                        // Skip the rest of the chunk if a strictly lower-indexed
+                        // chunk has already matched (no earlier row possible here).
+                        for (row_number, record_result) in (start_row..).zip(it) {
+                            if lowest_match.load(Ordering::Relaxed) < chunk_index {
+                                break;
+                            }
+                            let record = record_result?;
+                            let row_matched = sel.select(&record).any(|f| pattern.is_match(f));
+                            let final_matched = if invert_match {
+                                !row_matched
+                            } else {
+                                row_matched
+                            };
+                            if final_matched {
+                                // Publish this chunk as the lowest matching chunk
+                                // (only if it's strictly lower than the current value).
+                                let mut current = lowest_match.load(Ordering::Relaxed);
+                                while chunk_index < current {
+                                    match lowest_match.compare_exchange_weak(
+                                        current,
+                                        chunk_index,
+                                        Ordering::Relaxed,
+                                        Ordering::Relaxed,
+                                    ) {
+                                        Ok(_) => break,
+                                        Err(c) => current = c,
+                                    }
+                                }
+                                return Ok(ChunkOutput {
+                                    chunk_index,
+                                    results: Vec::new(),
+                                    match_row_count: 1,
+                                    first_match_row: Some(row_number),
+                                });
                             }
                         }
-                        is_match
-                    });
-
-                    let final_matched = if invert_match {
-                        !row_matched
-                    } else {
-                        row_matched
-                    };
-
-                    // Set flag if we found a match in quick mode
-                    if flag_quick && final_matched {
-                        match_found_flag.store(true, Ordering::Relaxed);
+                        return Ok(ChunkOutput {
+                            chunk_index,
+                            results: Vec::new(),
+                            match_row_count: 0,
+                            first_match_row: None,
+                        });
                     }
 
-                    results.push(SearchSetResult {
-                        row_number,
-                        record,
-                        matched: final_matched,
-                        match_list,
-                    });
-                }
-                send.send(results).unwrap();
+                    // Normal mode: only retain records that need to be written.
+                    let mut results: Vec<SearchSetResult> = Vec::new();
+                    let mut match_row_count: u64 = 0;
+                    for (row_number, record_result) in (start_row..).zip(it) {
+                        let record = record_result?;
+                        let mut match_list = Vec::with_capacity(pattern.len());
+                        let row_matched = sel.select(&record).any(|f| {
+                            let is_match = pattern.is_match(f);
+                            if is_match && do_match_list {
+                                for m in pattern.matches(f) {
+                                    match_list.push(m + 1); // 1-based for human readability
+                                }
+                            }
+                            is_match
+                        });
+                        let final_matched = if invert_match {
+                            !row_matched
+                        } else {
+                            row_matched
+                        };
+                        if final_matched {
+                            match_row_count += 1;
+                        }
+                        if final_matched || needs_unmatched {
+                            results.push(SearchSetResult {
+                                row_number,
+                                record,
+                                matched: final_matched,
+                                match_list,
+                            });
+                        }
+                    }
+                    Ok(ChunkOutput {
+                        chunk_index,
+                        results,
+                        match_row_count,
+                        first_match_row: None,
+                    })
+                })();
+                // If the receiver has already been dropped (e.g., main thread
+                // returned early on another worker's error), discard quietly.
+                let _ = send.send(result);
             });
         }
         drop(send);
 
-        // Collect all results from all chunks
-        let mut all_chunks: Vec<Vec<SearchSetResult>> = Vec::with_capacity(nchunks);
-        for chunk_results in &recv {
-            all_chunks.push(chunk_results);
-        }
-
-        // Sort chunks by first row_number to maintain original order
-        all_chunks.sort_unstable_by_key(|chunk| chunk.first().map_or(0, |r| r.row_number));
-
-        // Handle --quick mode: find earliest match
+        // --quick mode: collect each worker's earliest-match-in-chunk and
+        // pick the lowest chunk_index that reported Some(row).
         if self.flag_quick {
-            if let Some(first_match) = all_chunks.iter().flatten().find(|r| r.matched) {
-                if !self.flag_quiet {
-                    eprintln!("{}", first_match.row_number);
+            let mut earliest: Option<(usize, u64)> = None;
+            for chunk_msg in &recv {
+                let chunk = chunk_msg?;
+                if let Some(row) = chunk.first_match_row {
+                    match earliest {
+                        None => earliest = Some((chunk.chunk_index, row)),
+                        Some((idx, _)) if chunk.chunk_index < idx => {
+                            earliest = Some((chunk.chunk_index, row));
+                        },
+                        _ => {},
+                    }
                 }
-                info!("quick searchset first match at {}", first_match.row_number);
+            }
+            if let Some((_, row)) = earliest {
+                if !self.flag_quiet {
+                    eprintln!("{row}");
+                }
+                info!("quick searchset first match at {row}");
                 return Ok(());
             }
             // No match found
@@ -549,53 +643,63 @@ impl Args {
         #[allow(unused_assignments)]
         let mut match_list_with_row = String::with_capacity(20);
 
-        for chunk in all_chunks {
-            for result in chunk {
-                let mut record = result.record;
-                let matched = result.matched;
-                let match_list = result.match_list;
+        // Stream chunks in row order as they arrive. Out-of-order chunks
+        // are buffered in `pending` until their predecessor lands; this caps
+        // memory at roughly the number of in-flight workers worth of rows
+        // rather than the whole file.
+        let mut pending: BTreeMap<usize, ChunkOutput> = BTreeMap::new();
+        let mut next_chunk: usize = 0;
 
-                if matched {
-                    match_row_ctr += 1;
-                }
+        for chunk_msg in &recv {
+            let chunk = chunk_msg?;
+            pending.insert(chunk.chunk_index, chunk);
 
-                if do_match_list {
-                    let flag_column = if matched {
-                        itoa::Buffer::new()
-                            .format(result.row_number)
-                            .clone_into(&mut matched_rows);
-                        if self.flag_invert_match {
-                            matched_rows.as_bytes().to_vec()
-                        } else {
-                            total_matches += match_list.len() as u64;
-                            // builds format!("{matched_rows};{match_list}")
-                            // without intermediate Vec allocation
-                            match_list_with_row.clear();
-                            match_list_with_row.push_str(&matched_rows);
-                            match_list_with_row.push(';');
-                            for (idx, i) in match_list.iter().enumerate() {
-                                if idx > 0 {
-                                    match_list_with_row.push(',');
+            while let Some(chunk) = pending.remove(&next_chunk) {
+                match_row_ctr += chunk.match_row_count;
+                for result in chunk.results {
+                    let mut record = result.record;
+                    let matched = result.matched;
+                    let match_list = result.match_list;
+
+                    if do_match_list {
+                        let flag_column = if matched {
+                            itoa::Buffer::new()
+                                .format(result.row_number)
+                                .clone_into(&mut matched_rows);
+                            if self.flag_invert_match {
+                                matched_rows.as_bytes().to_vec()
+                            } else {
+                                total_matches += match_list.len() as u64;
+                                // builds format!("{matched_rows};{match_list}")
+                                // without intermediate Vec allocation
+                                match_list_with_row.clear();
+                                match_list_with_row.push_str(&matched_rows);
+                                match_list_with_row.push(';');
+                                for (idx, i) in match_list.iter().enumerate() {
+                                    if idx > 0 {
+                                        match_list_with_row.push(',');
+                                    }
+                                    match_list_with_row.push_str(&regex_labels[*i - 1]);
                                 }
-                                match_list_with_row.push_str(&regex_labels[*i - 1]);
+                                match_list_with_row.as_bytes().to_vec()
                             }
-                            match_list_with_row.as_bytes().to_vec()
-                        }
-                    } else {
-                        b"0".to_vec()
-                    };
+                        } else {
+                            b"0".to_vec()
+                        };
 
-                    if self.flag_flag_matches_only && !matched {
-                        if self.flag_unmatched_output.is_some() {
-                            unmatched_wtr.write_byte_record(&record)?;
+                        if self.flag_flag_matches_only && !matched {
+                            if has_unmatched_output {
+                                unmatched_wtr.write_byte_record(&record)?;
+                            }
+                            continue;
                         }
-                        continue;
+                        record.push_field(&flag_column);
+                        wtr.write_byte_record(&record)?;
+                    } else if matched {
+                        wtr.write_byte_record(&record)?;
                     }
-                    record.push_field(&flag_column);
-                    wtr.write_byte_record(&record)?;
-                } else if matched {
-                    wtr.write_byte_record(&record)?;
                 }
+                next_chunk += 1;
             }
         }
 

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -268,6 +268,9 @@ impl Args {
         regex_labels: &[String],
     ) -> CliResult<()> {
         let flag_not_one = self.flag_not_one;
+        // Per USAGE, --quick is "Ignored if --json is enabled" - --json needs the
+        // full record_count and total_matches summary, so we must not break early.
+        let flag_quick = self.flag_quick && !self.flag_json;
 
         let mut rdr = rconfig.reader()?;
         let mut wtr = Config::new(self.flag_output.as_ref()).writer()?;
@@ -281,7 +284,7 @@ impl Args {
             true
         });
 
-        if !rconfig.no_headers && !self.flag_quick {
+        if !rconfig.no_headers && !flag_quick {
             wtr.write_record(&headers)?;
         }
 
@@ -341,7 +344,7 @@ impl Args {
             }
             if m {
                 match_row_ctr += 1;
-                if self.flag_quick {
+                if flag_quick {
                     break;
                 }
             }
@@ -408,7 +411,7 @@ impl Args {
             });
             eprintln!("{json}");
         } else {
-            if self.flag_count && !self.flag_quick {
+            if self.flag_count && !flag_quick {
                 if !self.flag_quiet {
                     eprintln!("{match_row_ctr}");
                 }
@@ -417,7 +420,7 @@ impl Args {
 
             if match_row_ctr == 0 && !flag_not_one {
                 return Err(CliError::NoMatch());
-            } else if self.flag_quick {
+            } else if flag_quick {
                 if !self.flag_quiet {
                     eprintln!("{row_ctr}");
                 }
@@ -467,7 +470,11 @@ impl Args {
 
         let pattern = Arc::new(pattern);
         let invert_match = self.flag_invert_match;
-        let flag_quick = self.flag_quick;
+        // Per USAGE, --quick is "Ignored if --json is enabled" - --json needs the
+        // full record_count and total_matches summary, so workers must scan
+        // every chunk in normal mode and the quick early-return block below
+        // must be skipped.
+        let flag_quick = self.flag_quick && !self.flag_json;
 
         // Lowest chunk_index that has reported a match in --quick mode (or
         // usize::MAX if none yet). A chunk can stop scanning only when a
@@ -599,7 +606,8 @@ impl Args {
 
         // --quick mode: collect each worker's earliest-match-in-chunk and
         // pick the lowest chunk_index that reported Some(row).
-        if self.flag_quick {
+        // Skipped when --json is enabled (per USAGE: --quick is ignored).
+        if flag_quick {
             let mut earliest: Option<(usize, u64)> = None;
             for chunk_msg in &recv {
                 let chunk = chunk_msg?;

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -220,6 +220,99 @@ fn search_match_quick() {
 }
 
 #[test]
+fn search_match_quick_json() {
+    // regression: --quick + --json must not emit an unclosed JSON array `[`
+    let wrk = Workdir::new("search_match_quick_json");
+    wrk.create("data.csv", data(true));
+    let mut cmd = wrk.command("search");
+    cmd.arg("^a").arg("--quick").arg("--json").arg("data.csv");
+
+    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(got, "");
+}
+
+#[test]
+fn search_indexed_parallel_quick() {
+    // regression: parallel --quick must report the same earliest-match row
+    // as sequential search and produce no stdout
+    let wrk = Workdir::new("search_indexed_parallel_quick");
+    let data = wrk.load_test_resource("boston311-100.csv");
+    wrk.create_from_string("data.csv", &data);
+
+    // index the file
+    let mut idx_cmd = wrk.command("index");
+    idx_cmd.arg("data.csv");
+    wrk.assert_success(&mut idx_cmd);
+
+    // sequential baseline (--jobs 1 routes to sequential_search)
+    let mut seq_cmd = wrk.command("search");
+    seq_cmd
+        .arg("Charlestown")
+        .arg("--quick")
+        .arg("--jobs")
+        .arg("1")
+        .arg("data.csv");
+    let seq_err = wrk.output_stderr(&mut seq_cmd);
+    wrk.assert_success(&mut seq_cmd);
+
+    // parallel run
+    let mut par_cmd = wrk.command("search");
+    par_cmd
+        .arg("Charlestown")
+        .arg("--quick")
+        .arg("--jobs")
+        .arg("4")
+        .arg("data.csv");
+    let par_err = wrk.output_stderr(&mut par_cmd);
+    wrk.assert_success(&mut par_cmd);
+
+    // Same earliest-match row regardless of parallelism
+    assert_eq!(seq_err, par_err);
+    assert!(!seq_err.trim().is_empty());
+
+    // --quick produces no stdout
+    let par_out: String = wrk.stdout(&mut par_cmd);
+    assert_eq!(par_out, "");
+}
+
+#[test]
+fn search_indexed_parallel_invert_match() {
+    // covers: the parallel filter-mode optimization that drops non-matched
+    // rows in workers must still produce identical output to sequential mode
+    // when --invert-match flips the meaning of "matched"
+    let wrk = Workdir::new("search_indexed_parallel_invert_match");
+    let data = wrk.load_test_resource("boston311-100.csv");
+    wrk.create_from_string("data.csv", &data);
+
+    // sequential baseline (no index yet)
+    let mut seq_cmd = wrk.command("search");
+    seq_cmd
+        .arg("Charlestown")
+        .arg("--invert-match")
+        .arg("data.csv");
+    let seq_out: String = wrk.stdout(&mut seq_cmd);
+    wrk.assert_success(&mut seq_cmd);
+
+    // index and run in parallel
+    let mut idx_cmd = wrk.command("index");
+    idx_cmd.arg("data.csv");
+    wrk.assert_success(&mut idx_cmd);
+
+    let mut par_cmd = wrk.command("search");
+    par_cmd
+        .arg("Charlestown")
+        .arg("--invert-match")
+        .arg("--jobs")
+        .arg("4")
+        .arg("data.csv");
+    let par_out: String = wrk.stdout(&mut par_cmd);
+    wrk.assert_success(&mut par_cmd);
+
+    assert_eq!(seq_out, par_out);
+}
+
+#[test]
 fn search_nomatch() {
     let wrk = Workdir::new("search_nomatch");
     wrk.create("data.csv", data(true));

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -221,12 +221,21 @@ fn search_match_quick() {
 
 #[test]
 fn search_match_quick_json() {
-    // regression: --quick + --json must not emit an unclosed JSON array `[`
+    // regression: --quick + --json must not emit an unclosed JSON array `[`,
+    // and per USAGE --json "Automatically sets --quiet" so the --quick row
+    // number must NOT be printed to stderr either.
     let wrk = Workdir::new("search_match_quick_json");
     wrk.create("data.csv", data(true));
     let mut cmd = wrk.command("search");
     cmd.arg("^a").arg("--quick").arg("--json").arg("data.csv");
 
+    // Workdir::output_stderr returns the literal "No error" sentinel when
+    // stderr is empty and the command succeeded.
+    let got_err = wrk.output_stderr(&mut cmd);
+    assert_eq!(
+        got_err, "No error",
+        "--quick --json should silence stderr (--json implies --quiet); got: {got_err:?}"
+    );
     wrk.assert_success(&mut cmd);
     let got: String = wrk.stdout(&mut cmd);
     assert_eq!(got, "");

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -174,6 +174,53 @@ fn searchset_indexed_parallel_quick() {
 }
 
 #[test]
+fn searchset_indexed_parallel_quick_json() {
+    // regression: per USAGE, searchset's --quick is "Ignored if --json is
+    // enabled" - --json must scan all records and print the full JSON summary
+    // to stderr, NOT exit early on first match.
+    let wrk = Workdir::new("searchset_indexed_parallel_quick_json");
+    let data = wrk.load_test_resource("boston311-100.csv");
+    wrk.create_from_string("data.csv", &data);
+    wrk.create_from_string("regexset.txt", "Brighton\nMission Hill");
+
+    // index the file
+    let mut idx_cmd = wrk.command("index");
+    idx_cmd.arg("data.csv");
+    wrk.assert_success(&mut idx_cmd);
+
+    // parallel run: --quick + --json must NOT short-circuit
+    let mut cmd = wrk.command("searchset");
+    cmd.arg("regexset.txt")
+        .arg("--quick")
+        .arg("--json")
+        .arg("--jobs")
+        .arg("4")
+        .arg("data.csv");
+    let stderr = wrk.output_stderr(&mut cmd);
+    wrk.assert_success(&mut cmd);
+
+    // stderr must be a JSON summary, not a single row number
+    let json: serde_json::Value = serde_json::from_str(stderr.trim())
+        .expect("stderr should be a JSON summary when --json is set");
+    // record_count reflects full scan (boston311-100.csv has 100 records);
+    // assert > 1 to prove --quick did not exit on the first match.
+    let record_count = json["record_count"].as_u64().expect("record_count");
+    assert!(
+        record_count > 1,
+        "record_count should reflect a full scan, got {record_count}"
+    );
+    // rows_with_matches > 1 also proves we didn't break on first match
+    let rows_with_matches = json["rows_with_matches"]
+        .as_u64()
+        .expect("rows_with_matches");
+    assert!(
+        rows_with_matches > 1,
+        "rows_with_matches should be > 1 (--quick is ignored under --json), got \
+         {rows_with_matches}"
+    );
+}
+
+#[test]
 fn searchset_indexed_parallel_invert_match() {
     // covers: the parallel filter-mode optimization that drops non-matched
     // rows in workers must still produce identical output to sequential mode

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -129,6 +129,88 @@ fn searchset_indexed_parallel() {
 }
 
 #[test]
+fn searchset_indexed_parallel_quick() {
+    // regression: parallel --quick must report the same earliest-match row
+    // as sequential and produce no stdout
+    let wrk = Workdir::new("searchset_indexed_parallel_quick");
+    let data = wrk.load_test_resource("boston311-100.csv");
+    wrk.create_from_string("data.csv", &data);
+    wrk.create_from_string("regexset.txt", "Brighton\nMission Hill");
+
+    // index the file
+    let mut idx_cmd = wrk.command("index");
+    idx_cmd.arg("data.csv");
+    wrk.assert_success(&mut idx_cmd);
+
+    // sequential baseline (--jobs 1 routes to sequential_search)
+    let mut seq_cmd = wrk.command("searchset");
+    seq_cmd
+        .arg("regexset.txt")
+        .arg("--quick")
+        .arg("--jobs")
+        .arg("1")
+        .arg("data.csv");
+    let seq_err = wrk.output_stderr(&mut seq_cmd);
+    wrk.assert_success(&mut seq_cmd);
+
+    // parallel run
+    let mut par_cmd = wrk.command("searchset");
+    par_cmd
+        .arg("regexset.txt")
+        .arg("--quick")
+        .arg("--jobs")
+        .arg("4")
+        .arg("data.csv");
+    let par_err = wrk.output_stderr(&mut par_cmd);
+    wrk.assert_success(&mut par_cmd);
+
+    // Same earliest-match row regardless of parallelism
+    assert_eq!(seq_err, par_err);
+    assert!(!seq_err.trim().is_empty());
+
+    // --quick produces no stdout
+    let par_out: String = wrk.stdout(&mut par_cmd);
+    assert_eq!(par_out, "");
+}
+
+#[test]
+fn searchset_indexed_parallel_invert_match() {
+    // covers: the parallel filter-mode optimization that drops non-matched
+    // rows in workers must still produce identical output to sequential mode
+    // when --invert-match flips the meaning of "matched"
+    let wrk = Workdir::new("searchset_indexed_parallel_invert_match");
+    let data = wrk.load_test_resource("boston311-100.csv");
+    wrk.create_from_string("data.csv", &data);
+    wrk.create_from_string("regexset.txt", "Brighton\nMission Hill");
+
+    // sequential baseline (no index yet)
+    let mut seq_cmd = wrk.command("searchset");
+    seq_cmd
+        .arg("regexset.txt")
+        .arg("--invert-match")
+        .arg("data.csv");
+    let seq_out: String = wrk.stdout(&mut seq_cmd);
+    wrk.assert_success(&mut seq_cmd);
+
+    // index and run in parallel
+    let mut idx_cmd = wrk.command("index");
+    idx_cmd.arg("data.csv");
+    wrk.assert_success(&mut idx_cmd);
+
+    let mut par_cmd = wrk.command("searchset");
+    par_cmd
+        .arg("regexset.txt")
+        .arg("--invert-match")
+        .arg("--jobs")
+        .arg("4")
+        .arg("data.csv");
+    let par_out: String = wrk.stdout(&mut par_cmd);
+    wrk.assert_success(&mut par_cmd);
+
+    assert_eq!(seq_out, par_out);
+}
+
+#[test]
 fn searchset_match() {
     let wrk = Workdir::new("searchset_match");
     wrk.create("data.csv", data(true));


### PR DESCRIPTION
## Summary

Review-driven cleanup of `qsv search` and `qsv searchset` parallel-mode pipelines. Fixes one scalability bug, two correctness bugs, and a panic-on-error path; aligns USAGE with actual behavior.

### Parallel mode (both commands)
- **Memory**: `parallel_search` now streams chunks in row order via `BTreeMap` rather than buffering the entire indexed CSV before writing. Workers also drop non-matched rows when they aren't needed (filter mode, or `--flag-matches-only` without `--unmatched-output`). Memory is now bounded by in-flight workers instead of total file size.
- **`--quick` allocations**: workers no longer allocate a full `Vec<…Result>` per chunk; they track only the earliest matched row in their own chunk and return on first hit.
- **`--quick` earliest-row race**: the old `AtomicBool` early-exit could let a worker break out of chunk 0 *before* reaching its own earlier match because a higher-indexed chunk had set the flag first. Replaced with an `AtomicUsize` tracking the lowest matched `chunk_index` — workers only break when a *strictly lower* chunk has already matched, preserving the sequential "first match in row order" semantic. The new `searchset_indexed_parallel_quick` test was flaky 4-out-of-5 runs against the old implementation; it's now stable across 8+ runs.
- **Worker panics**: I/O / CSV / index errors are propagated via `CliResult` through the channel instead of `unwrap()`-panicking, and `byte_records` errors are no longer silently dropped via `.flatten()`.
- **`Arc<Args>`**: shared across workers instead of `self.clone()` per worker.

### `search` only
- **`--quick --json`** no longer writes an unclosed `[` (the function returned early without writing the closing `]`).

### USAGE alignment (both commands)
- Top doc no longer claims match count is printed by default — only `--count` does that, suppressed by `--quiet` and `--json`.
- `search`: documents the `--flag M` magic value, the dual count/ms semantics of `--preview-match`, that `--progressbar` is disabled by parallel (not all indexed) mode, and that `--json`'s implicit `--quiet` also suppresses `--count`.
- `searchset`: same `--count`/`--quiet`/top-doc tightening, with the note that `--json` still prints its summary even under `--quiet`.

### Other
- `should_collect_preview`: removed unreachable `preview_limit == 0` short-circuit (caller already gates on this).

## Test plan
- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo clippy --locked -F all_features --bin qsv` — clean
- [x] `cargo test --locked -F all_features test_search` — 80 passing, 3 deterministic full-suite runs
- [x] 5 new regression tests added:
  - `search_match_quick_json` — `--quick --json` produces no orphan `[`
  - `search_indexed_parallel_quick` — parallel `--quick` reports same earliest row as sequential
  - `search_indexed_parallel_invert_match` — parallel filter-mode output matches sequential under `--invert-match`
  - `searchset_indexed_parallel_quick` — same as above for searchset (this one specifically caught the AtomicBool race)
  - `searchset_indexed_parallel_invert_match` — same as above for searchset

🤖 Generated with [Claude Code](https://claude.com/claude-code)