### PR TITLE
blake3: check-mode interop fixes and parser polish

### DIFF
--- a/src/cmd/blake3.rs
+++ b/src/cmd/blake3.rs
@@ -308,8 +308,11 @@ fn parse_standard_line(line: &str) -> CliResult<(String, String)> {
 
 /// Parse a BSD-style tag line: `BLAKE3 (filename) = hash`
 fn parse_tag_line(line: &str) -> CliResult<(String, String)> {
-    // Caller already verified the `BLAKE3 (` prefix, so strip_prefix cannot fail here.
-    let rest = &line["BLAKE3 (".len()..];
+    // Caller (check_mode) gates on `line.starts_with("BLAKE3 (")` before
+    // dispatching here, so this strip_prefix is infallible by contract.
+    let rest = line
+        .strip_prefix("BLAKE3 (")
+        .expect("parse_tag_line: caller must verify BLAKE3 ( prefix");
     if let Some((filename, hash)) = rest.rsplit_once(") = ") {
         Ok((hash.to_string(), filename.to_string()))
     } else {

--- a/src/cmd/blake3.rs
+++ b/src/cmd/blake3.rs
@@ -266,7 +266,7 @@ fn check_mode(
                 bytes_to_hex(&buf)
             };
 
-            if actual_hex == expected_hash {
+            if actual_hex.eq_ignore_ascii_case(&expected_hash) {
                 if !args.flag_quiet {
                     writeln!(output_writer, "{filename}: OK")?;
                 }
@@ -292,22 +292,24 @@ fn check_mode(
     Ok(())
 }
 
-/// Parse a standard checksum line: `hash  filename`
+/// Parse a standard checksum line: `hash  filename` (text mode)
+/// or `hash *filename` (binary mode, single space + asterisk).
 fn parse_standard_line(line: &str) -> CliResult<(String, String)> {
-    // Split on two spaces (standard b3sum format)
+    // Text mode: two spaces between hash and filename (standard b3sum format).
     if let Some((hash, filename)) = line.split_once("  ") {
-        Ok((hash.to_string(), filename.to_string()))
-    } else {
-        fail_clierror!("Invalid checksum line: {line}")
+        return Ok((hash.to_string(), filename.to_string()));
     }
+    // Binary mode: single space + asterisk-prefixed filename.
+    if let Some((hash, filename)) = line.split_once(" *") {
+        return Ok((hash.to_string(), filename.to_string()));
+    }
+    fail_clierror!("Invalid checksum line: {line}")
 }
 
 /// Parse a BSD-style tag line: `BLAKE3 (filename) = hash`
 fn parse_tag_line(line: &str) -> CliResult<(String, String)> {
-    // Format: BLAKE3 (filename) = hash
-    let rest = line
-        .strip_prefix("BLAKE3 (")
-        .ok_or_else(|| CliError::Other(format!("Invalid tag line: {line}")))?;
+    // Caller already verified the `BLAKE3 (` prefix, so strip_prefix cannot fail here.
+    let rest = &line["BLAKE3 (".len()..];
     if let Some((filename, hash)) = rest.rsplit_once(") = ") {
         Ok((hash.to_string(), filename.to_string()))
     } else {

--- a/tests/test_blake3.rs
+++ b/tests/test_blake3.rs
@@ -400,3 +400,78 @@ fn blake3_check_invalid_hex() {
 
     wrk.assert_err(&mut cmd);
 }
+
+#[test]
+fn blake3_check_uppercase_hex() {
+    // Checksum file containing uppercase hex must verify OK; the comparison
+    // is ASCII-case-insensitive so files produced by tools that emit
+    // uppercase hashes still round-trip.
+    let wrk = Workdir::new("blake3_check_uppercase_hex");
+    wrk.create_from_string("hello.txt", "hello");
+
+    // Generate the (lowercase) checksum first, then uppercase the hash half.
+    let mut cmd = wrk.command("blake3");
+    cmd.arg(wrk.path("hello.txt"));
+    let checksum_line: String = wrk.stdout(&mut cmd);
+    let (hash, rest) = checksum_line.split_once("  ").expect("two-space separator");
+    let upper_line = format!("{}  {}", hash.to_uppercase(), rest);
+
+    let checksum_path = wrk.path("checksums.txt");
+    fs::write(&checksum_path, format!("{upper_line}\n")).unwrap();
+
+    let mut cmd = wrk.command("blake3");
+    cmd.arg("--check").arg(&checksum_path);
+
+    let got: String = wrk.stdout(&mut cmd);
+    assert!(
+        got.contains("OK"),
+        "uppercase hex should verify OK, got: {got}"
+    );
+}
+
+#[test]
+fn blake3_check_binary_mode_separator() {
+    // `<hash> *<filename>` (single space + asterisk) is the standard *sum
+    // binary-mode separator; check_mode must accept it alongside the
+    // two-space text-mode separator.
+    let wrk = Workdir::new("blake3_check_binary_mode_separator");
+    wrk.create_from_string("hello.txt", "hello");
+
+    // Generate the checksum (text-mode default), then rewrite to binary mode.
+    let mut cmd = wrk.command("blake3");
+    cmd.arg(wrk.path("hello.txt"));
+    let checksum_line: String = wrk.stdout(&mut cmd);
+    let (hash, filename) = checksum_line.split_once("  ").expect("two-space separator");
+    let binary_line = format!("{hash} *{filename}");
+
+    let checksum_path = wrk.path("checksums.txt");
+    fs::write(&checksum_path, format!("{binary_line}\n")).unwrap();
+
+    let mut cmd = wrk.command("blake3");
+    cmd.arg("--check").arg(&checksum_path);
+
+    let got: String = wrk.stdout(&mut cmd);
+    assert!(
+        got.contains("OK"),
+        "binary-mode separator should verify OK, got: {got}"
+    );
+}
+
+#[test]
+fn blake3_check_malformed_separator() {
+    // A line that is neither `<hash>  <filename>` (two spaces) nor
+    // `<hash> *<filename>` (single space + asterisk) must error.
+    let wrk = Workdir::new("blake3_check_malformed_separator");
+    wrk.create_from_string("hello.txt", "hello");
+
+    // 64-char valid hex but with a single plain space (no asterisk) — neither format.
+    let checksum_path = wrk.path("checksums.txt");
+    let hash = "a".repeat(64);
+    let hello_path = wrk.path("hello.txt").to_string_lossy().to_string();
+    fs::write(&checksum_path, format!("{hash} {hello_path}\n")).unwrap();
+
+    let mut cmd = wrk.command("blake3");
+    cmd.arg("--check").arg(&checksum_path);
+
+    wrk.assert_err(&mut cmd);
+}


### PR DESCRIPTION
## Summary
- `check_mode`: compare hashes with `eq_ignore_ascii_case` so checksum files containing uppercase hex verify correctly (matches blake3's `Hash::from_hex` case-tolerant parsing).
- `parse_standard_line`: also accept the standard `*sum` binary-mode `<hash> *<filename>` separator alongside the text-mode two-space form for interop with files produced by other tooling.
- `parse_tag_line`: make the caller-side `BLAKE3 (` prefix invariant explicit via `strip_prefix(...).expect(...)` and use `fail_clierror!` consistently for the single failure path.
- Tests: added uppercase-hex round-trip, binary-mode separator round-trip, and malformed-separator error coverage.

## Test plan
- [x] `cargo test blake3 -F all_features` — 23/23 pass (3 new + 20 existing)
- [x] `cargo clippy --bin qsv -F all_features --no-deps -- -D warnings` — clean
- [x] roborev review #1802 addressed and closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)