### PR TITLE
edit: review-driven fixes for --in-place, bounds checks, and silent no-ops

### DIFF
--- a/docs/help/edit.md
+++ b/docs/help/edit.md
@@ -52,7 +52,7 @@ qsv edit --help
 
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
-| &nbsp;`‑i,`<br>`‑‑in‑place`&nbsp; | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. |  |
+| &nbsp;`‑i,`<br>`‑‑in‑place`&nbsp; | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. If the .bak file already exists, the command errors instead of overwriting it. |  |
 
 <a name="common-options"></a>
 

--- a/docs/help/edit.md
+++ b/docs/help/edit.md
@@ -52,7 +52,7 @@ qsv edit --help
 
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
-| &nbsp;`‑i,`<br>`‑‑in‑place`&nbsp; | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. If the .bak file already exists, the command errors instead of overwriting it. |  |
+| &nbsp;`‑i,`<br>`‑‑in‑place`&nbsp; | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. If the .bak file already exists, the command errors instead of overwriting it. Symlinks are rejected; pass the resolved path instead. |  |
 
 <a name="common-options"></a>
 

--- a/docs/help/edit.md
+++ b/docs/help/edit.md
@@ -52,7 +52,7 @@ qsv edit --help
 
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
-| &nbsp;`‑i,`<br>`‑‑in‑place`&nbsp; | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. If the .bak file already exists, the command errors instead of overwriting it. Symlinks are rejected; pass the resolved path instead. |  |
+| &nbsp;`‑i,`<br>`‑‑in‑place`&nbsp; | flag | Overwrite the input file data with the output. The input file is renamed to a .bak file in the same directory. If the .bak file already exists, the command errors instead of overwriting it. Symbolic links are rejected; pass the resolved path instead. (Other Windows reparse points such as junction points are not detected.) |  |
 
 <a name="common-options"></a>
 

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -41,6 +41,7 @@ edit options:
     -i, --in-place         Overwrite the input file data with the output.
                            The input file is renamed to a .bak file in the same directory.
                            If the .bak file already exists, the command errors instead of overwriting it.
+                           Symlinks are rejected; pass the resolved path instead.
 
 Common options:
     -h, --help             Display this message
@@ -76,17 +77,40 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let value = args.arg_value;
     let no_headers = args.flag_no_headers;
 
-    // --in-place needs a real on-disk path; reject stdin / unset input early.
-    if in_place && !matches!(input.as_deref(), Some(p) if p != "-") {
-        return fail_clierror!("--in-place requires an input file path (stdin is not supported).");
-    }
+    // --in-place needs a real, non-symlink on-disk path. Validate up front so
+    // we don't create a tempfile or do any work for an obviously-bad request.
+    let in_place_path = if in_place {
+        let p = match input.as_deref() {
+            Some(p) if p != "-" => std::path::PathBuf::from(p),
+            _ => {
+                return fail_clierror!(
+                    "--in-place requires an input file path (stdin is not supported).",
+                );
+            },
+        };
+        let metadata = std::fs::symlink_metadata(&p)?;
+        if metadata.file_type().is_symlink() {
+            return fail_clierror!(
+                "--in-place does not support symlinks; pass the resolved path instead.",
+            );
+        }
+        Some(p)
+    } else {
+        None
+    };
 
     // Build the CSV reader and iterate over each record.
     let conf = Config::new(input.as_ref()).no_headers(true);
     let mut rdr = conf.reader()?;
 
-    let mut tempfile = if in_place {
-        Some(NamedTempFile::new()?)
+    // Place the in-place tempfile in the same directory as the input so the
+    // final persist is a same-filesystem rename (atomic and fast).
+    let mut tempfile = if let Some(p) = in_place_path.as_ref() {
+        let parent = p
+            .parent()
+            .filter(|d| !d.as_os_str().is_empty())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        Some(NamedTempFile::new_in(parent)?)
     } else {
         None
     };
@@ -146,16 +170,20 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // the input to .bak and replace it with an unchanged copy). For stdout/output
     // mode, warn but still emit the unchanged CSV so callers piping output get a
     // valid pass-through with exit 0.
-    if let (Some(tempfile), Some(input_path_string)) = (tempfile, input) {
+    if let (Some(tempfile), Some(input_path)) = (tempfile, in_place_path) {
         if !row_matched {
             return fail_clierror!("Row {row} not found.");
         }
-        let input_path = std::path::Path::new(&input_path_string);
         let backup_path = input_path.with_added_extension("bak");
-        // Atomically reserve the backup path via hard_link so a concurrent
+        // Atomically reserve the backup path with create_new so a concurrent
         // process can't slip in between an existence check and the rename.
-        match std::fs::hard_link(input_path, &backup_path) {
-            Ok(()) => {},
+        // Works on any filesystem (unlike hard_link, which fails on FAT/SMB).
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&backup_path)
+        {
+            Ok(_) => {},
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 return fail_clierror!(
                     "Backup file {} already exists; refusing to overwrite.",
@@ -164,8 +192,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             },
             Err(e) => return Err(e.into()),
         }
-        std::fs::remove_file(input_path)?;
-        std::fs::copy(tempfile.path(), input_path)?;
+        // Move input over our placeholder. std::fs::rename replaces the
+        // destination on all platforms.
+        std::fs::rename(&input_path, &backup_path)?;
+        // Persist the edited tempfile to input_path. Since the tempfile lives
+        // in the same directory as the input, this is an atomic same-fs rename
+        // — no window where input_path is missing.
+        tempfile.persist(&input_path).map_err(|e| e.error)?;
     } else if !row_matched {
         eprintln!("Warning: row {row} not found; input passed through unchanged.");
     }

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -199,17 +199,29 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // Persist the edited tempfile to input_path. Since the tempfile lives
         // in the same directory as the input, this is an atomic same-fs rename.
         // The window between this and the rename above is two same-dir rename
-        // syscalls — much smaller than the prior copy, but not zero.
+        // syscalls — much smaller than the prior copy, but not zero. We accept
+        // the small window rather than copy-then-persist (which would halve
+        // throughput on every successful edit by doubling disk I/O); the only
+        // loser is a concurrent reader hitting ENOENT.
+        // NOTE: the rollback branch below is not covered by an automated test
+        // — reliably forcing tempfile.persist to fail after a successful rename
+        // requires platform-specific filesystem manipulation.
         if let Err(e) = tempfile.persist(&input_path) {
             // Best-effort rollback: restore the original from the backup we
             // just took, so the user isn't left without input_path.
-            let _ = std::fs::rename(&backup_path, &input_path);
+            let recovery = match std::fs::rename(&backup_path, &input_path) {
+                Ok(()) => format!("original restored from {}", backup_path.display()),
+                Err(rollback_err) => format!(
+                    "rollback also failed ({}); original remains at {}",
+                    rollback_err,
+                    backup_path.display()
+                ),
+            };
             return fail_clierror!(
-                "Failed to install edited file at {}: {}. Backup at {} (restored if rollback \
-                 succeeded).",
+                "Failed to install edited file at {}: {}. {}.",
                 input_path.display(),
                 e.error,
-                backup_path.display()
+                recovery
             );
         }
     } else if !row_matched {

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -193,8 +193,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             },
             Err(e) => return Err(e.into()),
         }
-        // Move input over our placeholder. std::fs::rename replaces the
-        // destination on all platforms.
+        // Move input over our placeholder. std::fs::rename is documented to
+        // replace the destination on all platforms (per std docs: "This
+        // function will replace the destination file if it already exists.").
+        // On Windows, this is backed by FileRenameInfoEx on supported
+        // filesystems and by MoveFileEx with REPLACE_EXISTING otherwise — the
+        // only case rename refuses to overwrite is directory-on-directory,
+        // which doesn't apply here since our placeholder is a regular file.
         std::fs::rename(&input_path, &backup_path)?;
         // Persist the edited tempfile to input_path. Since the tempfile lives
         // in the same directory as the input, this is an atomic same-fs rename.

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -152,16 +152,22 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
         let input_path = std::path::Path::new(&input_path_string);
         let backup_path = input_path.with_added_extension("bak");
-        if backup_path.exists() {
-            return fail_clierror!(
-                "Backup file {} already exists; refusing to overwrite.",
-                backup_path.display()
-            );
+        // Atomically reserve the backup path via hard_link so a concurrent
+        // process can't slip in between an existence check and the rename.
+        match std::fs::hard_link(input_path, &backup_path) {
+            Ok(()) => {},
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                return fail_clierror!(
+                    "Backup file {} already exists; refusing to overwrite.",
+                    backup_path.display()
+                );
+            },
+            Err(e) => return Err(e.into()),
         }
-        std::fs::rename(input_path, &backup_path)?;
+        std::fs::remove_file(input_path)?;
         std::fs::copy(tempfile.path(), input_path)?;
     } else if !row_matched {
-        eprintln!("Warning: row {row} not found; output is unchanged.");
+        eprintln!("Warning: row {row} not found; input passed through unchanged.");
     }
 
     Ok(())

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -33,9 +33,14 @@ edit arguments:
     row                    The cell's row index. Indices start from the first non-header row as 0.
     value                  The new value to replace the old cell content with.
 
+If <row> is out of range:
+  - in stdout/--output mode, the input is passed through unchanged with a warning on stderr.
+  - in --in-place mode, the command errors and the input file is left untouched.
+
 edit options:
     -i, --in-place         Overwrite the input file data with the output.
                            The input file is renamed to a .bak file in the same directory.
+                           If the .bak file already exists, the command errors instead of overwriting it.
 
 Common options:
     -h, --help             Display this message
@@ -112,7 +117,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut record = csv::ByteRecord::new();
     #[allow(clippy::bool_to_int_with_if)]
     let mut current_row: usize = if no_headers { 1 } else { 0 };
-    let target_row = row + 1;
+    let Some(target_row) = row.checked_add(1) else {
+        return fail_clierror!("Row index too large.");
+    };
     let mut row_matched = false;
     while rdr.read_byte_record(&mut record)? {
         if current_row == target_row {
@@ -132,17 +139,29 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         current_row += 1;
     }
 
-    if !row_matched {
-        return fail_clierror!("Row {row} not found.");
-    }
-
     wtr.flush()?;
     drop(wtr);
 
+    // For in-place edits, missing rows are a hard error (we don't want to rename
+    // the input to .bak and replace it with an unchanged copy). For stdout/output
+    // mode, warn but still emit the unchanged CSV so callers piping output get a
+    // valid pass-through with exit 0.
     if let (Some(tempfile), Some(input_path_string)) = (tempfile, input) {
+        if !row_matched {
+            return fail_clierror!("Row {row} not found.");
+        }
         let input_path = std::path::Path::new(&input_path_string);
-        std::fs::rename(input_path, input_path.with_added_extension("bak"))?;
+        let backup_path = input_path.with_added_extension("bak");
+        if backup_path.exists() {
+            return fail_clierror!(
+                "Backup file {} already exists; refusing to overwrite.",
+                backup_path.display()
+            );
+        }
+        std::fs::rename(input_path, &backup_path)?;
         std::fs::copy(tempfile.path(), input_path)?;
+    } else if !row_matched {
+        eprintln!("Warning: row {row} not found; output is unchanged.");
     }
 
     Ok(())

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -41,7 +41,8 @@ edit options:
     -i, --in-place         Overwrite the input file data with the output.
                            The input file is renamed to a .bak file in the same directory.
                            If the .bak file already exists, the command errors instead of overwriting it.
-                           Symlinks are rejected; pass the resolved path instead.
+                           Symbolic links are rejected; pass the resolved path instead.
+                           (Other Windows reparse points such as junction points are not detected.)
 
 Common options:
     -h, --help             Display this message
@@ -196,9 +197,21 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // destination on all platforms.
         std::fs::rename(&input_path, &backup_path)?;
         // Persist the edited tempfile to input_path. Since the tempfile lives
-        // in the same directory as the input, this is an atomic same-fs rename
-        // — no window where input_path is missing.
-        tempfile.persist(&input_path).map_err(|e| e.error)?;
+        // in the same directory as the input, this is an atomic same-fs rename.
+        // The window between this and the rename above is two same-dir rename
+        // syscalls — much smaller than the prior copy, but not zero.
+        if let Err(e) = tempfile.persist(&input_path) {
+            // Best-effort rollback: restore the original from the backup we
+            // just took, so the user isn't left without input_path.
+            let _ = std::fs::rename(&backup_path, &input_path);
+            return fail_clierror!(
+                "Failed to install edited file at {}: {}. Backup at {} (restored if rollback \
+                 succeeded).",
+                input_path.display(),
+                e.error,
+                backup_path.display()
+            );
+        }
     } else if !row_matched {
         eprintln!("Warning: row {row} not found; input passed through unchanged.");
     }

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -70,63 +70,79 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let in_place = args.flag_in_place;
     let value = args.arg_value;
     let no_headers = args.flag_no_headers;
-    let mut tempfile = NamedTempFile::new()?;
+
+    // --in-place needs a real on-disk path; reject stdin / unset input early.
+    if in_place && !matches!(input.as_deref(), Some(p) if p != "-") {
+        return fail_clierror!("--in-place requires an input file path (stdin is not supported).");
+    }
 
     // Build the CSV reader and iterate over each record.
     let conf = Config::new(input.as_ref()).no_headers(true);
     let mut rdr = conf.reader()?;
-    let mut wtr: Writer<Box<dyn std::io::Write>> = if in_place {
-        csv::Writer::from_writer(Box::new(tempfile.as_file_mut()))
+
+    let mut tempfile = if in_place {
+        Some(NamedTempFile::new()?)
+    } else {
+        None
+    };
+    let mut wtr: Writer<Box<dyn std::io::Write>> = if let Some(tf) = tempfile.as_mut() {
+        csv::Writer::from_writer(Box::new(tf.as_file_mut()))
     } else {
         Config::new(args.flag_output.as_ref()).writer()?
     };
 
     let headers = rdr.headers()?;
-    let mut column_index: Option<usize> = None;
-    if column == "_" {
-        column_index = Some(headers.len() - 1);
-    } else if let Ok(c) = column.parse::<usize>() {
-        column_index = Some(c);
-    } else {
-        for (i, header) in headers.iter().enumerate() {
-            if column.as_str() == header {
-                column_index = Some(i);
-                break;
-            }
+    let column_index: usize = if column == "_" {
+        match headers.len().checked_sub(1) {
+            Some(i) => i,
+            None => return fail_clierror!("Invalid column selected."),
         }
-    }
-    if column_index.is_none() {
-        return fail_clierror!("Invalid column selected.");
-    }
+    } else if let Ok(c) = column.parse::<usize>() {
+        if c >= headers.len() {
+            return fail_clierror!("Invalid column selected.");
+        }
+        c
+    } else {
+        match headers.iter().position(|h| column.as_str() == h) {
+            Some(i) => i,
+            None => return fail_clierror!("Invalid column selected."),
+        }
+    };
 
     let mut record = csv::ByteRecord::new();
     #[allow(clippy::bool_to_int_with_if)]
     let mut current_row: usize = if no_headers { 1 } else { 0 };
+    let target_row = row + 1;
+    let mut row_matched = false;
     while rdr.read_byte_record(&mut record)? {
-        if row + 1 == current_row {
-            for (current_col, field) in record.iter().enumerate() {
-                if column_index == Some(current_col) {
-                    wtr.write_field(&value)?;
+        if current_row == target_row {
+            row_matched = true;
+            let mut updated = csv::ByteRecord::new();
+            for (i, field) in record.iter().enumerate() {
+                if i == column_index {
+                    updated.push_field(value.as_bytes());
                 } else {
-                    wtr.write_field(field)?;
+                    updated.push_field(field);
                 }
             }
-            wtr.write_record(None::<&[u8]>)?;
+            wtr.write_byte_record(&updated)?;
         } else {
             wtr.write_byte_record(&record)?;
         }
         current_row += 1;
     }
 
+    if !row_matched {
+        return fail_clierror!("Row {row} not found.");
+    }
+
     wtr.flush()?;
     drop(wtr);
 
-    if in_place && let Some(input_path_string) = input {
+    if let (Some(tempfile), Some(input_path_string)) = (tempfile, input) {
         let input_path = std::path::Path::new(&input_path_string);
-        if input_path.extension().is_some() {
-            std::fs::rename(input_path, input_path.with_added_extension("bak"))?;
-            std::fs::copy(tempfile.path(), input_path)?;
-        }
+        std::fs::rename(input_path, input_path.with_added_extension("bak"))?;
+        std::fs::copy(tempfile.path(), input_path)?;
     }
 
     Ok(())

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -226,6 +226,33 @@ fn edit_unknown_column_name_errors() {
     assert!(got_stderr.contains("Invalid column selected."));
 }
 
+#[cfg(unix)]
+#[test]
+fn edit_in_place_rejects_symlink() {
+    let wrk = Workdir::new("edit_in_place_rejects_symlink");
+    wrk.create(
+        "real.csv",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+    std::os::unix::fs::symlink(wrk.path("real.csv"), wrk.path("link.csv")).unwrap();
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("link.csv");
+    cmd.arg("number");
+    cmd.arg("0");
+    cmd.arg("3");
+    cmd.arg("--in-place");
+
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(got_stderr.contains("does not support symlinks"));
+
+    // real file untouched, no .bak created
+    let got_real = std::fs::read_to_string(wrk.path("real.csv")).unwrap();
+    assert_eq!(got_real, "letter,number\na,1\nb,2\n");
+    assert!(!wrk.path("real.csv.bak").exists());
+    assert!(!wrk.path("link.csv.bak").exists());
+}
+
 #[test]
 fn edit_in_place_existing_bak_errors() {
     let wrk = Workdir::new("edit_in_place_existing_bak_errors");

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -159,8 +159,8 @@ fn edit_in_place_rejects_stdin() {
 }
 
 #[test]
-fn edit_row_out_of_range_errors() {
-    let wrk = Workdir::new("edit_row_out_of_range_errors");
+fn edit_row_out_of_range_warns_on_stdout() {
+    let wrk = Workdir::new("edit_row_out_of_range_warns_on_stdout");
     wrk.create(
         "data.csv",
         vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
@@ -172,8 +172,82 @@ fn edit_row_out_of_range_errors() {
     cmd.arg("99");
     cmd.arg("3");
 
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "letter,number\na,1\nb,2".to_string();
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn edit_row_out_of_range_in_place_errors() {
+    let wrk = Workdir::new("edit_row_out_of_range_in_place_errors");
+    wrk.create(
+        "data.csv",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("data.csv");
+    cmd.arg("number");
+    cmd.arg("99");
+    cmd.arg("3");
+    cmd.arg("--in-place");
+
     let got_stderr = wrk.output_stderr(&mut cmd);
     assert!(got_stderr.contains("Row 99 not found"));
+
+    // input must be untouched and no .bak created
+    let test_file = wrk.path("data.csv");
+    let backup_file = wrk.path("data.csv.bak");
+    let got = std::fs::read_to_string(test_file).unwrap();
+    let expected = "letter,number\na,1\nb,2\n".to_string();
+    assert_eq!(got, expected);
+    assert!(!backup_file.exists());
+}
+
+#[test]
+fn edit_unknown_column_name_errors() {
+    let wrk = Workdir::new("edit_unknown_column_name_errors");
+    wrk.create(
+        "data.csv",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("data.csv");
+    cmd.arg("nonexistent");
+    cmd.arg("0");
+    cmd.arg("3");
+
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(got_stderr.contains("Invalid column selected."));
+}
+
+#[test]
+fn edit_in_place_existing_bak_errors() {
+    let wrk = Workdir::new("edit_in_place_existing_bak_errors");
+    wrk.create(
+        "data.csv",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+    // pre-existing backup
+    std::fs::write(wrk.path("data.csv.bak"), b"old backup\n").unwrap();
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("data.csv");
+    cmd.arg("number");
+    cmd.arg("0");
+    cmd.arg("3");
+    cmd.arg("--in-place");
+
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(got_stderr.contains("Backup file"));
+    assert!(got_stderr.contains("already exists"));
+
+    // input must be untouched and pre-existing .bak preserved
+    let got_input = std::fs::read_to_string(wrk.path("data.csv")).unwrap();
+    let got_backup = std::fs::read_to_string(wrk.path("data.csv.bak")).unwrap();
+    assert_eq!(got_input, "letter,number\na,1\nb,2\n");
+    assert_eq!(got_backup, "old backup\n");
 }
 
 #[test]

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -116,6 +116,85 @@ b,2"
 }
 
 #[test]
+fn edit_in_place_no_extension() {
+    let wrk = Workdir::new("edit_in_place_no_extension");
+    wrk.create(
+        "data",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+
+    let mut cmd = wrk.command("edit");
+    cmd.env("QSV_SKIP_FORMAT_CHECK", "1");
+    cmd.arg("data");
+    cmd.arg("number");
+    cmd.arg("0");
+    cmd.arg("3");
+    cmd.arg("--in-place");
+
+    cmd.output().unwrap();
+
+    let test_file = wrk.path("data");
+    let backup_file = wrk.path("data.bak");
+    let got = std::fs::read_to_string(test_file).unwrap();
+    let got_backup = std::fs::read_to_string(backup_file).unwrap();
+    let expected = "letter,number\na,3\nb,2\n".to_string();
+    let expected_backup = "letter,number\na,1\nb,2\n".to_string();
+    assert_eq!(got, expected);
+    assert_eq!(got_backup, expected_backup);
+}
+
+#[test]
+fn edit_in_place_rejects_stdin() {
+    let wrk = Workdir::new("edit_in_place_rejects_stdin");
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("-");
+    cmd.arg("0");
+    cmd.arg("0");
+    cmd.arg("x");
+    cmd.arg("--in-place");
+
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(got_stderr.contains("--in-place requires an input file path"));
+}
+
+#[test]
+fn edit_row_out_of_range_errors() {
+    let wrk = Workdir::new("edit_row_out_of_range_errors");
+    wrk.create(
+        "data.csv",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("data.csv");
+    cmd.arg("number");
+    cmd.arg("99");
+    cmd.arg("3");
+
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(got_stderr.contains("Row 99 not found"));
+}
+
+#[test]
+fn edit_column_index_out_of_range_errors() {
+    let wrk = Workdir::new("edit_column_index_out_of_range_errors");
+    wrk.create(
+        "data.csv",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("data.csv");
+    cmd.arg("99");
+    cmd.arg("0");
+    cmd.arg("3");
+
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(got_stderr.contains("Invalid column selected."));
+}
+
+#[test]
 fn edit_in_place() {
     let wrk = Workdir::new("edit_in_place");
     wrk.create(

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -172,6 +172,10 @@ fn edit_row_out_of_range_warns_on_stdout() {
     cmd.arg("99");
     cmd.arg("3");
 
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(got_stderr.contains("row 99 not found"));
+    assert!(got_stderr.contains("input passed through unchanged"));
+
     let got: String = wrk.stdout(&mut cmd);
     let expected = "letter,number\na,1\nb,2".to_string();
     assert_eq!(got, expected);


### PR DESCRIPTION
## Summary
- Fix `--in-place` silently dropping edits on extensionless files (vestigial `extension().is_some()` guard left over from the `with_extension` → `with_added_extension` refactor).
- Reject `--in-place` with stdin (`-`) or missing input rather than calling `std::fs::rename("-", "-.bak")`.
- Replace `headers.len() - 1` with `checked_sub(1)` so `column == "_"` on empty headers returns "Invalid column selected." instead of panicking.
- Numeric column index out of range and row index out of range now return clear errors instead of silently rewriting the file unchanged.
- Only allocate `NamedTempFile` when `--in-place` is actually set; build the target row via a single `ByteRecord` instead of a per-field write loop.

## Test plan
- [x] `cargo test test_edit -F all_features` (10/10 pass, including 4 new tests for extensionless in-place, stdin rejection, out-of-range row, out-of-range column index)
- [x] `cargo build --locked --bin qsv -F all_features` clean
- [x] `cargo clippy --bin qsv -F all_features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)