### PR TITLE
clipboard: review-driven cleanup, fix .unwrap() panics and surface error details

### DIFF
--- a/src/cmd/clipboard.rs
+++ b/src/cmd/clipboard.rs
@@ -59,12 +59,10 @@ impl From<arboard::Error> for CliError {
                  incompatible format to the requested one."
                     .to_string(),
             ),
-            arboard::Error::Unknown { description: _ } => CliError::Other(
-                "An unknown error occurred while attempting to use the clipboard.".to_string(),
-            ),
-            _ => CliError::Other(
-                "An unexpected error occurred while using the clipboard.".to_string(),
-            ),
+            arboard::Error::Unknown { description } => CliError::Other(format!(
+                "An unknown error occurred while attempting to use the clipboard: {description}"
+            )),
+            other => CliError::Other(format!("Unexpected clipboard error: {other}")),
         }
     }
 }
@@ -75,9 +73,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if args.flag_save {
         let mut buffer = String::new();
         std::io::stdin().read_to_string(&mut buffer)?;
-        clipboard.set_text(buffer).unwrap();
+        clipboard.set_text(buffer)?;
     } else {
-        print!("{}", clipboard.get_text().unwrap());
+        print!("{}", clipboard.get_text()?);
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` on `Clipboard::set_text` / `Clipboard::get_text` with `?` so user-reachable failures (empty clipboard → `ContentNotAvailable`, `ClipboardOccupied`, `ConversionFailure`) route through the existing `From<arboard::Error> for CliError` impl with friendly messages instead of panicking the binary.
- Bind `arboard::Error::Unknown { description }` and include the OS-supplied description in the message — previously discarded as `_`, losing the only info the catch-all variant carries.
- Replace the `_ =>` wildcard arm with `other =>` and format via `arboard::Error`'s `Display` impl. The arm is still required (`arboard::Error` is `#[non_exhaustive]`), but now any future variant degrades gracefully with library-supplied detail instead of a generic "unexpected error" string.

## Test plan
- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings`
- [x] `cargo t -F all_features clipboard` — `test_clipboard::clipboard_success` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)