### PR TITLE
split: fix Windows --filter quoted-arg corruption via raw_arg

### DIFF
--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -127,6 +127,8 @@ Common options:
     -q, --quiet            Do not display an output summary to stderr.
 "#;
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::{fs, io, path::Path, process::Command};
 
 use log::debug;
@@ -529,18 +531,24 @@ impl Args {
             };
 
             // Execute the command using the appropriate shell based on platform.
-            // On Windows we pass the entire command as a single argument to `cmd /C`
-            // so that quoted arguments containing spaces are preserved (a previous
-            // implementation split on whitespace, which corrupted such commands).
-            let status = if cfg!(windows) {
+            // On Windows we hand the entire filter string to `cmd /C` via `raw_arg`
+            // so cmd.exe sees the literal command line. Using the cross-platform
+            // `arg` would let Rust apply CommandLineToArgvW escaping (wrapping the
+            // arg in quotes and back-slash-escaping inner quotes), which then
+            // corrupts cmd.exe's two-quote parsing for filters like
+            // `copy /Y %FILE% "name with space.bak"`.
+            #[cfg(windows)]
+            let status = {
                 debug!("Running Windows command: cmd /C {cmd}");
                 Command::new("cmd")
                     .arg("/C")
-                    .arg(&cmd)
+                    .raw_arg(&cmd)
                     .current_dir(&canonical_outdir)
                     .env("FILE", path_str)
                     .status()
-            } else {
+            };
+            #[cfg(not(windows))]
+            let status = {
                 debug!("Running Unix command: sh -c {cmd}");
                 Command::new("sh")
                     .arg("-c")


### PR DESCRIPTION
## Summary
- Windows CI ([run 25117323154](https://github.com/dathere/qsv/actions/runs/25117323154/job/73608098736)) fails on `test_split::split_filter_multiword_command_windows` — the regression test added in #3780 was exposing a real bug it was meant to guard against.
- Root cause: `run_filter_command` passed the whole filter string to `cmd /C` via cross-platform `Command::arg`. Rust's CommandLineToArgvW escaping wraps the string in quotes and backslash-escapes inner quotes, which collapses cmd.exe's two-quote parsing. For a filter like `copy /Y %FILE% "name with space.bak"`, copy.exe ends up seeing the destination split into three tokens (`"name`, `with`, `space.bak"`) and fails with "The system cannot find the path specified.".
- Fix: use `std::os::windows::process::CommandExt::raw_arg` so cmd.exe receives the literal command line. The `if cfg!(windows)` runtime branch is replaced with compile-time `#[cfg(windows)] / #[cfg(not(windows))]` blocks since `raw_arg` only exists on Windows.

## Test plan
- [x] `cargo build --locked --bin qsvlite -F lite` — clean
- [x] `cargo t split_filter -F lite` — all 13 Unix split_filter tests pass
- [x] `cargo clippy --locked -F lite --bin qsvlite` — no new warnings in split.rs
- [ ] CI: Windows Lite job runs `split_filter_multiword_command_windows` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)