### PR TITLE
split: review-driven correctness fixes, error propagation, and tests

### DIFF
--- a/docs/help/split.md
+++ b/docs/help/split.md
@@ -70,20 +70,21 @@ qsv split . -s 100 input.csv
 qsv split outdir --kb-size 1000 input.csv
 ```
 
-> Read from stdin and create files like mysplitoutput_0.csv, mysplitoutput_1000.csv, etc.
+> Read from stdin and create files like 0.csv, 1000.csv, etc. in the directory
+> 'mysplitoutput', creating it if it does not exist.
 
 ```console
 cat in.csv | qsv split mysplitoutput -s 1000
 ```
 
-> Create 10 files with names like 0.csv, 1000.csv, etc. in the directory 'outdir',
+> Split into 10 chunks. Files are named with the zero-based starting row index
+> of each chunk (e.g. 0.csv, N.csv, 2N.csv, ...) in the directory 'outdir'.
 
 ```console
 qsv split outdir --chunks 10 input.csv
 ```
 
-> Create 10 files with names like splitoutdir_0.csv, splitoutdir_1000.csv, etc.
-> using 4 parallel jobs. Note that the input CSV must have an index
+> Same, using 4 parallel jobs. Note that the input CSV must have an index.
 
 ```console
 qsv split splitoutdir -c 10 -j 4 input.csv

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -225,14 +225,26 @@ impl Args {
         let mut rdr = rconfig.reader()?;
         let headers = rdr.byte_headers()?.clone();
 
+        // Helper: measure the CSV-encoded byte length of a record using the same
+        // writer settings that `new_writer` will use on disk. We go through
+        // `Config::from_writer` so that any future tweak to Config's quoting,
+        // terminator, or delimiter stays consistent between measurement and the
+        // produced chunk file. (BOM bytes, when QSV_OUTPUT_BOM is set, are
+        // emitted by both paths and cancel out for budget purposes — at worst
+        // they cause slightly earlier rollover, never an over-the-budget chunk.)
+        let measure_record = |record: &csv::ByteRecord| -> CliResult<usize> {
+            let mut buf: Vec<u8> = Vec::with_capacity(256);
+            let mut m = Config::new(None).from_writer(&mut buf);
+            m.write_byte_record(record)?;
+            m.flush()?;
+            drop(m);
+            Ok(buf.len())
+        };
+
         let header_byte_size = if self.flag_no_headers {
             0
         } else {
-            let mut headerbuf_wtr = csv::WriterBuilder::new().from_writer(Vec::with_capacity(256));
-            headerbuf_wtr.write_byte_record(&headers)?;
-
-            // safety: vec writer cannot fail to flush/finalize
-            headerbuf_wtr.into_inner().unwrap().len()
+            measure_record(&headers)?
         };
 
         let chunk_size_bytes = chunk_size * 1024;
@@ -243,50 +255,65 @@ impl Args {
             );
         }
 
-        let mut wtr = self.new_writer(&headers, 0, self.flag_pad)?;
+        // Open chunk files lazily so an empty input produces zero chunks
+        // (no phantom `0.csv` containing only the header row).
+        let mut wtr: Option<csv::Writer<Box<dyn io::Write + 'static>>> = None;
         let mut i: usize = 0; // total data rows processed
-        let mut num_chunks: usize = 1; // we always create chunk 0
+        let mut num_chunks: usize = 0;
         let mut chunk_start: usize = 0;
         let mut chunk_used_bytes = header_byte_size;
-
         let mut row = csv::ByteRecord::new();
-        // Reusable buffer to measure CSV-encoded row sizes without allocating per row.
+        // Per-row measurement buffer reused between reads.
         let mut measure_buf: Vec<u8> = Vec::with_capacity(256);
 
         while rdr.read_byte_record(&mut row)? {
-            // Measure the CSV-encoded size of `row` using a reusable buffer.
+            // Measure the CSV-encoded size of `row` using the shared writer settings.
             let row_size = {
                 measure_buf.clear();
-                let mut m = csv::WriterBuilder::new().from_writer(&mut measure_buf);
+                let mut m = Config::new(None).from_writer(&mut measure_buf);
                 m.write_byte_record(&row)?;
                 m.flush()?;
                 drop(m);
                 measure_buf.len()
             };
 
-            // Roll over if adding this row would exceed the budget. Always allow
-            // at least one data row per chunk (otherwise an oversized row would
-            // loop forever with empty chunks).
-            if chunk_used_bytes + row_size > chunk_size_bytes && chunk_used_bytes > header_byte_size
-            {
-                wtr.flush()?;
-                if self.flag_filter.is_some() {
-                    self.run_filter_command(chunk_start, self.flag_pad)?;
+            let need_new_chunk = match &wtr {
+                None => true,
+                // Roll over if adding this row would exceed the budget. Always
+                // allow at least one data row per chunk (otherwise an oversized
+                // single row would loop forever with empty chunks).
+                Some(_) => {
+                    chunk_used_bytes + row_size > chunk_size_bytes
+                        && chunk_used_bytes > header_byte_size
+                },
+            };
+
+            if need_new_chunk {
+                if let Some(mut w) = wtr.take() {
+                    w.flush()?;
+                    if self.flag_filter.is_some() {
+                        self.run_filter_command(chunk_start, self.flag_pad)?;
+                    }
+                    chunk_start = i;
                 }
-                chunk_start = i;
-                wtr = self.new_writer(&headers, i, self.flag_pad)?;
+                wtr = Some(self.new_writer(&headers, chunk_start, self.flag_pad)?);
                 chunk_used_bytes = header_byte_size;
                 num_chunks += 1;
             }
 
-            wtr.write_byte_record(&row)?;
+            // safety: `wtr` was just set above when `need_new_chunk` was true,
+            // and was Some on every prior iteration once initialized.
+            let active = wtr.as_mut().unwrap();
+            active.write_byte_record(&row)?;
             chunk_used_bytes += row_size;
             i += 1;
         }
-        wtr.flush()?;
-        // Run filter for the final chunk only if it actually received data rows.
-        if self.flag_filter.is_some() && i > 0 {
-            self.run_filter_command(chunk_start, self.flag_pad)?;
+
+        if let Some(mut w) = wtr {
+            w.flush()?;
+            if self.flag_filter.is_some() {
+                self.run_filter_command(chunk_start, self.flag_pad)?;
+            }
         }
 
         if !self.flag_quiet {

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -42,14 +42,15 @@ Examples:
   # to 1000KB in size.
   qsv split outdir --kb-size 1000 input.csv
 
-  # Read from stdin and create files like mysplitoutput_0.csv, mysplitoutput_1000.csv, etc.
+  # Read from stdin and create files like 0.csv, 1000.csv, etc. in the directory
+  # 'mysplitoutput', creating it if it does not exist.
   cat in.csv | qsv split mysplitoutput -s 1000
 
-  # Create 10 files with names like 0.csv, 1000.csv, etc. in the directory 'outdir',
+  # Split into 10 chunks. Files are named with the zero-based starting row index
+  # of each chunk (e.g. 0.csv, N.csv, 2N.csv, ...) in the directory 'outdir'.
   qsv split outdir --chunks 10 input.csv
 
-  # Create 10 files with names like splitoutdir_0.csv, splitoutdir_1000.csv, etc.
-  # using 4 parallel jobs. Note that the input CSV must have an index
+  # Same, using 4 parallel jobs. Note that the input CSV must have an index.
   qsv split splitoutdir -c 10 -j 4 input.csv
 
   # This will create files with names like 0.csv, 100.csv, etc. in the directory
@@ -128,7 +129,6 @@ Common options:
 
 use std::{fs, io, path::Path, process::Command};
 
-use dunce;
 use log::debug;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::Deserialize;
@@ -162,6 +162,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: Args = util::get_args(USAGE, argv)?;
     if args.flag_size == 0 {
         return fail_incorrectusage_clierror!("--size must be greater than 0.");
+    }
+    if let Some(0) = args.flag_chunks {
+        return fail_incorrectusage_clierror!("--chunks must be greater than 0.");
+    }
+    if let Some(0) = args.flag_kb_size {
+        return fail_incorrectusage_clierror!("--kb-size must be greater than 0.");
+    }
+
+    // --filter-cleanup and --filter-ignore-errors only make sense with --filter
+    if args.flag_filter.is_none() && (args.flag_filter_cleanup || args.flag_filter_ignore_errors) {
+        return fail_incorrectusage_clierror!(
+            "--filter-cleanup and --filter-ignore-errors require --filter to be set."
+        );
     }
 
     // check if outdir is set correctly
@@ -215,71 +228,74 @@ impl Args {
         let header_byte_size = if self.flag_no_headers {
             0
         } else {
-            let mut headerbuf_wtr = csv::WriterBuilder::new().from_writer(vec![]);
+            let mut headerbuf_wtr = csv::WriterBuilder::new().from_writer(Vec::with_capacity(256));
             headerbuf_wtr.write_byte_record(&headers)?;
 
-            // safety: we know the inner vec is valid
+            // safety: vec writer cannot fail to flush/finalize
             headerbuf_wtr.into_inner().unwrap().len()
         };
 
-        let mut wtr = self.new_writer(&headers, 0, self.flag_pad)?;
-        let mut i = 0;
-        let mut num_chunks = 0;
-        let mut chunk_start = 0; // Track the start index of current chunk
-        let mut row = csv::ByteRecord::new();
         let chunk_size_bytes = chunk_size * 1024;
-        let mut chunk_size_bytes_left = chunk_size_bytes - header_byte_size;
+        if chunk_size_bytes <= header_byte_size {
+            return fail_incorrectusage_clierror!(
+                "--kb-size {chunk_size}KB ({chunk_size_bytes} bytes) is too small to fit the \
+                 header row ({header_byte_size} bytes). Increase --kb-size or use --no-headers."
+            );
+        }
 
-        let mut not_empty = rdr.read_byte_record(&mut row)?;
-        let mut curr_size_bytes;
-        let mut next_size_bytes;
-        wtr.write_byte_record(&row)?;
+        let mut wtr = self.new_writer(&headers, 0, self.flag_pad)?;
+        let mut i: usize = 0; // total data rows processed
+        let mut num_chunks: usize = 1; // we always create chunk 0
+        let mut chunk_start: usize = 0;
+        let mut chunk_used_bytes = header_byte_size;
 
-        while not_empty {
-            let mut buf_curr_wtr = csv::WriterBuilder::new().from_writer(vec![]);
-            buf_curr_wtr.write_byte_record(&row)?;
+        let mut row = csv::ByteRecord::new();
+        // Reusable buffer to measure CSV-encoded row sizes without allocating per row.
+        let mut measure_buf: Vec<u8> = Vec::with_capacity(256);
 
-            curr_size_bytes = buf_curr_wtr.into_inner().unwrap().len();
-
-            not_empty = rdr.read_byte_record(&mut row)?;
-            next_size_bytes = if not_empty {
-                let mut buf_next_wtr = csv::WriterBuilder::new().from_writer(vec![]);
-                buf_next_wtr.write_byte_record(&row)?;
-
-                buf_next_wtr.into_inner().unwrap().len()
-            } else {
-                0
+        while rdr.read_byte_record(&mut row)? {
+            // Measure the CSV-encoded size of `row` using a reusable buffer.
+            let row_size = {
+                measure_buf.clear();
+                let mut m = csv::WriterBuilder::new().from_writer(&mut measure_buf);
+                m.write_byte_record(&row)?;
+                m.flush()?;
+                drop(m);
+                measure_buf.len()
             };
 
-            if curr_size_bytes + next_size_bytes >= chunk_size_bytes_left {
+            // Roll over if adding this row would exceed the budget. Always allow
+            // at least one data row per chunk (otherwise an oversized row would
+            // loop forever with empty chunks).
+            if chunk_used_bytes + row_size > chunk_size_bytes && chunk_used_bytes > header_byte_size
+            {
                 wtr.flush()?;
-                // Run filter command if specified
                 if self.flag_filter.is_some() {
                     self.run_filter_command(chunk_start, self.flag_pad)?;
                 }
-                chunk_start = i; // Set start index for next chunk
+                chunk_start = i;
                 wtr = self.new_writer(&headers, i, self.flag_pad)?;
-                chunk_size_bytes_left = chunk_size_bytes - header_byte_size;
+                chunk_used_bytes = header_byte_size;
                 num_chunks += 1;
             }
-            if next_size_bytes > 0 {
-                wtr.write_byte_record(&row)?;
-                chunk_size_bytes_left -= curr_size_bytes;
-                i += 1;
-            }
+
+            wtr.write_byte_record(&row)?;
+            chunk_used_bytes += row_size;
+            i += 1;
         }
         wtr.flush()?;
-        // Run filter command for the last chunk if specified
-        if self.flag_filter.is_some() {
+        // Run filter for the final chunk only if it actually received data rows.
+        if self.flag_filter.is_some() && i > 0 {
             self.run_filter_command(chunk_start, self.flag_pad)?;
         }
 
         if !self.flag_quiet {
             eprintln!(
-                "Wrote chunk/s to '{}'. Size/chunk: <= {}KB; Num chunks: {}",
+                "Wrote {} chunk/s to '{}'. Size/chunk: <= {}KB; Num records: {}",
+                num_chunks,
                 dunce::canonicalize(Path::new(&self.arg_outdir))?.display(),
                 chunk_size,
-                num_chunks + 1
+                i
             );
         }
 
@@ -321,8 +337,10 @@ impl Args {
             i += 1;
         }
         wtr.flush()?;
-        // Run filter command for the last chunk if specified
-        if self.flag_filter.is_some() {
+        // Run filter command for the last chunk if specified.
+        // Skip when input had zero data rows: the unconditional new_writer above
+        // already created (an empty) `0.csv`, but `i == 0` would underflow below.
+        if self.flag_filter.is_some() && i > 0 {
             // Calculate the start index for the last chunk
             let last_chunk_start = ((i - 1) / chunk_size) * chunk_size;
             self.run_filter_command(last_chunk_start, self.flag_pad)?;
@@ -361,41 +379,35 @@ impl Args {
 
         util::njobs(self.flag_jobs);
 
-        // safety: we cannot use ? here because we're in a closure
-        (0..nchunks).into_par_iter().for_each(|i| {
-            let conf = self.rconfig();
-            // safety: safe to unwrap because we know the file is indexed
-            let mut idx = conf.indexed().unwrap().unwrap();
-            // safety: the only way this can fail is if the file first row of the chunk
-            // is not a valid CSV record, which is impossible because we're reading
-            // from a file with a valid index
-            let headers = idx.byte_headers().unwrap();
+        // Each worker writes its chunk independently; errors from any worker
+        // short-circuit the whole operation via try_for_each.
+        (0..nchunks)
+            .into_par_iter()
+            .try_for_each(|i| -> CliResult<()> {
+                let conf = self.rconfig();
+                // safety: indexed() returned Some at the call site; the index is
+                // guaranteed to exist because parallel_split is only entered when
+                // the caller observed a valid index. A failed re-open here is a
+                // genuine I/O error and should propagate.
+                let mut idx = conf.indexed()?.ok_or_else(|| {
+                    crate::CliError::Other("indexed CSV vanished during parallel split".to_string())
+                })?;
+                let headers = idx.byte_headers()?;
 
-            let mut wtr = self
-                // safety: the only way this can fail is if we cannot create a file
-                .new_writer(headers, i * chunk_size, self.flag_pad)
-                .unwrap();
+                let mut wtr = self.new_writer(headers, i * chunk_size, self.flag_pad)?;
 
-            // safety: we know that there is more than one chunk, so we can safely
-            // seek to the start of the chunk
-            idx.seek((i * chunk_size) as u64).unwrap();
-            let mut write_row;
-            for row in idx.byte_records().take(chunk_size) {
-                write_row = row.unwrap();
-                wtr.write_byte_record(&write_row).unwrap();
-            }
-            // safety: safe to unwrap because we know the writer is a file
-            // the only way this can fail is if we cannot write to the file
-            wtr.flush().unwrap();
-
-            // Run filter command if specified
-            if self.flag_filter.is_some() {
-                // We can't use ? here because we're in a closure
-                if let Err(e) = self.run_filter_command(i * chunk_size, self.flag_pad) {
-                    eprintln!("Error running filter command: {e}");
+                idx.seek((i * chunk_size) as u64)?;
+                for row in idx.byte_records().take(chunk_size) {
+                    let write_row = row?;
+                    wtr.write_byte_record(&write_row)?;
                 }
-            }
-        });
+                wtr.flush()?;
+
+                if self.flag_filter.is_some() {
+                    self.run_filter_command(i * chunk_size, self.flag_pad)?;
+                }
+                Ok(())
+            })?;
 
         if !self.flag_quiet {
             eprintln!(
@@ -475,13 +487,15 @@ impl Args {
                 },
             };
 
-            // Execute the command using the appropriate shell based on platform
+            // Execute the command using the appropriate shell based on platform.
+            // On Windows we pass the entire command as a single argument to `cmd /C`
+            // so that quoted arguments containing spaces are preserved (a previous
+            // implementation split on whitespace, which corrupted such commands).
             let status = if cfg!(windows) {
                 debug!("Running Windows command: cmd /C {cmd}");
-                let cmd_vec = cmd.split(' ').collect::<Vec<&str>>();
                 Command::new("cmd")
                     .arg("/C")
-                    .args(&cmd_vec)
+                    .arg(&cmd)
                     .current_dir(&canonical_outdir)
                     .env("FILE", path_str)
                     .status()

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -225,20 +225,42 @@ impl Args {
         let mut rdr = rconfig.reader()?;
         let headers = rdr.byte_headers()?.clone();
 
-        // Helper: measure the CSV-encoded byte length of a record using the same
-        // writer settings that `new_writer` will use on disk. We go through
-        // `Config::from_writer` so that any future tweak to Config's quoting,
-        // terminator, or delimiter stays consistent between measurement and the
-        // produced chunk file. (BOM bytes, when QSV_OUTPUT_BOM is set, are
-        // emitted by both paths and cancel out for budget purposes — at worst
-        // they cause slightly earlier rollover, never an over-the-budget chunk.)
-        let measure_record = |record: &csv::ByteRecord| -> CliResult<usize> {
-            let mut buf: Vec<u8> = Vec::with_capacity(256);
-            let mut m = Config::new(None).from_writer(&mut buf);
+        // Build a representative chunk path (chunk-0) so the measurement Config
+        // resolves the same extension-driven settings as `new_writer` (e.g. a
+        // `--filename foo_{}.tsv` template uses tab delimiters). This way the
+        // budget tracker and the on-disk writer agree on per-record bytes even
+        // when the user picks a non-CSV extension or relies on extension-based
+        // sniffing.
+        let sample_chunk_path = Path::new(&self.arg_outdir)
+            .join(
+                self.flag_filename
+                    .filename(&format!("{:0>width$}", 0, width = self.flag_pad)),
+            )
+            .display()
+            .to_string();
+        let measure_cfg = Config::new(Some(&sample_chunk_path));
+
+        // `Config::from_writer` writes a UTF-8 BOM at writer construction when
+        // QSV_OUTPUT_BOM is set. The real chunk writer emits that BOM exactly
+        // once per file, so subtract it from each per-record measurement and
+        // re-add it once below when initializing per-chunk byte usage.
+        const UTF8_BOM_LEN: usize = 3;
+        let bom_overhead = if util::get_envvar_flag("QSV_OUTPUT_BOM") {
+            UTF8_BOM_LEN
+        } else {
+            0
+        };
+
+        // Single helper used for both header and per-row measurement. Reuses
+        // one buffer to avoid allocating per row.
+        let mut measure_buf: Vec<u8> = Vec::with_capacity(256);
+        let mut measure_record = |record: &csv::ByteRecord| -> CliResult<usize> {
+            measure_buf.clear();
+            let mut m = measure_cfg.from_writer(&mut measure_buf);
             m.write_byte_record(record)?;
             m.flush()?;
             drop(m);
-            Ok(buf.len())
+            Ok(measure_buf.len().saturating_sub(bom_overhead))
         };
 
         let header_byte_size = if self.flag_no_headers {
@@ -248,7 +270,9 @@ impl Args {
         };
 
         let chunk_size_bytes = chunk_size * 1024;
-        if chunk_size_bytes <= header_byte_size {
+        // Each chunk file actually contains: [BOM?] + header + rows.
+        let per_chunk_fixed_overhead = bom_overhead + header_byte_size;
+        if chunk_size_bytes <= per_chunk_fixed_overhead {
             return fail_incorrectusage_clierror!(
                 "--kb-size {chunk_size}KB ({chunk_size_bytes} bytes) is too small to fit the \
                  header row ({header_byte_size} bytes). Increase --kb-size or use --no-headers."
@@ -261,21 +285,11 @@ impl Args {
         let mut i: usize = 0; // total data rows processed
         let mut num_chunks: usize = 0;
         let mut chunk_start: usize = 0;
-        let mut chunk_used_bytes = header_byte_size;
+        let mut chunk_used_bytes = per_chunk_fixed_overhead;
         let mut row = csv::ByteRecord::new();
-        // Per-row measurement buffer reused between reads.
-        let mut measure_buf: Vec<u8> = Vec::with_capacity(256);
 
         while rdr.read_byte_record(&mut row)? {
-            // Measure the CSV-encoded size of `row` using the shared writer settings.
-            let row_size = {
-                measure_buf.clear();
-                let mut m = Config::new(None).from_writer(&mut measure_buf);
-                m.write_byte_record(&row)?;
-                m.flush()?;
-                drop(m);
-                measure_buf.len()
-            };
+            let row_size = measure_record(&row)?;
 
             let need_new_chunk = match &wtr {
                 None => true,
@@ -284,7 +298,7 @@ impl Args {
                 // single row would loop forever with empty chunks).
                 Some(_) => {
                     chunk_used_bytes + row_size > chunk_size_bytes
-                        && chunk_used_bytes > header_byte_size
+                        && chunk_used_bytes > per_chunk_fixed_overhead
                 },
             };
 
@@ -297,7 +311,7 @@ impl Args {
                     chunk_start = i;
                 }
                 wtr = Some(self.new_writer(&headers, chunk_start, self.flag_pad)?);
-                chunk_used_bytes = header_byte_size;
+                chunk_used_bytes = per_chunk_fixed_overhead;
                 num_chunks += 1;
             }
 

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -790,18 +790,19 @@ fn split_kbsize_boston_5k() {
         .arg(test_file);
     wrk.run(&mut cmd);
 
-    assert!(wrk.path("0.csv").exists());
-    assert!(wrk.path("11.csv").exists());
-    assert!(wrk.path("19.csv").exists());
-    assert!(wrk.path("27.csv").exists());
-    assert!(wrk.path("36.csv").exists());
-    assert!(wrk.path("45.csv").exists());
-    assert!(wrk.path("52.csv").exists());
-    assert!(wrk.path("61.csv").exists());
-    assert!(wrk.path("70.csv").exists());
-    assert!(wrk.path("78.csv").exists());
-    assert!(wrk.path("86.csv").exists());
-    assert!(wrk.path("95.csv").exists());
+    let chunks = [
+        "0", "12", "21", "30", "40", "49", "58", "68", "77", "86", "96",
+    ];
+    for stem in chunks {
+        let p = wrk.path(&format!("{stem}.csv"));
+        assert!(p.exists(), "expected chunk {stem}.csv to exist");
+        // Each chunk must respect the 5KB (5120 byte) budget.
+        let len = std::fs::metadata(&p).unwrap().len();
+        assert!(
+            len <= 5 * 1024,
+            "chunk {stem}.csv is {len} bytes; exceeds 5KB"
+        );
+    }
 }
 
 #[test]
@@ -818,17 +819,16 @@ fn split_kbsize_boston_5k_padded() {
     wrk.run(&mut cmd);
 
     assert!(wrk.path("testme-000.csv").exists());
-    assert!(wrk.path("testme-011.csv").exists());
-    assert!(wrk.path("testme-019.csv").exists());
-    assert!(wrk.path("testme-027.csv").exists());
-    assert!(wrk.path("testme-036.csv").exists());
-    assert!(wrk.path("testme-045.csv").exists());
-    assert!(wrk.path("testme-052.csv").exists());
-    assert!(wrk.path("testme-061.csv").exists());
-    assert!(wrk.path("testme-070.csv").exists());
-    assert!(wrk.path("testme-078.csv").exists());
+    assert!(wrk.path("testme-012.csv").exists());
+    assert!(wrk.path("testme-021.csv").exists());
+    assert!(wrk.path("testme-030.csv").exists());
+    assert!(wrk.path("testme-040.csv").exists());
+    assert!(wrk.path("testme-049.csv").exists());
+    assert!(wrk.path("testme-058.csv").exists());
+    assert!(wrk.path("testme-068.csv").exists());
+    assert!(wrk.path("testme-077.csv").exists());
     assert!(wrk.path("testme-086.csv").exists());
-    assert!(wrk.path("testme-095.csv").exists());
+    assert!(wrk.path("testme-096.csv").exists());
 }
 
 #[test]
@@ -844,16 +844,15 @@ fn split_kbsize_boston_5k_no_headers() {
     wrk.run(&mut cmd);
 
     assert!(wrk.path("0.csv").exists());
-    assert!(wrk.path("12.csv").exists());
-    assert!(wrk.path("21.csv").exists());
-    assert!(wrk.path("29.csv").exists());
-    assert!(wrk.path("39.csv").exists());
-    assert!(wrk.path("48.csv").exists());
-    assert!(wrk.path("56.csv").exists());
-    assert!(wrk.path("66.csv").exists());
-    assert!(wrk.path("76.csv").exists());
-    assert!(wrk.path("84.csv").exists());
-    assert!(wrk.path("93.csv").exists());
+    assert!(wrk.path("13.csv").exists());
+    assert!(wrk.path("22.csv").exists());
+    assert!(wrk.path("31.csv").exists());
+    assert!(wrk.path("42.csv").exists());
+    assert!(wrk.path("51.csv").exists());
+    assert!(wrk.path("61.csv").exists());
+    assert!(wrk.path("72.csv").exists());
+    assert!(wrk.path("82.csv").exists());
+    assert!(wrk.path("92.csv").exists());
 }
 
 #[test]
@@ -1133,15 +1132,15 @@ fn split_filter_with_kb_size() {
     wrk.assert_success(&mut cmd);
     // Check that at least some of the original files were created
     assert!(wrk.path("0.csv").exists());
-    assert!(wrk.path("11.csv").exists());
+    assert!(wrk.path("12.csv").exists());
 
     // Check that at least some of the filtered files were created
     assert!(wrk.path("0.bak").exists());
-    assert!(wrk.path("11.bak").exists());
+    assert!(wrk.path("12.bak").exists());
 
     // Verify the content of the filtered files matches the original files
     split_eq!(wrk, "0.bak", wrk.from_str::<String>(&wrk.path("0.csv")));
-    split_eq!(wrk, "11.bak", wrk.from_str::<String>(&wrk.path("11.csv")));
+    split_eq!(wrk, "12.bak", wrk.from_str::<String>(&wrk.path("12.csv")));
 }
 
 #[test]
@@ -1658,4 +1657,202 @@ id,name,value
 99,item_99,value_99
 "
     );
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for review fixes:
+//   B1 — `--chunks 0` rejected on indexed inputs.
+//   B2 — empty input + `--filter` no longer underflows in sequential split.
+//   B3 — `--kb-size` with header larger than the budget returns a clean error.
+//   B4 — kb-size chunks always stay within the budget, even with variable row sizes.
+//   U1 — `--filter-cleanup` / `--filter-ignore-errors` require `--filter`.
+//   U2 — `--kb-size 0` rejected.
+//   U3 — empty input no longer creates a phantom kb-size chunk.
+//   B5/U-extra — multi-word filter commands are passed verbatim to the shell.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn split_chunks_zero_rejected() {
+    // Regression: parallel_split previously divided by zero; both code paths
+    // (sequential and parallel) must reject `--chunks 0`.
+    let wrk = Workdir::new("split_chunks_zero_rejected");
+    wrk.create("in.csv", data(true));
+
+    let mut cmd = wrk.command("split");
+    cmd.args(["--chunks", "0"])
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.assert_err(&mut cmd);
+
+    // also exercise the indexed path
+    wrk.create_indexed("in_idx.csv", data(true));
+    let mut cmd = wrk.command("split");
+    cmd.args(["--chunks", "0"])
+        .arg(&wrk.path("."))
+        .arg("in_idx.csv");
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn split_kb_size_zero_rejected() {
+    let wrk = Workdir::new("split_kb_size_zero_rejected");
+    wrk.create("in.csv", data(true));
+
+    let mut cmd = wrk.command("split");
+    cmd.args(["--kb-size", "0"])
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn split_filter_cleanup_without_filter_rejected() {
+    // Regression: --filter-cleanup without --filter was silently ignored.
+    let wrk = Workdir::new("split_filter_cleanup_without_filter_rejected");
+    wrk.create("in.csv", data(true));
+
+    let mut cmd = wrk.command("split");
+    cmd.args(["--size", "2"])
+        .arg("--filter-cleanup")
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.assert_err(&mut cmd);
+
+    let mut cmd2 = wrk.command("split");
+    cmd2.args(["--size", "2"])
+        .arg("--filter-ignore-errors")
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.assert_err(&mut cmd2);
+}
+
+#[test]
+fn split_kb_size_header_too_large_rejected() {
+    // Regression: header larger than --kb-size used to underflow the budget.
+    let wrk = Workdir::new("split_kb_size_header_too_large_rejected");
+    let mut wide_header: Vec<String> = Vec::new();
+    for i in 0..400 {
+        wide_header.push(format!("col_{i:04}"));
+    }
+    let row: Vec<String> = (0..400).map(|i| format!("v{i:04}")).collect();
+    wrk.create("in.csv", vec![wide_header.clone(), row.clone(), row]);
+
+    // 1KB budget vs. ~3KB+ header should produce a clean error.
+    let mut cmd = wrk.command("split");
+    cmd.args(["--kb-size", "1"])
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+fn split_kb_size_variable_rows_under_budget() {
+    // Regression for B4: after a chunk rollover the budget tracker used the
+    // wrong row's size, which could allow chunks to over- or under-shoot the
+    // requested kb-size when row widths vary.  Build a CSV that mixes short
+    // and long rows so any miscount surfaces.
+    let wrk = Workdir::new("split_kb_size_variable_rows_under_budget");
+    let mut rows: Vec<Vec<String>> = vec![svec!["id", "payload"]];
+    for i in 0..200 {
+        // Alternate 50-byte and 800-byte payloads.
+        let payload = if i % 2 == 0 {
+            "x".repeat(50)
+        } else {
+            "y".repeat(800)
+        };
+        rows.push(vec![format!("{i}"), payload]);
+    }
+    wrk.create("in.csv", rows);
+
+    let mut cmd = wrk.command("split");
+    cmd.args(["--kb-size", "2"])
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.run(&mut cmd);
+
+    // Every chunk file must be within budget. Check every numeric-prefixed
+    // .csv file in the workdir (skip the input "in.csv").
+    let budget = 2 * 1024;
+    let mut chunks_seen = 0usize;
+    for entry in std::fs::read_dir(wrk.path(".")).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name == "in.csv" || !name.ends_with(".csv") {
+            continue;
+        }
+        let stem = name.trim_end_matches(".csv");
+        if stem.parse::<u64>().is_err() {
+            continue;
+        }
+        chunks_seen += 1;
+        let len = entry.metadata().unwrap().len();
+        assert!(
+            len <= budget,
+            "chunk {name} is {len} bytes; exceeds {budget}-byte budget"
+        );
+    }
+    assert!(
+        chunks_seen > 1,
+        "expected multiple chunks, got {chunks_seen}"
+    );
+}
+
+#[test]
+fn split_empty_input_sequential() {
+    // Regression for B2/U3: empty input plus --filter must not underflow.
+    let wrk = Workdir::new("split_empty_input_sequential");
+    wrk.create("in.csv", vec![svec!["h1", "h2"]]);
+
+    let mut cmd = wrk.command("split");
+    if cfg!(windows) {
+        cmd.args(["--size", "10"])
+            .arg("--filter")
+            .arg("copy /Y %FILE% {}.bak")
+            .arg(&wrk.path("."))
+            .arg("in.csv");
+    } else {
+        cmd.args(["--size", "10"])
+            .arg("--filter")
+            .arg("cp $FILE {}.bak")
+            .arg(&wrk.path("."))
+            .arg("in.csv");
+    }
+    wrk.run(&mut cmd);
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+fn split_empty_input_kb_size() {
+    let wrk = Workdir::new("split_empty_input_kb_size");
+    wrk.create("in.csv", vec![svec!["h1", "h2"]]);
+
+    let mut cmd = wrk.command("split");
+    cmd.args(["--kb-size", "5"])
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.run(&mut cmd);
+    wrk.assert_success(&mut cmd);
+    // The first chunk is created (empty body) so the path exists, but we don't
+    // create a phantom second chunk — and the run must not error.
+    assert!(wrk.path("0.csv").exists());
+}
+
+#[test]
+#[cfg(not(windows))]
+fn split_filter_multiword_command() {
+    // Regression for B5: even on Unix, ensure that filter commands containing
+    // multiple words and shell metacharacters survive the round-trip.
+    let wrk = Workdir::new("split_filter_multiword_command");
+    wrk.create("in.csv", data(true));
+
+    let mut cmd = wrk.command("split");
+    cmd.args(["--size", "2"])
+        .arg("--filter")
+        .arg("sh -c 'cp \"$FILE\" \"$FILE.bak\"'")
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.run(&mut cmd);
+    wrk.assert_success(&mut cmd);
+    assert!(wrk.path("0.csv.bak").exists());
 }

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -1833,9 +1833,8 @@ fn split_empty_input_kb_size() {
         .arg("in.csv");
     wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
-    // The first chunk is created (empty body) so the path exists, but we don't
-    // create a phantom second chunk — and the run must not error.
-    assert!(wrk.path("0.csv").exists());
+    // Empty input must produce zero chunks (no phantom header-only file).
+    assert!(!wrk.path("0.csv").exists());
 }
 
 #[test]
@@ -1855,4 +1854,27 @@ fn split_filter_multiword_command() {
     wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     assert!(wrk.path("0.csv.bak").exists());
+}
+
+#[test]
+#[cfg(windows)]
+fn split_filter_multiword_command_windows() {
+    // Regression for B5 on Windows: previously the command was split on spaces
+    // before being handed to `cmd /C`, breaking quoted arguments. Use a quoted
+    // destination path with an embedded space to assert it survives intact.
+    let wrk = Workdir::new("split_filter_multiword_command_windows");
+    wrk.create("in.csv", data(true));
+
+    // The destination filename ("name with space.bak") contains a literal
+    // space inside a quoted argument; the pre-fix code would split on this
+    // space and copy to the wrong path.
+    let mut cmd = wrk.command("split");
+    cmd.args(["--size", "2"])
+        .arg("--filter")
+        .arg("copy /Y %FILE% \"name with space.bak\"")
+        .arg(&wrk.path("."))
+        .arg("in.csv");
+    wrk.run(&mut cmd);
+    wrk.assert_success(&mut cmd);
+    assert!(wrk.path("name with space.bak").exists());
 }

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -1718,12 +1718,12 @@ fn split_filter_cleanup_without_filter_rejected() {
         .arg("in.csv");
     wrk.assert_err(&mut cmd);
 
-    let mut cmd2 = wrk.command("split");
-    cmd2.args(["--size", "2"])
+    let mut cmd_2 = wrk.command("split");
+    cmd_2.args(["--size", "2"])
         .arg("--filter-ignore-errors")
         .arg(&wrk.path("."))
         .arg("in.csv");
-    wrk.assert_err(&mut cmd2);
+    wrk.assert_err(&mut cmd_2);
 }
 
 #[test]

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -1819,7 +1819,6 @@ fn split_empty_input_sequential() {
             .arg(&wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
 }
 
@@ -1832,7 +1831,6 @@ fn split_empty_input_kb_size() {
     cmd.args(["--kb-size", "5"])
         .arg(&wrk.path("."))
         .arg("in.csv");
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     // Empty input must produce zero chunks (no phantom header-only file).
     assert!(!wrk.path("0.csv").exists());
@@ -1852,7 +1850,6 @@ fn split_filter_multiword_command() {
         .arg("sh -c 'cp \"$FILE\" \"$FILE.bak\"'")
         .arg(&wrk.path("."))
         .arg("in.csv");
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     assert!(wrk.path("0.csv.bak").exists());
 }
@@ -1875,7 +1872,6 @@ fn split_filter_multiword_command_windows() {
         .arg("copy /Y %FILE% \"name with space.bak\"")
         .arg(&wrk.path("."))
         .arg("in.csv");
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     assert!(wrk.path("name with space.bak").exists());
 }

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -1719,7 +1719,8 @@ fn split_filter_cleanup_without_filter_rejected() {
     wrk.assert_err(&mut cmd);
 
     let mut cmd_2 = wrk.command("split");
-    cmd_2.args(["--size", "2"])
+    cmd_2
+        .args(["--size", "2"])
         .arg("--filter-ignore-errors")
         .arg(&wrk.path("."))
         .arg("in.csv");


### PR DESCRIPTION
## Summary

Review-driven cleanup of `qsv split` covering kb-size correctness, parallel error propagation, Windows `--filter` quoting, and argument validation, plus 9 new regression tests.

### Correctness fixes

- **kb-size** (`split_by_kb_size`)
  - Reject early when the header row is larger than `--kb-size * 1024` (previously underflowed `usize` and silently produced a single oversized chunk in release / panicked in debug).
  - Track per-chunk usage directly so the chunk after a rollover is charged its own row's size, not the previous chunk's last row. Chunks now reliably stay within budget across variable-width rows.
  - Measure CSV-encoded sizes through `Config::from_writer` — the same path `new_writer` uses on disk — so any future divergence in delimiter/quote-style/terminator stays consistent between the budget tracker and the produced files.
  - Open chunk files lazily so empty input produces 0 chunks instead of a phantom header-only `0.csv`.
- **`--chunks 0`** is now rejected up-front (the indexed/parallel path used to divide by zero).
- **`--kb-size 0`** is rejected up-front.
- **`--filter-cleanup` / `--filter-ignore-errors`** without `--filter` is rejected (was silently ignored).
- **`sequential_split`** no longer underflows `i - 1` when running `--filter` on a zero-row input.

### Error propagation & robustness

- **`parallel_split`** switched to `try_for_each` returning `CliResult<()>`; the six panicking `.unwrap()` calls and the misleading `// safety:` comments are gone, replaced with honest `?` propagation.
- **Windows `--filter`** now passes the full command string to `cmd /C` as a single argument, so quoted arguments containing spaces survive (the previous `cmd.split(' ')` corrupted them).

### Style / docs

- Removed the dead `use dunce;` import.
- Reworded misleading USAGE doc examples for `--chunks`.
- Regenerated `docs/help/split.md` from the updated USAGE.

### Tests added

9 new regression tests in `tests/test_split.rs`:
- `split_chunks_zero_rejected` (sequential + indexed) — `--chunks 0` validation
- `split_kb_size_zero_rejected` — `--kb-size 0` validation
- `split_filter_cleanup_without_filter_rejected` — flag dependency validation
- `split_kb_size_header_too_large_rejected` — header > budget error path
- `split_kb_size_variable_rows_under_budget` — asserts every chunk ≤ budget under variable row sizes
- `split_empty_input_sequential` — empty input + `--filter` no longer underflows
- `split_empty_input_kb_size` — asserts no phantom `0.csv` is produced
- `split_filter_multiword_command` (Unix) — multi-word filter survives round-trip
- `split_filter_multiword_command_windows` (Windows-only) — quoted destination with embedded space, the actual platform where the splitting bug lived

`boston311-100.csv` kb-size boundary expectations were updated to reflect the corrected budget tracking; one of those tests now also asserts every chunk is within the 5KB budget.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo test --locked -F all_features test_split::` — **44 passed, 0 failed** (was 36)
- [x] `cargo clippy --locked -F all_features` — clean for `src/cmd/split.rs`
- [ ] Windows CI runner exercises `split_filter_multiword_command_windows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)