### PR TITLE
transpose: review-driven correctness, perf cleanup, and polish

### DIFF
--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -272,7 +272,15 @@ impl Args {
         // No `.populate()` here on purpose — `--multipass` exists to avoid loading
         // the whole dataset into memory, so we let the OS page in lazily.
         let file = File::open(self.arg_input.as_ref().unwrap())?;
-        // safety: caller ensured we have a file input (input_is_stdin == false).
+        // safety: `run()` only routes here when `input_is_stdin == false`, so
+        // `arg_input` names an on-disk file that can be memory-mapped. The
+        // `file` binding stays in scope for the rest of this function and all
+        // uses of `mmap` are confined to the same scope, so the file handle
+        // outlives the mapping. We open the file read-only and only ever read
+        // from `&mmap[..]` to feed CSV parsers across passes — this command
+        // does not mutate or truncate the file. As with any file-backed mmap,
+        // soundness still relies on no other process concurrently truncating
+        // or otherwise mutating the file while the mapping is live.
         let mmap = unsafe { MmapOptions::new().map(&file)? };
 
         let rconfig = self.rconfig();

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -45,7 +45,7 @@ transpose options:
                            Output format is three columns:
                            field, attribute, value. Empty values are skipped.
                            Mutually exclusive with --multipass.
-                           
+
                            The <selection> argument is REQUIRED when using --long,
                            it specifies which column(s) to use as the "field" identifier.
                            It uses the same selection syntax as 'qsv select':
@@ -120,6 +120,21 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 }
 
 impl Args {
+    /// Resolve --select against the given header record.
+    /// Returns Ok(None) when --select was not specified.
+    fn parse_select(&self, headers: &ByteRecord) -> CliResult<Option<Vec<usize>>> {
+        let Some(ref sel) = self.flag_select else {
+            return Ok(None);
+        };
+        let selection = sel
+            .selection(headers, true)
+            .map_err(|e| CliError::Other(format!("--select error: {e}")))?;
+        if selection.is_empty() {
+            return fail_incorrectusage_clierror!("--select resulted in no columns to transpose.");
+        }
+        Ok(Some(selection.iter().copied().collect()))
+    }
+
     fn wide_to_long(&self) -> CliResult<()> {
         let mut rdr = Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
@@ -127,49 +142,37 @@ impl Args {
             .reader()?;
         let mut wtr = self.wconfig().writer()?;
 
-        // Read headers
         let headers = rdr.byte_headers()?.clone();
         if headers.is_empty() {
             return fail_incorrectusage_clierror!("CSV file must have at least one column.");
         }
 
-        // Determine which columns to use as field columns
-        let field_column_indices: Vec<usize> = if let Some(ref selection_str) = self.flag_long {
-            let select_cols = SelectColumns::parse(selection_str)
-                .map_err(|e| CliError::Other(format!("Invalid column selection: {e}")))?;
-            let selection = select_cols
-                .selection(&headers, true)
-                .map_err(|e| CliError::Other(format!("Column selection error: {e}")))?;
-            if selection.is_empty() {
+        // --long is required by docopt; defensively report a usage error if absent.
+        let selection_str = match self.flag_long.as_deref() {
+            Some(s) => s,
+            None => {
                 return fail_incorrectusage_clierror!(
-                    "Column selection resulted in no columns. At least one field column is \
-                     required."
+                    "--long requires a column selection argument."
                 );
-            }
-            selection.iter().copied().collect()
-        } else {
-            unreachable!("Should not happen as docopt --long <selection> is required.");
+            },
         };
-
-        // Create a set of field column indices for efficient lookup
+        let select_cols = SelectColumns::parse(selection_str)
+            .map_err(|e| CliError::Other(format!("--long parse error: {e}")))?;
+        let selection = select_cols
+            .selection(&headers, true)
+            .map_err(|e| CliError::Other(format!("--long selection error: {e}")))?;
+        if selection.is_empty() {
+            return fail_incorrectusage_clierror!(
+                "--long resulted in no columns. At least one field column is required."
+            );
+        }
+        let field_column_indices: Vec<usize> = selection.iter().copied().collect();
         let field_column_set: HashSet<usize> = field_column_indices.iter().copied().collect();
 
-        // Determine selected attribute columns if --select is specified
         // --select filters which columns become attribute rows (field columns are unaffected)
-        let selected_attribute_set: Option<HashSet<usize>> = if let Some(ref sel) = self.flag_select
-        {
-            let selection = sel
-                .selection(&headers, true)
-                .map_err(|e| CliError::Other(format!("Column selection error: {e}")))?;
-            if selection.is_empty() {
-                return fail_incorrectusage_clierror!(
-                    "--select resulted in no columns to transpose."
-                );
-            }
-            Some(selection.iter().copied().collect())
-        } else {
-            None
-        };
+        let selected_attribute_set: Option<HashSet<usize>> = self
+            .parse_select(&headers)?
+            .map(|v| v.into_iter().collect());
 
         // Write output headers
         let mut header_record = ByteRecord::with_capacity(64, 3);
@@ -178,59 +181,48 @@ impl Args {
         header_record.push_field(b"value");
         wtr.write_byte_record(&header_record)?;
 
-        // Process each record in a streaming fashion to avoid loading all records into memory
+        // Reusable buffers (allocated once, reused per row).
+        let multi_field = field_column_indices.len() > 1;
+        let mut field_buf: Vec<u8> = Vec::with_capacity(256);
         let mut output_record = ByteRecord::with_capacity(256, 3);
-        for result in rdr.byte_records() {
-            let record = result?;
-            if record.is_empty() {
-                continue;
-            }
+        let mut data_record = ByteRecord::new();
 
-            // Build the field value (concatenated if multiple columns)
-            let field_bytes: Vec<u8> = if field_column_indices.len() == 1 {
-                // Single field column - use directly
-                let idx = field_column_indices[0];
-                if idx < record.len() {
-                    record[idx].to_vec()
-                } else {
-                    Vec::new()
-                }
-            } else {
-                // Multiple field columns - concatenate with | separator
-                let mut concatenated = Vec::new();
+        while rdr.read_byte_record(&mut data_record)? {
+            // Build the field key — borrow the slice for the single-column case to
+            // avoid an allocation per row; concatenate into a reused buffer otherwise.
+            let field_slice: &[u8] = if multi_field {
+                field_buf.clear();
                 for (i, &idx) in field_column_indices.iter().enumerate() {
                     if i > 0 {
-                        concatenated.push(b'|');
+                        field_buf.push(b'|');
                     }
-                    if idx < record.len() {
-                        concatenated.extend_from_slice(&record[idx]);
+                    if let Some(v) = data_record.get(idx) {
+                        field_buf.extend_from_slice(v);
                     }
                 }
-                concatenated
+                &field_buf
+            } else {
+                data_record.get(field_column_indices[0]).unwrap_or(b"")
             };
 
             // Iterate through all columns, skipping field columns and non-selected columns
             for (i, attribute_header) in headers.iter().enumerate() {
-                // Skip if this is a field column
                 if field_column_set.contains(&i) {
                     continue;
                 }
-                // Skip if --select is specified and this column is not in the selection
                 if let Some(ref sel_set) = selected_attribute_set
                     && !sel_set.contains(&i)
                 {
                     continue;
                 }
-                if i < record.len() {
-                    let value = &record[i];
-                    // Skip empty values
-                    if !value.is_empty() {
-                        output_record.clear();
-                        output_record.push_field(&field_bytes);
-                        output_record.push_field(attribute_header);
-                        output_record.push_field(value);
-                        wtr.write_byte_record(&output_record)?;
-                    }
+                if let Some(value) = data_record.get(i)
+                    && !value.is_empty()
+                {
+                    output_record.clear();
+                    output_record.push_field(field_slice);
+                    output_record.push_field(attribute_header);
+                    output_record.push_field(value);
+                    wtr.write_byte_record(&output_record)?;
                 }
             }
         }
@@ -247,20 +239,20 @@ impl Args {
             return self.multipass_transpose_streaming();
         }
 
-        // Get selected column indices if --select is specified
-        let selected_indices = self.get_selected_indices()?;
-
         let mut rdr = self.rconfig().reader()?;
         let mut wtr = self.wconfig().writer()?;
-        let nrows = rdr.byte_headers()?.len();
 
+        // The reader is configured with no_headers(true), so the first record IS the
+        // input CSV's header row — we need it to participate in the transpose AND to
+        // resolve --select by column name. Collect everything once.
         let all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;
+        let ncols = all.first().map_or(0, ByteRecord::len);
 
-        // Determine which column indices to transpose
-        let indices: Vec<usize> = match &selected_indices {
-            Some(sel) => sel.clone(),
-            None => (0..nrows).collect(),
-        };
+        let empty_rec = ByteRecord::new();
+        let headers_for_select = all.first().unwrap_or(&empty_rec);
+        let indices: Vec<usize> = self
+            .parse_select(headers_for_select)?
+            .unwrap_or_else(|| (0..ncols).collect());
 
         let mut record = ByteRecord::with_capacity(1024, all.len());
         for i in indices {
@@ -276,34 +268,37 @@ impl Args {
     }
 
     fn multipass_transpose_streaming(&self) -> CliResult<()> {
-        // Get selected column indices if --select is specified
-        let selected_indices = self.get_selected_indices()?;
-
-        // Get the number of columns from the first row
-        let nrows = self.rconfig().reader()?.byte_headers()?.len();
-
-        // Determine which column indices to transpose
-        let indices: Vec<usize> = match &selected_indices {
-            Some(sel) => sel.clone(),
-            None => (0..nrows).collect(),
-        };
-
-        // Memory map the file for efficient access
+        // Memory map the file for efficient cross-pass access.
+        // No `.populate()` here on purpose — `--multipass` exists to avoid loading
+        // the whole dataset into memory, so we let the OS page in lazily.
         let file = File::open(self.arg_input.as_ref().unwrap())?;
-        // safety: we know we have a file input at this stage
-        let mmap = unsafe { MmapOptions::new().populate().map(&file)? };
-        let mut wtr = self.wconfig().writer()?;
+        // safety: caller ensured we have a file input (input_is_stdin == false).
+        let mmap = unsafe { MmapOptions::new().map(&file)? };
 
-        let mut record = ByteRecord::with_capacity(1024, nrows);
+        let rconfig = self.rconfig();
+
+        // Read the first record to determine column count & resolve --select. This
+        // also serves as the header row for name-based selection.
+        let mut header_rdr = rconfig.from_reader(&mmap[..]);
+        let mut headers = ByteRecord::new();
+        let _ = header_rdr.read_byte_record(&mut headers)?;
+        let ncols = headers.len();
+        drop(header_rdr);
+
+        let indices: Vec<usize> = self
+            .parse_select(&headers)?
+            .unwrap_or_else(|| (0..ncols).collect());
+
+        let mut wtr = self.wconfig().writer()?;
+        let mut record = ByteRecord::with_capacity(1024, ncols);
 
         for i in indices {
             record.clear();
 
-            // Create a reader from the memory-mapped data
-            // this is more efficient for large files as we reduce I/O
-            let mut rdr = self.rconfig().from_reader(&mmap[..]);
-
-            // Read all rows for this column
+            // Restart parsing of the mmap'd CSV for this output column.
+            // The mmap stays mapped across passes, so we get page-cache locality
+            // rather than re-reading bytes from disk.
+            let mut rdr = rconfig.from_reader(&mmap[..]);
             for row in rdr.byte_records() {
                 let row = row?;
                 if i < row.len() {
@@ -316,31 +311,9 @@ impl Args {
         Ok(wtr.flush()?)
     }
 
-    /// Compute which column indices should be transposed based on the --select flag.
-    /// Returns None if no selection was specified (meaning all columns).
-    fn get_selected_indices(&self) -> CliResult<Option<Vec<usize>>> {
-        if let Some(ref sel) = self.flag_select {
-            // Read headers with no_headers(false) to get actual column names
-            let mut rdr = Config::new(self.arg_input.as_ref())
-                .delimiter(self.flag_delimiter)
-                .no_headers(false)
-                .reader()?;
-            let headers = rdr.byte_headers()?.clone();
-            let selection = sel
-                .selection(&headers, true)
-                .map_err(|e| CliError::Other(format!("Column selection error: {e}")))?;
-            if selection.is_empty() {
-                return fail_incorrectusage_clierror!(
-                    "--select resulted in no columns to transpose."
-                );
-            }
-            Ok(Some(selection.iter().copied().collect()))
-        } else {
-            Ok(None)
-        }
-    }
-
     fn wconfig(&self) -> Config {
+        // Wide rows after transpose can be very large; bump the write buffer
+        // to amortize syscalls.
         Config::new(self.flag_output.as_ref()).set_write_buffer(DEFAULT_WTR_BUFFER_CAPACITY * 20)
     }
 

--- a/tests/test_transpose.rs
+++ b/tests/test_transpose.rs
@@ -824,9 +824,11 @@ fn transpose_long_format_stdin() {
 
     let mut child = cmd.spawn().unwrap();
     let mut stdin = child.stdin.take().unwrap();
-    std::thread::spawn(move || {
-        stdin.write_all(stdin_data.as_bytes()).unwrap();
-    });
+    // Small payload — write on the current thread and drop stdin to signal EOF
+    // to the child. (Avoid a detached writer thread that could panic on
+    // BrokenPipe and complicate failure diagnosis.)
+    stdin.write_all(stdin_data.as_bytes()).unwrap();
+    drop(stdin);
     let output = child.wait_with_output().unwrap();
     assert!(output.status.success());
 

--- a/tests/test_transpose.rs
+++ b/tests/test_transpose.rs
@@ -458,7 +458,7 @@ fn transpose_long_format_no_columns_selected() {
 
     // Verify the error message mentions no columns selected
     let stderr: String = wrk.output_stderr(&mut cmd);
-    let expected = "Column selection error: Selector regex '^nonexistent' does not match any \
+    let expected = "--long selection error: Selector regex '^nonexistent' does not match any \
                     columns in the CSV header.\n";
     assert_eq!(stderr, expected);
 }
@@ -774,6 +774,71 @@ fn transpose_select_single_column() {
     let expected = vec![svec!["b", "2", "5"]];
 
     wrk.assert_success(&mut cmd);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn transpose_long_format_mixed_empty_values() {
+    // Verifies that empty values are skipped *selectively* — non-empty values
+    // on the same row still emit output rows.
+    let wrk = Workdir::new("transpose_long_format_mixed_empty_values");
+
+    let wide_format = vec![
+        svec!["field", "type", "sum", "min", "max"],
+        svec!["name", "String", "", "Alice", ""],
+        svec!["age", "", "104", "", "53"],
+    ];
+
+    wrk.create("in.csv", wide_format);
+
+    let mut cmd = wrk.command("transpose");
+    cmd.args(["--long", "1"]).arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    let expected = vec![
+        svec!["field", "attribute", "value"],
+        svec!["name", "type", "String"],
+        svec!["name", "min", "Alice"],
+        svec!["age", "sum", "104"],
+        svec!["age", "max", "53"],
+    ];
+
+    wrk.assert_success(&mut cmd);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn transpose_long_format_stdin() {
+    // --long mode should work with stdin input.
+    use std::io::Write;
+
+    let wrk = Workdir::new("transpose_long_format_stdin");
+
+    let stdin_data = "field,type,sum,min\nname,String,,Alice\nage,Integer,104,6\n";
+
+    let mut cmd = wrk.command("transpose");
+    cmd.args(["--long", "1"]).arg("-");
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    std::thread::spawn(move || {
+        stdin.write_all(stdin_data.as_bytes()).unwrap();
+    });
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+
+    let got = String::from_utf8_lossy(&output.stdout);
+    let expected = concat!(
+        "field,attribute,value\n",
+        "name,type,String\n",
+        "name,min,Alice\n",
+        "age,type,Integer\n",
+        "age,sum,104\n",
+        "age,min,6\n",
+    );
     assert_eq!(got, expected);
 }
 


### PR DESCRIPTION
## Summary

Code review of `src/cmd/transpose.rs` surfaced one correctness/semantics bug, several perf improvements, and a few clarity wins. All changes land in one PR per review.

**Higher-severity:**
- **Drop `mmap.populate()` in `--multipass`** — `populate()` prefaults every page of the input into RAM, which directly contradicts `--multipass`'s purpose (low memory for big files). Lazy paging is what we want.
- **Hoist `rconfig` out of the per-column multipass loop** and rewrite the misleading "reduce I/O" comment (the actual win is page-cache locality across passes).
- **Single file open per invocation** — eliminate the second `no_headers(false)` reader that was used purely to fetch column names for `--select`. The first record of the data reader already holds the column names; use it directly. `get_selected_indices()` is removed, replaced by a small `parse_select(&headers)` helper shared across all three modes (`wide_to_long`, `in_memory_transpose`, `multipass_transpose_streaming`).
- **Rename `nrows` → `ncols`** in transpose paths — the variable holds the input column count (which becomes the row count *after* transpose). Confusing inside the pre-transpose reader scope.

**Medium:**
- **Reuse `Vec<u8>` field buffer** in `wide_to_long` for the multi-field concatenation case; for the single-field case, borrow the slice directly without copying. Was allocating per-row before.
- **Unify error wrapping** for `--long` / `--select` parse failures (was mixing two different prefixes).
- **Replace `unreachable!` with `fail_incorrectusage_clierror!`** in `wide_to_long` so a future refactor that drops the docopt `<selection>` requirement won't panic.

**Tests:**
- Add `transpose_long_format_stdin` — `--long` works with stdin input (was untested).
- Add `transpose_long_format_mixed_empty_values` — verifies empty-value-skipping is selective (per-cell, not per-row).
- Update `transpose_long_format_no_columns_selected` expected error string to match the unified prefix.

`tests/test_transpose.rs`: 32 tests, all pass.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo t test_transpose -F all_features` — 32 passed, 0 failed
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` — clean
- [x] Smoke: `qsv transpose`, `qsv transpose --multipass`, `qsv transpose --select 2-3` on `resources/test/adur-public-toilets-valid.csv` — output identical across modes
- [x] Smoke: `printf 'a,b,c\n1,2,3\n4,5,6\n' | qsv transpose --long 1` — produces correct long-format output

🤖 Generated with [Claude Code](https://claude.com/claude-code)