### PR TITLE
extsort: review-driven error propagation and temp-file handle release

### DIFF
--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -136,7 +136,7 @@ fn sort_csv(
             return fail_incorrectusage_clierror!("extsort CSV mode requires an index");
         },
         Err(e) => {
-            return fail_incorrectusage_clierror!("extsort CSV mode requires an index: {e}");
+            return fail_clierror!("could not load index for extsort CSV mode: {e}");
         },
     };
 

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -172,14 +172,12 @@ fn sort_csv(
         writeln!(line_wtr, "{sort_key}|{:01$}", idx_position.line(), width)?;
     }
     line_wtr.flush()?;
-    // Drop the writer so its handle on the temp file is released before
-    // we re-open the same path for reading (Windows file-sharing safety).
     drop(line_wtr);
 
-    let line_rdr = io::BufReader::with_capacity(
-        RW_BUFFER_CAPACITY,
-        std::fs::File::open(linewtr_tfile.path())?,
-    );
+    // Re-open the temp file for reading via NamedTempFile::reopen() rather than
+    // File::open(path) so the read handle is obtained directly from tempfile —
+    // avoids any path-based race and is the idiomatic Windows-safe approach.
+    let line_rdr = io::BufReader::with_capacity(RW_BUFFER_CAPACITY, linewtr_tfile.reopen()?);
 
     let reverse_flag = args.flag_reverse;
     let compare = |a: &String, b: &String| {
@@ -209,7 +207,6 @@ fn sort_csv(
         sorted_line_wtr.write_all(format!("{item}\n").as_bytes())?;
     }
     sorted_line_wtr.flush()?;
-    // Drop the writer before re-opening the path for reading below.
     drop(sorted_line_wtr);
     // Delete the temporary file containing unsorted lines
     linewtr_tfile.close()?;
@@ -218,8 +215,7 @@ fn sort_csv(
     // and extracting the position from each line
     // and then using that to seek the input file to retrieve the record
     // and then write the record to the final sorted CSV
-    let sorted_lines = std::fs::File::open(sorted_tfile.path())?;
-    let sorted_line_rdr = io::BufReader::with_capacity(RW_BUFFER_CAPACITY, sorted_lines);
+    let sorted_line_rdr = io::BufReader::with_capacity(RW_BUFFER_CAPACITY, sorted_tfile.reopen()?);
 
     let mut sorted_csv_wtr = Config::new(args.arg_output.as_ref()).writer()?;
 

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -131,14 +131,12 @@ fn sort_csv(
         .select(args.flag_select.clone().unwrap());
 
     let mut idxfile = match rconfig.indexed() {
-        Ok(idx) => {
-            if idx.is_none() {
-                return fail_incorrectusage_clierror!("extsort CSV mode requires an index");
-            }
-            idx.unwrap()
-        },
-        _ => {
+        Ok(Some(idx)) => idx,
+        Ok(None) => {
             return fail_incorrectusage_clierror!("extsort CSV mode requires an index");
+        },
+        Err(e) => {
+            return fail_incorrectusage_clierror!("extsort CSV mode requires an index: {e}");
         },
     };
 
@@ -151,7 +149,6 @@ fn sort_csv(
     let sel = rconfig.selection(&headers)?;
 
     let mut sort_key = String::with_capacity(20);
-    let mut utf8_string = String::with_capacity(20);
     let mut curr_row = csv::ByteRecord::new();
 
     let rowcount = idxfile.count();
@@ -167,9 +164,7 @@ fn sort_csv(
             if let Ok(s_utf8) = simdutf8::basic::from_utf8(field) {
                 sort_key.push_str(s_utf8);
             } else {
-                utf8_string.clear();
-                utf8_string.push_str(&String::from_utf8_lossy(field));
-                sort_key.push_str(&utf8_string);
+                sort_key.push_str(&String::from_utf8_lossy(field));
             }
         }
         let idx_position = curr_row.position().unwrap();
@@ -177,6 +172,9 @@ fn sort_csv(
         writeln!(line_wtr, "{sort_key}|{:01$}", idx_position.line(), width)?;
     }
     line_wtr.flush()?;
+    // Drop the writer so its handle on the temp file is released before
+    // we re-open the same path for reading (Windows file-sharing safety).
+    drop(line_wtr);
 
     let line_rdr = io::BufReader::with_capacity(
         RW_BUFFER_CAPACITY,
@@ -204,12 +202,16 @@ fn sort_csv(
     let mut sorted_line_wtr =
         io::BufWriter::with_capacity(RW_BUFFER_CAPACITY, sorted_tfile.as_file());
 
-    for item in sorted.map(Result::unwrap) {
+    for item in sorted {
+        let item = item.map_err(|e| {
+            crate::clitypes::CliError::Other(format!("cannot read sorted item: {e}"))
+        })?;
         sorted_line_wtr.write_all(format!("{item}\n").as_bytes())?;
     }
     sorted_line_wtr.flush()?;
+    // Drop the writer before re-opening the path for reading below.
+    drop(sorted_line_wtr);
     // Delete the temporary file containing unsorted lines
-    drop(line_wtr);
     linewtr_tfile.close()?;
 
     // now write the sorted CSV file by reading the sorted_line temp file
@@ -231,10 +233,9 @@ fn sort_csv(
 
     // amortize allocations
     let mut record_wrk = csv::ByteRecord::new();
-    let mut line = String::new();
 
     for l in sorted_line_rdr.lines() {
-        line.clone_from(&l?);
+        let line = l?;
         let Ok(position) =
             atoi_simd::parse::<u64, false, false>(&line.as_bytes()[line.len() - width..])
         else {
@@ -246,7 +247,6 @@ fn sort_csv(
         sorted_csv_wtr.write_byte_record(&record_wrk)?;
     }
     sorted_csv_wtr.flush()?;
-    drop(sorted_line_wtr);
     sorted_tfile.close()?;
 
     Ok(())
@@ -316,7 +316,10 @@ fn sort_lines(
         output_wtr.write_all(format!("{}\n", header.trim_end()).as_bytes())?;
     }
 
-    for item in sorted.map(Result::unwrap) {
+    for item in sorted {
+        let item = item.map_err(|e| {
+            crate::clitypes::CliError::Other(format!("cannot read sorted item: {e}"))
+        })?;
         output_wtr.write_all(format!("{item}\n").as_bytes())?;
     }
     output_wtr.flush()?;


### PR DESCRIPTION
## Summary
- Replace catch-all `_` arm in `sort_csv`'s index check so genuine errors from `rconfig.indexed()` surface (`fail_clierror!` for I/O / index-load failures, `fail_incorrectusage_clierror!` reserved for the actual "no index" case).
- Stop unwrapping iterator results in `sort_csv` and `sort_lines` — propagate via `CliError::Other` so a merge-phase I/O failure no longer panics.
- Drop the temp-file writers before re-opening their paths for reading, matching qsv's Windows file-handle release pattern (per `project_windows_file_handle_release.md`).
- Minor cleanup: remove dead `utf8_string` intermediate buffer in the UTF-8 fallback and a redundant `String::clone_from` in the sorted-line read loop.

## Test plan
- [x] `cargo test extsort -F all_features` (all 3 tests pass)
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` clean
- [x] roborev review (job 1818) addressed: `Err(e)` arm now returns generic `CliError` rather than usage error
- [ ] Follow-up tracked locally in `.claude/plans/extsort-position-delta-fix.md` for an unrelated `position_delta` off-by-one discovered during review (out of scope for this PR — needs fixture regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)