### PR TITLE
pseudo: reject --increment 0, preserve last-valid-counter row on overflow

### DIFF
--- a/docs/help/pseudo.md
+++ b/docs/help/pseudo.md
@@ -80,7 +80,7 @@ qsv pseudo --help
 |--------|------|-------------|--------|
 | &nbsp;`‑h,`<br>`‑‑help`&nbsp; | flag | Display this message |  |
 | &nbsp;`‑‑start`&nbsp; | string | The starting number for the incremental identifier. | `0` |
-| &nbsp;`‑‑increment`&nbsp; | string | The increment for the incremental identifier. | `1` |
+| &nbsp;`‑‑increment`&nbsp; | string | The increment for the incremental identifier. Must be greater than 0. | `1` |
 | &nbsp;`‑‑formatstr`&nbsp; | string | The format string for the incremental identifier. The format string must contain a single "{}" which will be replaced with the incremental identifier. | `{}` |
 | &nbsp;`‑o,`<br>`‑‑output`&nbsp; | string | Write output to <file> instead of stdout. |  |
 | &nbsp;`‑n,`<br>`‑‑no‑headers`&nbsp; | flag | When set, the first row will not be interpreted as headers. |  |

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -96,6 +96,26 @@ type ValuesNum = HashMap<String, u64>;
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
+
+    // Validate usage-level flags before opening any reader/writer so usage
+    // errors don't emit partial output (e.g. CSV headers) on stdout.
+    let increment = args.flag_increment;
+    if increment == 0 {
+        return fail_incorrectusage_clierror!("--increment must be greater than 0.");
+    }
+    if args.flag_formatstr != "{}"
+        && (!args.flag_formatstr.contains("{}")
+            || dynfmt2::SimpleCurlyFormat
+                .format(&args.flag_formatstr, [0])
+                .is_err())
+    {
+        return fail_incorrectusage_clierror!(
+            "Invalid format string: \"{}\". The format string must contain a single \"{{}}\" \
+             which will be replaced with the incremental identifier.",
+            args.flag_formatstr
+        );
+    }
+
     let rconfig = Config::new(args.arg_input.as_ref())
         .delimiter(args.flag_delimiter)
         .no_headers_flag(args.flag_no_headers)
@@ -122,11 +142,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     if !rconfig.no_headers {
         wtr.write_record(&headers)?;
-    }
-
-    let increment = args.flag_increment;
-    if increment == 0 {
-        return fail_incorrectusage_clierror!("--increment must be greater than 0.");
     }
 
     let mut record = csv::StringRecord::new();
@@ -160,20 +175,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
     } else {
         // we need to use dynfmt2::SimpleCurlyFormat if the format string is not "{}"
-
-        // first, validate the format string
-        if !args.flag_formatstr.contains("{}")
-            || dynfmt2::SimpleCurlyFormat
-                .format(&args.flag_formatstr, [0])
-                .is_err()
-        {
-            return fail_incorrectusage_clierror!(
-                "Invalid format string: \"{}\". The format string must contain a single \"{{}}\" \
-                 which will be replaced with the incremental identifier.",
-                args.flag_formatstr
-            );
-        }
-
+        // (format string was already validated up front)
         let mut values = Values::with_capacity(1000);
         while rdr.read_record(&mut record)? {
             let value = record[column_index].to_owned();

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -54,6 +54,7 @@ Common options:
     --start <number>        The starting number for the incremental identifier.
                             [default: 0]
     --increment <number>    The increment for the incremental identifier.
+                            Must be greater than 0.
                             [default: 1]
     --formatstr <template>  The format string for the incremental identifier.
                             The format string must contain a single "{}" which
@@ -123,9 +124,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         wtr.write_record(&headers)?;
     }
 
+    let increment = args.flag_increment;
+    if increment == 0 {
+        return fail_incorrectusage_clierror!("--increment must be greater than 0.");
+    }
+
     let mut record = csv::StringRecord::new();
     let mut counter: u64 = args.flag_start;
-    let increment = args.flag_increment;
     let mut curr_counter: u64 = 0;
     let mut overflowed = false;
 
@@ -135,18 +140,20 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         while rdr.read_record(&mut record)? {
             let value = record[column_index].to_owned();
-            let new_value = values_num.entry(value.clone()).or_insert_with(|| {
+            // refuse to allocate a new pseudonym once the counter has overflowed,
+            // but continue serving previously-assigned ones
+            if overflowed && !values_num.contains_key(&value) {
+                return fail_incorrectusage_clierror!(
+                    "Counter overflow: incrementing past u64::MAX ({}). Last valid counter: \
+                     {curr_counter}.",
+                    u64::MAX
+                );
+            }
+            let new_value = values_num.entry(value).or_insert_with(|| {
                 curr_counter = counter;
                 (counter, overflowed) = counter.overflowing_add(increment);
                 curr_counter
             });
-            if overflowed {
-                return fail_incorrectusage_clierror!(
-                    "Overflowed. The counter is larger than u64::MAX {}. The last valid counter \
-                     is {curr_counter}.",
-                    u64::MAX
-                );
-            }
             record = replace_column_value(&record, column_index, &new_value.to_string());
 
             wtr.write_record(&record)?;
@@ -170,9 +177,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let mut values = Values::with_capacity(1000);
         while rdr.read_record(&mut record)? {
             let value = record[column_index].to_owned();
+            // refuse to allocate a new pseudonym once the counter has overflowed,
+            // but continue serving previously-assigned ones
+            if overflowed && !values.contains_key(&value) {
+                return fail_incorrectusage_clierror!(
+                    "Counter overflow: incrementing past u64::MAX ({}). Last valid counter: \
+                     {curr_counter}.",
+                    u64::MAX
+                );
+            }
 
             // safety: we checked that the format string contains "{}"
-            let new_value = values.entry(value.clone()).or_insert_with(|| {
+            let new_value = values.entry(value).or_insert_with(|| {
                 curr_counter = counter;
                 (counter, overflowed) = counter.overflowing_add(increment);
                 dynfmt2::SimpleCurlyFormat
@@ -180,13 +196,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     .unwrap()
                     .to_string()
             });
-            if overflowed {
-                return fail_incorrectusage_clierror!(
-                    "Overflowed. The counter is larger than u64::MAX({}). The last valid counter \
-                     is {curr_counter}.",
-                    u64::MAX
-                );
-            }
 
             record = replace_column_value(&record, column_index, new_value);
             wtr.write_record(&record)?;

--- a/tests/test_pseudo.rs
+++ b/tests/test_pseudo.rs
@@ -226,4 +226,10 @@ fn pseudo_increment_zero_rejected() {
         got_err.contains("--increment must be greater than 0"),
         "stderr was: {got_err}"
     );
+    // usage-level errors must not write any partial output to stdout
+    let got_stdout = wrk.stdout::<String>(&mut cmd);
+    assert!(
+        got_stdout.is_empty(),
+        "expected empty stdout, got: {got_stdout:?}"
+    );
 }

--- a/tests/test_pseudo.rs
+++ b/tests/test_pseudo.rs
@@ -175,6 +175,7 @@ fn pseudo_overflow() {
             svec!["Sue", "orange"],
             svec!["John", "magenta"],
             svec!["Mary", "cyan"],
+            svec!["Bob", "teal"],
         ],
     );
     let close_to_max = std::u64::MAX - 10;
@@ -186,19 +187,43 @@ fn pseudo_overflow() {
         .arg("data.csv");
 
     wrk.assert_err(&mut cmd);
+    // Sue gets the last valid counter (u64::MAX) and is written. Repeats of
+    // Mary/John continue to resolve from the cache. Bob would need a new
+    // pseudonym after the counter overflowed, so the command errors there.
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["name", "colors"],
         svec!["ID-18446744073709551605", "yellow"],
         svec!["ID-18446744073709551610", "blue"],
         svec!["ID-18446744073709551605", "purple"],
+        svec!["ID-18446744073709551615", "orange"],
+        svec!["ID-18446744073709551610", "magenta"],
+        svec!["ID-18446744073709551605", "cyan"],
     ];
     assert_eq!(got, expected);
 
     let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(
         got_err,
-        "usage error: Overflowed. The counter is larger than u64::MAX(18446744073709551615). The \
-         last valid counter is 18446744073709551615.\n"
+        "usage error: Counter overflow: incrementing past u64::MAX (18446744073709551615). Last \
+         valid counter: 18446744073709551615.\n"
+    );
+}
+
+#[test]
+fn pseudo_increment_zero_rejected() {
+    let wrk = Workdir::new("pseudo_increment_zero_rejected");
+    wrk.create(
+        "data.csv",
+        vec![svec!["name"], svec!["Mary"], svec!["John"]],
+    );
+    let mut cmd = wrk.command("pseudo");
+    cmd.arg("name").args(["--increment", "0"]).arg("data.csv");
+
+    wrk.assert_err(&mut cmd);
+    let got_err = wrk.output_stderr(&mut cmd);
+    assert!(
+        got_err.contains("--increment must be greater than 0"),
+        "stderr was: {got_err}"
     );
 }


### PR DESCRIPTION
## Summary
- Reject `--increment 0` with a clear usage error (previously silently collapsed all distinct values to the same pseudonym).
- On counter overflow, write the row whose pseudonym used the last valid counter; only error when a *new* pseudonym is needed after overflow, so repeats keep resolving from the cache.
- Unify and clarify the overflow error message across both code paths; drop redundant `value.clone()` on `entry()` calls.

## Test plan
- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo clippy --bin qsv -F all_features` — clean
- [x] `cargo t test_pseudo -F all_features` — 7/7 pass (existing `pseudo_overflow` updated for new behavior; new `pseudo_increment_zero_rejected`)
- [x] `qsv --generate-help-md` regenerated `docs/help/pseudo.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)