### PR TITLE
json: preserve BigInt precision and surface jaq runtime errors

### DIFF
--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -256,9 +256,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let input: Val = serde_json::from_value(value.clone())
             .map_err(|e| CliError::Other(format!("Failed to convert JSON to jaq value: {e}")))?;
 
-        // Run the filter and convert jaq output back to serde_json::Value
+        // Run the filter and convert jaq output back to serde_json::Value.
+        // `first_dropped_err` captures the first error encountered while
+        // dropping values — either a jaq filter runtime error or a
+        // Val-to-JSON conversion error — so the user-facing message can
+        // surface the underlying cause when no values survive.
         let ctx = Ctx::<data::JustLut<Val>>::new(&jaq_filter.lut, Vars::new([]));
-        let mut first_runtime_err: Option<String> = None;
+        let mut first_dropped_err: Option<String> = None;
         let jaq_values: Vec<serde_json::Value> = jaq_filter
             .id
             .run((ctx, input))
@@ -272,13 +276,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     Err(e) => format!("jaq filter runtime error: {e}"),
                 };
                 warn!("{msg} (value dropped)");
-                first_runtime_err.get_or_insert(msg);
+                first_dropped_err.get_or_insert(msg);
                 None
             })
             .collect();
 
         if jaq_values.is_empty() {
-            return match first_runtime_err {
+            return match first_dropped_err {
                 Some(msg) => fail_clierror!("jaq query returned no results: {msg}"),
                 None => fail_clierror!("jaq query returned no results."),
             };
@@ -351,14 +355,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // convert JSON to CSV
     // its inside a block so all the unneeded resources are freed & flushed after the block ends
     {
-        // Use `as_array()` directly so the single-object branch can wrap the
-        // value in a 1-element stack slice without a heap allocation or
-        // temporary-lifetime extension across the if/else.
-        let single = [value.clone()];
-        let values: &[serde_json::Value] = if let Some(arr) = value.as_array() {
-            arr.as_slice()
-        } else {
-            &single
+        // Borrow either the existing array's slice or a 1-element slice over
+        // `value` itself. `slice::from_ref` avoids cloning the value — for
+        // an array input we never touch it, and for a single object we just
+        // wrap the existing reference.
+        let values: &[serde_json::Value] = match value.as_array() {
+            Some(arr) => arr.as_slice(),
+            None => std::slice::from_ref(&value),
         };
 
         let flattener = Flattener::new();

--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -258,28 +258,30 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         // Run the filter and convert jaq output back to serde_json::Value
         let ctx = Ctx::<data::JustLut<Val>>::new(&jaq_filter.lut, Vars::new([]));
+        let mut first_runtime_err: Option<String> = None;
         let jaq_values: Vec<serde_json::Value> = jaq_filter
             .id
             .run((ctx, input))
             .map(unwrap_valr)
-            .filter_map(|r| match r {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    warn!("jaq filter runtime error (value dropped): {e}");
-                    None
-                },
-            })
-            .filter_map(|v| match val_to_json_value(v) {
-                Ok(val) => Some(val),
-                Err(e) => {
-                    warn!("jaq Val could not be converted to JSON (value dropped): {e}");
-                    None
-                },
+            .filter_map(|r| {
+                let msg = match r {
+                    Ok(v) => match val_to_json_value(v) {
+                        Ok(val) => return Some(val),
+                        Err(e) => format!("jaq Val could not be converted to JSON: {e}"),
+                    },
+                    Err(e) => format!("jaq filter runtime error: {e}"),
+                };
+                warn!("{msg} (value dropped)");
+                first_runtime_err.get_or_insert(msg);
+                None
             })
             .collect();
 
         if jaq_values.is_empty() {
-            return fail_clierror!("jaq query returned no results.");
+            return match first_runtime_err {
+                Some(msg) => fail_clierror!("jaq query returned no results: {msg}"),
+                None => fail_clierror!("jaq query returned no results."),
+            };
         }
 
         let jaq_value = if jaq_values.len() == 1 {
@@ -349,11 +351,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // convert JSON to CSV
     // its inside a block so all the unneeded resources are freed & flushed after the block ends
     {
-        let empty_values = vec![serde_json::Value::Null; 1];
-        let values = if value.is_array() {
-            value.as_array().unwrap_or(&empty_values)
+        // `is_array()` already proved `as_array()` is `Some`; the single-object
+        // branch wraps the value in a 1-element slice on the stack so we don't
+        // pay for a heap allocation or rely on temporary-lifetime extension.
+        let single = [value.clone()];
+        let values: &[serde_json::Value] = if let Some(arr) = value.as_array() {
+            arr.as_slice()
         } else {
-            &vec![value.clone()]
+            &single
         };
 
         let flattener = Flattener::new();
@@ -419,6 +424,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 ///
 /// This avoids the `format!("{v}")` → `serde_json::from_str` round-trip which can
 /// produce non-JSON output for NaN, Infinity, byte strings, and objects with non-string keys.
+///
+/// Note on numeric precision: `serde_json` is built without the `arbitrary_precision`
+/// feature in this project, so `serde_json::Number` is internally `i64`/`u64`/`f64`.
+/// To avoid silently rounding, BigInts that don't fit `i64`/`u64` and `Num::Dec`
+/// values (which jaq uses precisely to preserve decimals that did not parse as
+/// integers) are emitted as `Value::String` so their original digits round-trip
+/// verbatim into the CSV output.
 fn val_to_json_value(v: Val) -> Result<serde_json::Value, String> {
     match v {
         Val::Null => Ok(serde_json::Value::Null),
@@ -437,21 +449,25 @@ fn val_to_json_value(v: Val) -> Result<serde_json::Value, String> {
                 }
             },
             Num::BigInt(bi) => {
-                // Try to parse the BigInt string representation as a JSON number
+                // Try i64/u64 directly without round-tripping through serde_json's
+                // f64 fallback, which would silently lose precision for values
+                // outside ±2^53.
                 let s = bi.to_string();
-                s.parse::<serde_json::Number>()
-                    .map(serde_json::Value::Number)
-                    .or_else(|_| {
-                        // BigInt too large for JSON number — represent as string
-                        warn!("BigInt {bi} too large for JSON number, converting to string");
-                        Ok(serde_json::Value::String(s))
-                    })
+                if let Ok(i) = s.parse::<i64>() {
+                    Ok(serde_json::Value::Number(i.into()))
+                } else if let Ok(u) = s.parse::<u64>() {
+                    Ok(serde_json::Value::Number(u.into()))
+                } else {
+                    warn!("BigInt {bi} too large for JSON number, converting to string");
+                    Ok(serde_json::Value::String(s))
+                }
             },
             Num::Dec(s) => {
-                // Decimal stored as string — parse it as a JSON number
-                s.parse::<serde_json::Number>()
-                    .map(serde_json::Value::Number)
-                    .map_err(|e| format!("invalid decimal number {s}: {e}"))
+                // jaq's Dec preserves decimals that didn't parse as integer. Without
+                // serde_json's arbitrary_precision feature, parse::<Number>() would
+                // round to f64 and silently drop precision. The downstream sink is
+                // CSV (text), so pass the original string through verbatim.
+                Ok(serde_json::Value::String(s.to_string()))
             },
         },
         Val::TStr(ref s) => Ok(serde_json::Value::String(

--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -351,9 +351,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // convert JSON to CSV
     // its inside a block so all the unneeded resources are freed & flushed after the block ends
     {
-        // `is_array()` already proved `as_array()` is `Some`; the single-object
-        // branch wraps the value in a 1-element slice on the stack so we don't
-        // pay for a heap allocation or rely on temporary-lifetime extension.
+        // Use `as_array()` directly so the single-object branch can wrap the
+        // value in a 1-element stack slice without a heap allocation or
+        // temporary-lifetime extension across the if/else.
         let single = [value.clone()];
         let values: &[serde_json::Value] = if let Some(arr) = value.as_array() {
             arr.as_slice()
@@ -425,12 +425,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 /// This avoids the `format!("{v}")` → `serde_json::from_str` round-trip which can
 /// produce non-JSON output for NaN, Infinity, byte strings, and objects with non-string keys.
 ///
-/// Note on numeric precision: `serde_json` is built without the `arbitrary_precision`
-/// feature in this project, so `serde_json::Number` is internally `i64`/`u64`/`f64`.
-/// To avoid silently rounding, BigInts that don't fit `i64`/`u64` and `Num::Dec`
-/// values (which jaq uses precisely to preserve decimals that did not parse as
-/// integers) are emitted as `Value::String` so their original digits round-trip
-/// verbatim into the CSV output.
+/// Note on numeric precision (CSV-sink-specific): `serde_json` is built without
+/// the `arbitrary_precision` feature in this project, so `serde_json::Number` is
+/// internally `i64`/`u64`/`f64`. To avoid silently rounding, BigInts that don't
+/// fit `i64`/`u64` and `Num::Dec` values (which jaq uses precisely to preserve
+/// decimals that did not parse as integers) are emitted as `Value::String` so
+/// their original digits round-trip verbatim into the CSV output.
+///
+/// Caveat: this means the returned `serde_json::Value` is **not** a faithful
+/// re-encoding of the input JSON — re-serializing it to JSON would produce
+/// quoted strings where the original had numeric literals. This helper is
+/// intended to feed `qsv json`'s CSV writer (where every cell is text, so
+/// quoting is invisible). Do not lift it to a JSON sink without revisiting
+/// these branches.
 fn val_to_json_value(v: Val) -> Result<serde_json::Value, String> {
     match v {
         Val::Null => Ok(serde_json::Value::Null),

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -392,3 +392,58 @@ fn json_2843_default_select() {
 
     assert_eq!(got.trim(), expected.trim());
 }
+
+
+#[test]
+#[serial]
+fn json_jaq_bigint_precision() {
+    // 2^53 + 1 = 9007199254740993 — outside f64 exact-integer range.
+    // jaq parses this as Num::BigInt; the converter must preserve every digit.
+    let wrk = Workdir::new("json_jaq_bigint_precision");
+    let json_data = r#"[{"id": 9007199254740993, "name": "alice"}]"#;
+    wrk.create_from_string("data.json", json_data);
+
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+    cmd.args(vec!["--jaq", "."]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["id", "name"],
+        svec!["9007199254740993", "alice"],
+    ];
+    assert_eq!(got, expected);
+}
+
+
+
+#[test]
+#[serial]
+fn json_jaq_runtime_error_surfaced() {
+    // When every produced value errors, the user should see the underlying
+    // jaq runtime error rather than a generic "no results" message.
+    let wrk = Workdir::new("json_jaq_runtime_error_surfaced");
+    let json_data = r#"[{"a": 1}]"#;
+    wrk.create_from_string("data.json", json_data);
+
+    // `error("...")` is jq's explicit runtime-error builtin — guaranteed to
+    // produce an Exn::Err for every value, so the filter yields zero usable
+    // outputs and the new error-surfacing branch should fire.
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+    cmd.args(vec!["--jaq", r#"error("custom_runtime_err")"#]);
+
+    wrk.assert_err(&mut cmd);
+    let got_stderr = wrk.output_stderr(&mut cmd);
+    assert!(
+        got_stderr.contains("jaq query returned no results"),
+        "stderr did not mention 'no results': {got_stderr}"
+    );
+    assert!(
+        got_stderr.contains("jaq filter runtime error")
+            || got_stderr.contains("custom_runtime_err"),
+        "stderr did not surface the underlying runtime error: {got_stderr}"
+    );
+}

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -393,7 +393,6 @@ fn json_2843_default_select() {
     assert_eq!(got.trim(), expected.trim());
 }
 
-
 #[test]
 #[serial]
 fn json_jaq_bigint_precision() {
@@ -410,14 +409,36 @@ fn json_jaq_bigint_precision() {
     wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    let expected = vec![
-        svec!["id", "name"],
-        svec!["9007199254740993", "alice"],
-    ];
+    let expected = vec![svec!["id", "name"], svec!["9007199254740993", "alice"]];
     assert_eq!(got, expected);
 }
 
 
+#[test]
+#[serial]
+fn json_jaq_bigint_u64_precision() {
+    // 12345678901234567890 is in (i64::MAX, u64::MAX]. serde_json parses it
+    // as u64 and jaq_json's visit_u64 routes that through Num::from_integral,
+    // which puts u64-but-not-isize values into Num::BigInt — exercising the
+    // new u64 parse arm of val_to_json_value (the i64 parse fails, the u64
+    // parse succeeds, no String fallback).
+    let wrk = Workdir::new("json_jaq_bigint_u64_precision");
+    let json_data = r#"[{"id": 12345678901234567890, "name": "alice"}]"#;
+    wrk.create_from_string("data.json", json_data);
+
+    let mut cmd = wrk.command("json");
+    cmd.arg("data.json");
+    cmd.args(vec!["--jaq", "."]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["id", "name"],
+        svec!["12345678901234567890", "alice"],
+    ];
+    assert_eq!(got, expected);
+}
 
 #[test]
 #[serial]

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -413,7 +413,6 @@ fn json_jaq_bigint_precision() {
     assert_eq!(got, expected);
 }
 
-
 #[test]
 #[serial]
 fn json_jaq_bigint_u64_precision() {
@@ -433,10 +432,7 @@ fn json_jaq_bigint_u64_precision() {
     wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    let expected = vec![
-        svec!["id", "name"],
-        svec!["12345678901234567890", "alice"],
-    ];
+    let expected = vec![svec!["id", "name"], svec!["12345678901234567890", "alice"]];
     assert_eq!(got, expected);
 }
 


### PR DESCRIPTION
## Summary

- `val_to_json_value::Num::BigInt` now parses through `i64`/`u64` directly and only falls back to `Value::String` when digits don't fit either. The prior code round-tripped through `serde_json::Number`'s `f64` fallback, silently rounding values outside ±2^53 (e.g. `2^53 + 1` → `2^53`).
- `val_to_json_value::Num::Dec` now emits `Value::String` verbatim. `serde_json` is built without the `arbitrary_precision` feature, so the previous `parse::<Number>()` lossily collapsed jaq's `Dec` (which exists precisely to preserve high-precision decimals) to `f64`.
- `run` captures the first jaq runtime/conversion error so an empty result reports the underlying cause instead of a bare `"jaq query returned no results."` message.
- `run` replaces the unreachable `empty_values` defensive fallback (a mis-named 1-element `Null` vec) and the `&vec![value.clone()]` heap allocation with a stack `[value.clone()]` bound to an `&[Value]` slice.
- Doc comment on `val_to_json_value` now flags the CSV-only assumption for the BigInt-overflow and `Num::Dec` arms — re-serializing the returned `serde_json::Value` to JSON would produce quoted strings where the input had numeric literals, so the helper is not safe to lift to a JSON sink as-is.

## Test plan

- [x] `cargo test --test tests test_json:: -F all_features` — all 19 json tests pass (16 pre-existing + 3 new).
- [x] `cargo clippy --bin qsv -F all_features` — no new warnings on `src/cmd/json.rs`.
- [x] Manual smoke: `echo '[{"id": 9007199254740993, "name": "alice"}]' | qsv json --jaq .` → `id` cell preserves all 16 digits.
- [x] Manual smoke: `echo '[{"a":1}]' | qsv json --jaq 'error("custom_runtime_err")'` → stderr now reads `jaq query returned no results: jaq filter runtime error: "custom_runtime_err"` instead of the bare "no results".
- New regression tests:
  - `json_jaq_bigint_precision` — `9007199254740993` round-trips exactly via the i64 arm.
  - `json_jaq_bigint_u64_precision` — `12345678901234567890` (in `(i64::MAX, u64::MAX]`) round-trips via the new u64 arm; serde_json parses as u64 → jaq_json `visit_u64` → `Num::from_integral` → `Num::BigInt`.
  - `json_jaq_runtime_error_surfaced` — verifies the user-facing message includes the underlying jaq error.

## Notes / out of scope

- The `Num::Dec` String-fallback fix is in place but isn't end-to-end testable through `qsv json` today: `serde_json` without `arbitrary_precision` lossily converts both `>u64` integers and high-precision decimals to `f64` at input parse, before the converter ever runs. Fully closing that gap requires enabling `serde_json/arbitrary_precision` crate-wide, which has broader blast radius and is out of scope.
- The array-wrapping-array unwrap heuristic in `run` (`.data` vs `.data[]` jaq filter handling) was reviewed but not changed — tightening it from "first element is array" to "all elements are arrays" would be a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)