### PR TITLE
validate: correctness, perf cleanup, and polish from code review

### DIFF
--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1138,6 +1138,20 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // if no JSON Schema supplied, only let csv reader RFC4180-validate csv file
     if !has_json_schema && args.arg_json_schema.is_none() {
+        // Warn when a .json file appears earlier in the input list — schema detection
+        // only looks at the last positional, so a misordered argument silently falls
+        // into RFC 4180 mode.
+        if args.arg_input.iter().rev().skip(1).any(|p| {
+            p.extension()
+                .and_then(std::ffi::OsStr::to_str)
+                .is_some_and(|ext| ext.to_lowercase() == "json")
+        }) {
+            wwarn!(
+                "A .json file is present in the input list but is not the last argument. Falling \
+                 back to RFC 4180 validation. Move the schema file to the end if you intended \
+                 JSON Schema validation."
+            );
+        }
         // For RFC 4180 validation mode, we support Extended Input Support
         return validate_rfc4180_mode(&args);
     }
@@ -1167,6 +1181,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         );
     }
 
+    // JSON Schema validation requires headers — reject early, before opening the file.
+    if args.flag_no_headers {
+        return fail_clierror!("Cannot validate CSV without headers against a JSON Schema.");
+    }
+
     let input_path = input_files.first().ok_or_else(|| {
         if has_json_schema && args.arg_input.len() == 1 {
             CliError::Other(
@@ -1190,15 +1209,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if args.flag_delimiter.is_some() {
         rconfig = rconfig.delimiter(args.flag_delimiter);
     }
-    DELIMITER.set(args.flag_delimiter).unwrap();
+    // ignore the "already set" error so re-entrant calls (e.g., qsv used as a library)
+    // don't panic; first-call value wins, which is fine for a single-shot command.
+    let _ = DELIMITER.set(args.flag_delimiter);
 
     let mut rdr = rconfig.reader()?;
-
-    // if we're here, we're validating with a JSON Schema
-    // JSONSchema validation requires headers
-    if args.flag_no_headers {
-        return fail_clierror!("Cannot validate CSV without headers against a JSON Schema.");
-    }
 
     // prep progress bar
     #[cfg(any(feature = "feature_capable", feature = "lite"))]
@@ -1224,27 +1239,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let header_len = headers.len();
 
     #[cfg(not(feature = "lite"))]
-    let qsv_cache_dir = lookup::set_qsv_cache_dir(&args.flag_cache_dir)?;
-    #[cfg(not(feature = "lite"))]
-    QSV_CACHE_DIR.set(qsv_cache_dir)?;
+    {
+        let qsv_cache_dir = lookup::set_qsv_cache_dir(&args.flag_cache_dir)?;
+        // ignore "already set" — first-call value wins; safe under re-entry.
+        let _ = QSV_CACHE_DIR.set(qsv_cache_dir);
 
-    // check the QSV_CKAN_API environment variable
-    #[cfg(not(feature = "lite"))]
-    CKAN_API.set(if let Ok(api) = std::env::var("QSV_CKAN_API") {
-        api
-    } else {
-        args.flag_ckan_api.clone()
-    })?;
+        let ckan_api = std::env::var("QSV_CKAN_API").unwrap_or_else(|_| args.flag_ckan_api.clone());
+        let _ = CKAN_API.set(ckan_api);
 
-    // check the QSV_CKAN_TOKEN environment variable
-    #[cfg(not(feature = "lite"))]
-    CKAN_TOKEN
-        .set(if let Ok(token) = std::env::var("QSV_CKAN_TOKEN") {
-            Some(token)
-        } else {
-            args.flag_ckan_token.clone()
-        })
-        .unwrap();
+        let ckan_token = std::env::var("QSV_CKAN_TOKEN")
+            .ok()
+            .or_else(|| args.flag_ckan_token.clone());
+        let _ = CKAN_TOKEN.set(ckan_token);
+    }
 
     // parse and compile supplied JSON Schema
     let json_schema_path =
@@ -1368,8 +1375,9 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
         debug!("schema json: {:?}", &schema_json);
     }
 
-    // set this once, as this is used repeatedly in a hot loop
-    NULL_TYPE.set(Value::String("null".to_string())).unwrap();
+    // set this once, as this is used repeatedly in a hot loop.
+    // get_or_init makes this re-entry-safe (first-call value wins).
+    NULL_TYPE.get_or_init(|| Value::String("null".to_string()));
 
     // get JSON types for each column in CSV file
     let header_types = get_json_types(&headers, &schema_json)?;
@@ -2603,6 +2611,9 @@ fn test_validate_currency_email_dynamicenum_validator() {
 }
 
 #[test]
+// makes a live network call; ignored by default so CI/offline runs are deterministic.
+// run explicitly with `cargo test test_load_json_via_url -- --ignored`.
+#[ignore]
 fn test_load_json_via_url() {
     #[cfg(not(feature = "lite"))]
     let qsv_cache_dir = lookup::set_qsv_cache_dir("~/.qsv-cache").unwrap();

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -495,7 +495,11 @@ impl Keyword for UniqueCombinedWithValidator {
             }
         }
 
-        // Get values from column indices by converting to array first
+        // Get values from column indices.
+        // Index N refers to the Nth field of the CSV record. This relies on the JSON
+        // instance preserving header order — true here because qsv enables
+        // `serde_json/preserve_order` (so `Map` is `IndexMap`) and `to_json_instance`
+        // inserts in header order.
         if !self.column_indices.is_empty() {
             let array: Vec<_> = obj.values().collect();
             for &idx in &self.column_indices {
@@ -537,33 +541,12 @@ impl Keyword for UniqueCombinedWithValidator {
         Ok(())
     }
 
-    fn is_valid(&self, instance: &Value) -> bool {
-        let Some(obj) = instance.as_object() else {
-            return false;
-        };
-
-        let mut values = Vec::with_capacity(self.column_names.len() + self.column_indices.len());
-
-        // Get values from column names
-        for name in &self.column_names {
-            if let Some(value) = obj.get(name) {
-                values.push(value.to_string());
-            }
-        }
-
-        // Get values from column indices by converting to array first
-        if !self.column_indices.is_empty() {
-            let array: Vec<_> = obj.values().collect();
-            for &idx in &self.column_indices {
-                if let Some(value) = array.get(idx) {
-                    values.push(value.to_string());
-                }
-            }
-        }
-
-        let combination = values.join("|");
-        let seen = self.seen_combinations.read().unwrap();
-        !seen.contains(&combination)
+    fn is_valid(&self, _instance: &Value) -> bool {
+        // `uniqueCombinedWith` is stateful: a "valid" answer must atomically record the
+        // combination, otherwise two concurrent duplicates both pass. Since `is_valid` is
+        // not allowed to observably mutate state, we always return `false` to force the
+        // caller through `validate`, which performs the check + insert under lock.
+        false
     }
 }
 
@@ -1067,6 +1050,85 @@ fn dyn_enum_validator_factory<'a>(
     }
 }
 
+/// Walk a parsed JSON Schema and detect which custom formats/keywords are present.
+///
+/// Returns (has_currency_format, has_email_format, has_dynamic_enum, has_unique_combined).
+///
+/// We look for:
+/// - `"format": "currency"` and `"format": "email"` on objects (any nesting)
+/// - any object key named `dynamicEnum` or `uniqueCombinedWith`
+///
+/// This replaces a substring search on the raw schema text, which was sensitive to
+/// whitespace and could false-match on descriptions/titles containing these literals.
+fn detect_custom_schema_features(schema: &Value) -> (bool, bool, bool, bool) {
+    let mut has_currency = false;
+    let mut has_email = false;
+    let mut has_dynamic_enum = false;
+    let mut has_unique_combined = false;
+
+    fn walk(
+        v: &Value,
+        has_currency: &mut bool,
+        has_email: &mut bool,
+        has_dynamic_enum: &mut bool,
+        has_unique_combined: &mut bool,
+    ) {
+        match v {
+            Value::Object(map) => {
+                for (k, val) in map {
+                    match k.as_str() {
+                        "format" => {
+                            if let Some(s) = val.as_str() {
+                                match s {
+                                    "currency" => *has_currency = true,
+                                    "email" => *has_email = true,
+                                    _ => {},
+                                }
+                            }
+                        },
+                        "dynamicEnum" => *has_dynamic_enum = true,
+                        "uniqueCombinedWith" => *has_unique_combined = true,
+                        _ => {},
+                    }
+                    walk(
+                        val,
+                        has_currency,
+                        has_email,
+                        has_dynamic_enum,
+                        has_unique_combined,
+                    );
+                }
+            },
+            Value::Array(arr) => {
+                for item in arr {
+                    walk(
+                        item,
+                        has_currency,
+                        has_email,
+                        has_dynamic_enum,
+                        has_unique_combined,
+                    );
+                }
+            },
+            _ => {},
+        }
+    }
+
+    walk(
+        schema,
+        &mut has_currency,
+        &mut has_email,
+        &mut has_dynamic_enum,
+        &mut has_unique_combined,
+    );
+    (
+        has_currency,
+        has_email,
+        has_dynamic_enum,
+        has_unique_combined,
+    )
+}
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
@@ -1234,14 +1296,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             // safety: we know the schema is_some() because we checked above
             match load_json(&json_schema_path.to_string_lossy()) {
             Ok(s) => {
-                // Check for custom formats and keywords before parsing
-                let has_currency_format = s.contains(r#""format": "currency""#);
-                let has_dynamic_enum = s.contains("dynamicEnum");
-                let has_unique_combined = s.contains("uniqueCombinedWith");
-                let has_email_format = s.contains(r#""format": "email""#);
-                debug!("Custom formats/keywords: currency: {has_currency_format}, dynamicEnum: {has_dynamic_enum}");
-                debug!("uniqueCombinedWith: {has_unique_combined}, email: {has_email_format}");
-
                 // parse JSON string - use platform-appropriate JSON deserialization
                 #[cfg(target_endian = "big")]
                 let json_result = serde_json::from_str::<Value>(&s);
@@ -1253,25 +1307,57 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
                 match json_result {
                     Ok(json) => {
+                        // Detect custom formats/keywords by walking the parsed schema.
+                        // This is robust to whitespace and avoids false matches on
+                        // descriptions/titles that mention these strings as text.
+                        let (
+                            has_currency_format,
+                            has_email_format,
+                            has_dynamic_enum,
+                            has_unique_combined,
+                        ) = detect_custom_schema_features(&json);
+                        debug!(
+                            "Custom formats/keywords: currency: {has_currency_format}, dynamicEnum: {has_dynamic_enum}"
+                        );
+                        debug!(
+                            "uniqueCombinedWith: {has_unique_combined}, email: {has_email_format}"
+                        );
+
                         // compile JSON Schema
                         let mut validator_options = Validator::options()
                             .should_validate_formats(!args.flag_no_format_validation);
 
                         // Add custom validators based on pre-checked flags
                         if has_email_format {
+                            // Apply each option explicitly:
+                            // - required_tld is enable-only in the jsonschema crate, but the
+                            //   default ("not required") matches the docopt default (flag off),
+                            //   so this is fine.
+                            // - display_text and domain_literal toggles are explicit in both
+                            //   directions so future jsonschema default flips don't silently
+                            //   change behavior.
+                            // - min_subdomains keeps the `> 2` guard: at the default of 2 we
+                            //   preserve the jsonschema crate's lenient default rather than
+                            //   forcing a stricter rule. Users who want strict enforcement
+                            //   set it to 3+.
                             let mut email_options = EmailOptions::default();
                             if args.flag_email_required_tld {
                                 email_options = email_options.with_required_tld();
                             }
-                            if !args.flag_email_display_text {
-                                email_options = email_options.without_display_text();
-                            }
+                            email_options = if args.flag_email_display_text {
+                                email_options.with_display_text()
+                            } else {
+                                email_options.without_display_text()
+                            };
                             if args.flag_email_min_subdomains > 2 {
-                                email_options = email_options.with_minimum_sub_domains(args.flag_email_min_subdomains);
+                                email_options = email_options
+                                    .with_minimum_sub_domains(args.flag_email_min_subdomains);
                             }
-                            if !args.flag_email_domain_literal {
-                                email_options = email_options.without_domain_literal();
-                            }
+                            email_options = if args.flag_email_domain_literal {
+                                email_options.with_domain_literal()
+                            } else {
+                                email_options.without_domain_literal()
+                            };
                             validator_options = validator_options.with_email_options(email_options);
                         }
 
@@ -1446,7 +1532,9 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
         // because Rayon collect() guarantees original order, we can sequentially append results
         // to vector with each batch
         let start_idx = valid_flags.len();
-        valid_flags.extend(std::iter::repeat_n(true, batch_size));
+        // extend by the actual batch length, not batch_size — the last batch may be partial,
+        // and over-extending would leave trailing `true` flags for nonexistent rows.
+        valid_flags.extend(std::iter::repeat_n(true, batch.len()));
         for (i, result) in batch_validation_results.iter().enumerate() {
             if let Some(validation_error_msg) = result {
                 invalid_count += 1;
@@ -2095,7 +2183,18 @@ fn load_json(uri: &str) -> Result<String, String> {
             };
 
             match client.get(url).send() {
-                Ok(response) => response.text().unwrap_or_default(),
+                Ok(response) => {
+                    let status = response.status();
+                    if !status.is_success() {
+                        return fail_format!("HTTP error fetching JSON at url {url}: {status}");
+                    }
+                    match response.text() {
+                        Ok(body) => body,
+                        Err(e) => {
+                            return fail_format!("Cannot read response body from {url}: {e}.");
+                        },
+                    }
+                },
                 Err(e) => return fail_format!("Cannot read JSON at url {url}: {e}."),
             }
         },
@@ -2103,9 +2202,9 @@ fn load_json(uri: &str) -> Result<String, String> {
             let mut buffer = String::new();
             match File::open(path) {
                 Ok(p) => {
-                    BufReader::new(p)
-                        .read_to_string(&mut buffer)
-                        .unwrap_or_default();
+                    if let Err(e) = BufReader::new(p).read_to_string(&mut buffer) {
+                        return fail_format!("Cannot read JSON file {path}: {e}.");
+                    }
                 },
                 Err(e) => return fail_format!("Cannot read JSON file {path}: {e}."),
             }

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -959,24 +959,28 @@ fn dyn_enum_validator_factory<'a>(
         ));
     };
 
-    let temp_download = match NamedTempFile::new() {
-        Ok(file) => file,
-        Err(e) => return fail_validation_error!("Failed to create temporary file: {e}"),
-    };
-
     // Split URI to get column specification
     let parts: Vec<&str> = uri.split('|').collect();
     let base_uri = parts[0];
     let column = parts.get(1).map(std::string::ToString::to_string);
 
+    // Hold the temp file across the load so it isn't deleted prematurely.
+    // Only created in the URL branch; local paths don't need a temp file.
+    let mut _temp_download: Option<NamedTempFile> = None;
+
     let dynenum_path = if base_uri.starts_with("http") {
         let valid_url = reqwest::Url::parse(base_uri)
             .map_err(|e| ValidationError::custom(format!("Error parsing dynamicEnum URL: {e}")))?;
 
+        let temp_file = match NamedTempFile::new() {
+            Ok(file) => file,
+            Err(e) => return fail_validation_error!("Failed to create temporary file: {e}"),
+        };
+
         let download_timeout = TIMEOUT_SECS.load(Ordering::Relaxed);
         let future = util::download_file(
             valid_url.as_str(),
-            temp_download.path().to_path_buf(),
+            temp_file.path().to_path_buf(),
             false,
             None,
             Some(download_timeout),
@@ -992,18 +996,35 @@ fn dyn_enum_validator_factory<'a>(
                 return fail_validation_error!("Error creating Tokio runtime - {e}");
             },
         }
-        temp_download.path().to_str().unwrap().to_string()
+        let path_str = match temp_file.path().to_str() {
+            Some(p) => p.to_string(),
+            None => {
+                return fail_validation_error!(
+                    "Downloaded dynamicEnum file path is not valid UTF-8: {}",
+                    temp_file.path().display()
+                );
+            },
+        };
+        _temp_download = Some(temp_file);
+        path_str
     } else {
         let uri_path = std::path::Path::new(base_uri);
         if !uri_path.exists() {
             return fail_validation_error!("dynamicEnum file not found - {base_uri}");
         }
-        uri_path.to_str().unwrap().to_string()
+        match uri_path.to_str() {
+            Some(p) => p.to_string(),
+            None => {
+                return fail_validation_error!(
+                    "dynamicEnum file path is not valid UTF-8: {}",
+                    uri_path.display()
+                );
+            },
+        }
     };
 
     let enum_set = load_dynenum_set(&dynenum_path, column, 50)?;
-    // `temp_download` outlives the load above; drop it explicitly to make intent clear.
-    drop(temp_download);
+    // `_temp_download` is dropped at end of scope after `enum_set` is fully populated.
     Ok(Box::new(DynEnumValidator::new(enum_set)))
 }
 

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -464,7 +464,9 @@ impl Keyword for DynEnumValidator {
 struct UniqueCombinedWithValidator {
     column_names:      Vec<String>,
     column_indices:    Vec<usize>,
-    seen_combinations: std::sync::RwLock<HashSet<String>>,
+    // Mutex (not RwLock): `validate` always check-and-inserts under exclusive access,
+    // so there is no read-only path that would benefit from an RwLock.
+    seen_combinations: std::sync::Mutex<HashSet<String>>,
 }
 
 impl UniqueCombinedWithValidator {
@@ -472,7 +474,7 @@ impl UniqueCombinedWithValidator {
         Self {
             column_names,
             column_indices,
-            seen_combinations: std::sync::RwLock::new(HashSet::new()),
+            seen_combinations: std::sync::Mutex::new(HashSet::new()),
         }
     }
 }
@@ -510,7 +512,7 @@ impl Keyword for UniqueCombinedWithValidator {
         }
 
         let combination = values.join("|");
-        let mut seen = self.seen_combinations.write().unwrap();
+        let mut seen = self.seen_combinations.lock().unwrap();
 
         if seen.contains(&combination) {
             let mut column_desc_parts =
@@ -827,6 +829,63 @@ fn test_parse_dynenum_uri() {
     assert_eq!(column, Some("state_col".to_string()));
 }
 
+/// Drain `column` (or column 0 if `None`) of a CSV file at `path` into a `HashSet`.
+///
+/// Shared by the lite and non-lite `dyn_enum_validator_factory` variants.
+/// `column` may be either a numeric index (parsed as `usize`) or a header name.
+#[allow(clippy::result_large_err)]
+fn load_dynenum_set<'a>(
+    path: &str,
+    column: Option<String>,
+    initial_capacity: usize,
+) -> Result<HashSet<String>, ValidationError<'a>> {
+    let rconfig = Config::new(Some(path.to_owned()).as_ref());
+    let mut rdr = match rconfig
+        .flexible(true)
+        .comment(Some(b'#'))
+        .skip_format_check(true)
+        .reader()
+    {
+        Ok(reader) => reader,
+        Err(e) => return fail_validation_error!("Error opening dynamicEnum file: {e}"),
+    };
+
+    let column_idx = if let Some(col_name) = column {
+        if let Ok(idx) = col_name.parse::<usize>() {
+            idx
+        } else {
+            match rdr.headers() {
+                Ok(headers) => match headers.iter().position(|h| h == col_name) {
+                    Some(i) => i,
+                    None => {
+                        return fail_validation_error!(
+                            "Column '{col_name}' not found in lookup table"
+                        );
+                    },
+                },
+                Err(e) => {
+                    return fail_validation_error!("Error reading headers: {e}");
+                },
+            }
+        }
+    } else {
+        0
+    };
+
+    let mut enum_set = HashSet::with_capacity(initial_capacity);
+    for result in rdr.records() {
+        match result {
+            Ok(record) => {
+                if let Some(value) = record.get(column_idx) {
+                    enum_set.insert(value.to_owned());
+                }
+            },
+            Err(e) => return fail_validation_error!("Error reading dynamicEnum file - {e}"),
+        }
+    }
+    Ok(enum_set)
+}
+
 /// Factory function that creates a DynEnumValidator for validating against dynamic enums loaded
 /// from CSV files.
 ///
@@ -866,7 +925,6 @@ fn dyn_enum_validator_factory<'a>(
 
     let (lookup_name, final_uri, cache_age_secs, column) = parse_dynenum_uri(uri);
 
-    // Create lookup table options
     let opts = LookupTableOptions {
         name: lookup_name,
         uri: final_uri,
@@ -878,63 +936,13 @@ fn dyn_enum_validator_factory<'a>(
         timeout_secs: TIMEOUT_SECS.load(Ordering::Relaxed),
     };
 
-    // Load the lookup table
     let lookup_result = match load_lookup_table(&opts) {
         Ok(result) => result,
         Err(e) => return fail_validation_error!("Error loading dynamicEnum lookup table: {e}"),
     };
 
-    // Read the specified column into a HashSet
-    let mut enum_set = HashSet::with_capacity(lookup_result.headers.len());
-    let rconfig = Config::new(Some(lookup_result.filepath).as_ref());
-    let mut rdr = match rconfig
-        .flexible(true)
-        .comment(Some(b'#'))
-        .skip_format_check(true)
-        .reader()
-    {
-        Ok(reader) => reader,
-        Err(e) => return fail_validation_error!("Error opening dynamicEnum file: {e}"),
-    };
-
-    // Get column index based on name or default to first column
-    let column_idx = if let Some(col_name) = column {
-        // Try parsing as index first
-        if let Ok(idx) = col_name.parse::<usize>() {
-            idx
-        } else {
-            // Try finding column by name
-            match rdr.headers() {
-                Ok(headers) => {
-                    let idx = headers.iter().position(|h| h == col_name);
-                    match idx {
-                        Some(i) => i,
-                        None => {
-                            return fail_validation_error!(
-                                "Column '{}' not found in lookup table",
-                                col_name
-                            );
-                        },
-                    }
-                },
-                Err(e) => return fail_validation_error!("Error reading headers: {e}"),
-            }
-        }
-    } else {
-        0
-    };
-
-    for result in rdr.records() {
-        match result {
-            Ok(record) => {
-                if let Some(value) = record.get(column_idx) {
-                    enum_set.insert(value.to_owned());
-                }
-            },
-            Err(e) => return fail_validation_error!("Error reading dynamicEnum file - {e}"),
-        }
-    }
-
+    let initial_capacity = lookup_result.headers.len();
+    let enum_set = load_dynenum_set(&lookup_result.filepath, column, initial_capacity)?;
     Ok(Box::new(DynEnumValidator::new(enum_set)))
 }
 
@@ -945,109 +953,58 @@ fn dyn_enum_validator_factory<'a>(
     value: &'a Value,
     _location: Location,
 ) -> Result<Box<dyn Keyword>, ValidationError<'a>> {
-    if let Value::String(uri) = value {
-        let temp_download = match NamedTempFile::new() {
-            Ok(file) => file,
-            Err(e) => return fail_validation_error!("Failed to create temporary file: {e}"),
-        };
-
-        // Split URI to get column specification
-        let parts: Vec<&str> = uri.split('|').collect();
-        let base_uri = parts[0];
-        let column = parts.get(1).map(std::string::ToString::to_string);
-
-        let dynenum_path = if base_uri.starts_with("http") {
-            let valid_url = reqwest::Url::parse(base_uri).map_err(|e| {
-                ValidationError::custom(format!("Error parsing dynamicEnum URL: {e}"))
-            })?;
-
-            // download the CSV file from the URL
-            let download_timeout = TIMEOUT_SECS.load(Ordering::Relaxed);
-            let future = util::download_file(
-                valid_url.as_str(),
-                temp_download.path().to_path_buf(),
-                false,
-                None,
-                Some(download_timeout),
-                None,
-            );
-            match tokio::runtime::Runtime::new() {
-                Ok(runtime) => {
-                    if let Err(e) = runtime.block_on(future) {
-                        return fail_validation_error!("Error downloading dynamicEnum file - {e}");
-                    }
-                },
-                Err(e) => {
-                    return fail_validation_error!("Error creating Tokio runtime - {e}");
-                },
-            }
-
-            temp_download.path().to_str().unwrap().to_string()
-        } else {
-            // its a local file
-            let uri_path = std::path::Path::new(base_uri);
-            let uri_exists = uri_path.exists();
-            if !uri_exists {
-                return fail_validation_error!("dynamicEnum file not found - {base_uri}");
-            }
-            uri_path.to_str().unwrap().to_string()
-        };
-
-        // read the specified column into a HashSet
-        let mut enum_set = HashSet::with_capacity(50);
-        let rconfig = Config::new(Some(dynenum_path).as_ref());
-        let mut rdr = match rconfig
-            .flexible(true)
-            .comment(Some(b'#'))
-            .skip_format_check(true)
-            .reader()
-        {
-            Ok(reader) => reader,
-            Err(e) => return fail_validation_error!("Error opening dynamicEnum file: {e}"),
-        };
-
-        // Get column index based on name or default to first column
-        let column_idx = if let Some(col_name) = column {
-            // Try parsing as index first
-            if let Ok(idx) = col_name.parse::<usize>() {
-                idx
-            } else {
-                // Try finding column by name
-                match rdr.headers() {
-                    Ok(headers) => match headers.iter().position(|h| h == col_name) {
-                        Some(i) => i,
-                        None => {
-                            return fail_validation_error!(
-                                "dynamicEnum column '{col_name}' not found in headers"
-                            );
-                        },
-                    },
-                    Err(e) => {
-                        return fail_validation_error!("Error reading dynamicEnum headers: {e}");
-                    },
-                }
-            }
-        } else {
-            0
-        };
-
-        for result in rdr.records() {
-            match result {
-                Ok(record) => {
-                    if let Some(value) = record.get(column_idx) {
-                        enum_set.insert(value.to_owned());
-                    }
-                },
-                Err(e) => return fail_validation_error!("Error reading dynamicEnum file - {e}"),
-            };
-        }
-
-        Ok(Box::new(DynEnumValidator::new(enum_set)))
-    } else {
-        Err(ValidationError::custom(
+    let Value::String(uri) = value else {
+        return Err(ValidationError::custom(
             "'dynamicEnum' must be set to a CSV file on the local filesystem or on a URL.",
-        ))
-    }
+        ));
+    };
+
+    let temp_download = match NamedTempFile::new() {
+        Ok(file) => file,
+        Err(e) => return fail_validation_error!("Failed to create temporary file: {e}"),
+    };
+
+    // Split URI to get column specification
+    let parts: Vec<&str> = uri.split('|').collect();
+    let base_uri = parts[0];
+    let column = parts.get(1).map(std::string::ToString::to_string);
+
+    let dynenum_path = if base_uri.starts_with("http") {
+        let valid_url = reqwest::Url::parse(base_uri)
+            .map_err(|e| ValidationError::custom(format!("Error parsing dynamicEnum URL: {e}")))?;
+
+        let download_timeout = TIMEOUT_SECS.load(Ordering::Relaxed);
+        let future = util::download_file(
+            valid_url.as_str(),
+            temp_download.path().to_path_buf(),
+            false,
+            None,
+            Some(download_timeout),
+            None,
+        );
+        match tokio::runtime::Runtime::new() {
+            Ok(runtime) => {
+                if let Err(e) = runtime.block_on(future) {
+                    return fail_validation_error!("Error downloading dynamicEnum file - {e}");
+                }
+            },
+            Err(e) => {
+                return fail_validation_error!("Error creating Tokio runtime - {e}");
+            },
+        }
+        temp_download.path().to_str().unwrap().to_string()
+    } else {
+        let uri_path = std::path::Path::new(base_uri);
+        if !uri_path.exists() {
+            return fail_validation_error!("dynamicEnum file not found - {base_uri}");
+        }
+        uri_path.to_str().unwrap().to_string()
+    };
+
+    let enum_set = load_dynenum_set(&dynenum_path, column, 50)?;
+    // `temp_download` outlives the load above; drop it explicitly to make intent clear.
+    drop(temp_download);
+    Ok(Box::new(DynEnumValidator::new(enum_set)))
 }
 
 /// Walk a parsed JSON Schema and detect which custom formats/keywords are present.
@@ -1446,6 +1403,11 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
             match rdr.read_byte_record(&mut record) {
                 Ok(true) => {
                     row_number += 1;
+                    // Append the row number as an extra ByteRecord field at index `header_len`.
+                    // It travels with the record into the parallel closure where it's read back
+                    // via `record[header_len]` for error-report formatting. `to_json_instance`
+                    // ignores it because it iterates `header_types` (length = header_len), so
+                    // the appended field is not visible to schema validation.
                     record.push_field(itoa_buffer.format(row_number).as_bytes());
                     if flag_trim {
                         record.trim();
@@ -1538,8 +1500,8 @@ Try running `qsv validate schema {}` to check the JSON Schema file."#, json_sche
         for (i, result) in batch_validation_results.iter().enumerate() {
             if let Some(validation_error_msg) = result {
                 invalid_count += 1;
-                // safety: we know the index is in bounds because we just extended the vector
-                unsafe { valid_flags.set_unchecked(start_idx + i, false) };
+                // safe set(): negligible cost on this path (dominated by validator work)
+                valid_flags.set(start_idx + i, false);
                 validation_error_messages.push(validation_error_msg.to_owned());
             }
         }
@@ -1962,6 +1924,17 @@ Alternatively, transcode your data to UTF-8 first using `iconv` or `recode`."#
     Ok(())
 }
 
+/// Re-reads the input CSV and demuxes records into `.valid` / `.invalid` files.
+///
+/// We intentionally re-read the input rather than streaming during the validation loop:
+/// - The OS page cache makes the second read very cheap (the file was just read once).
+/// - The all-valid case is the common case and currently produces no output files at all; a
+///   streaming approach would have to write every record to `.valid` and then delete the file on
+///   success, costing extra I/O on the hot path.
+/// - Memory is bounded — we keep only the BitVec of valid/invalid flags, not the records
+///   themselves.
+///
+/// Only called when there is at least one invalid record.
 fn split_invalid_records(
     rconfig: &Config,
     valid_flags: &BitSlice,

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -554,12 +554,8 @@ fn validate_dynenum_with_invalid_column() {
 
     // Check error output
     let got = wrk.output_stderr(&mut cmd);
-    #[cfg(feature = "lite")]
-    assert!(got.ends_with(
-        "Cannot compile JSONschema. error: dynamicEnum column 'nonexistent_column' not found in \
-         headers\nTry running `qsv validate schema schema.json` to check the JSON Schema file.\n"
-    ));
-    #[cfg(not(feature = "lite"))]
+    // Both lite and non-lite share the same helper (`load_dynenum_set`) and emit the
+    // same error wording.
     assert!(got.ends_with(
         "Cannot compile JSONschema. error: Column 'nonexistent_column' not found in lookup \
          table\nTry running `qsv validate schema schema.json` to check the JSON Schema file.\n"

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -2061,6 +2061,7 @@ fn validate_schema_subcommand_with_invalid_url_schema() {
             || got.contains("io error")
             || got.contains("timeout")
             || got.contains("JSON error")
+            || got.contains("HTTP error")
     );
 }
 


### PR DESCRIPTION
## Summary

A multi-pass review of `src/cmd/validate.rs` (~2,650 lines) surfaced a mix of correctness bugs, perf-leaning cleanups, and polish items. This PR lands all three groups as separate commits so each can be read and reverted independently.

### Commit 1 — `fix(validate): correctness fixes in JSON Schema validation`
- **`UniqueCombinedWithValidator::is_valid` always returns `false`**, forcing callers through `validate()` (which atomically check-and-inserts under lock). The previous impl read `seen_combinations` but never inserted, so any caller invoking `Validator::is_valid()` against a `uniqueCombinedWith` schema would let duplicates pass silently.
- **Substring schema-feature detection replaced with a tree walker** (`detect_custom_schema_features`). The substring approach was whitespace-sensitive (`"format" : "currency"` silently disabled the custom format) and could false-match on `description`/`title` text containing literal keyword names. The tree walk runs once after the schema is parsed.
- **`load_json` now checks `response.status().is_success()`** and propagates `response.text()` errors instead of `.unwrap_or_default()` flowing empty bodies into the JSON parser as confusing parse errors.
- **Email options apply `display_text` and `domain_literal` toggles explicitly in both directions** (no more reliance on jsonschema crate defaults that may flip in future versions).
- **`valid_flags` is now extended by `batch.len()`** rather than `batch_size`, so the last partial batch doesn't leave trailing valid flags for nonexistent rows.
- Documented the implicit `serde_json/preserve_order` dependency at the `uniqueCombinedWith` index-resolution site.
- Updated `validate_schema_subcommand_with_invalid_url_schema` to accept the new `"HTTP error"` substring.

### Commit 2 — `refactor(validate): perf and cleanup tweaks`
- `UniqueCombinedWithValidator`: `RwLock<HashSet>` → `Mutex<HashSet>` (validate path always takes the write lock; no read-only path benefits from RwLock).
- `BitVec::set_unchecked` (unsafe) → `BitVec::set` (safe). This path is dominated by validator work, so the micro-opt is irrelevant.
- Documented the row-number-as-extra-`ByteRecord`-field convention used to pass the row index into the parallel closure.
- Added a doc comment on `split_invalid_records` explaining the intentional re-read (page cache + all-valid hot path) instead of streaming.
- Extracted a shared `load_dynenum_set` helper; lite and non-lite factories now delegate column resolution + drain to one function instead of duplicating ~60 lines.

### Commit 3 — `chore(validate): polish — re-entrant safety, arg checks, test hygiene`
- `OnceLock::set(...).unwrap()` / `?` replaced with `get_or_init` / `let _ = .set()` for `NULL_TYPE`, `DELIMITER`, `QSV_CACHE_DIR`, `CKAN_API`, and `CKAN_TOKEN`. The previous code panics or returns `Err` on re-entry (e.g. qsv used as a library, or under qsvmcp).
- `flag_no_headers` rejection moved earlier in `run()` so we don't open a CSV reader only to immediately drop it on user error.
- Warn when a `.json` file appears earlier in the input list — schema detection only inspects the last positional, so a misordered argument silently fell into RFC 4180 mode.
- `test_load_json_via_url` marked `#[ignore]` so CI/offline runs are deterministic; run with `--ignored` to exercise it.

## Test plan
- [x] `cargo build --bin qsv -F all_features`
- [x] `cargo build --bin qsvlite -F lite`
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` (clean)
- [x] `cargo test -F all_features` → **2715 passed, 0 failed, 29 ignored**
- [x] Each commit independently builds and passes `cargo test validate -F all_features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)