### PR TITLE
json: clarify --jaq numeric precision in USAGE; defer BigInt to_string allocation

### DIFF
--- a/docs/help/json.md
+++ b/docs/help/json.md
@@ -119,7 +119,11 @@ price,fruit
 2.5,apple
 3.0,banana
 
-Note: Trailing zeroes in decimal numbers after the decimal are truncated (2.50 becomes 2.5).
+Note: Trailing zeroes in decimal numbers from the input data are truncated (2.50 becomes 2.5)
+because input numbers round-trip through f64. With --jaq, integer literals beyond f64's
+precision are preserved (BigInts are kept exact when they fit i64/u64, otherwise emitted as
+strings), and decimal literals written inside the --jaq filter expression itself are passed
+through verbatim (2.50 stays 2.50, scientific notation is kept as written).
 
 If the JSON data was provided using stdin then either use - or do not provide a file path.
 For example you may copy the JSON data above to your clipboard then run:  

--- a/docs/help/json.md
+++ b/docs/help/json.md
@@ -120,9 +120,10 @@ price,fruit
 3.0,banana
 
 Note: Trailing zeroes in decimal numbers from the input data are truncated (2.50 becomes 2.5)
-because input numbers round-trip through f64. With --jaq, integer literals beyond f64's
-precision are preserved (BigInts are kept exact when they fit i64/u64, otherwise emitted as
-strings), and decimal literals written inside the --jaq filter expression itself are passed
+because JSON decimals (numbers with a fractional part or exponent) round-trip through f64.
+Plain integer tokens are preserved exactly (serde_json parses them as i64/u64). With --jaq,
+integers that don't fit i64/u64 are emitted verbatim as strings to avoid silent precision
+loss, and decimal literals written inside the --jaq filter expression itself are passed
 through verbatim (2.50 stays 2.50, scientific notation is kept as written).
 
 If the JSON data was provided using stdin then either use - or do not provide a file path.

--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -98,7 +98,11 @@ price,fruit
 2.5,apple
 3.0,banana
 
-Note: Trailing zeroes in decimal numbers after the decimal are truncated (2.50 becomes 2.5).
+Note: Trailing zeroes in decimal numbers from the input data are truncated (2.50 becomes 2.5)
+because input numbers round-trip through f64. With --jaq, integer literals beyond f64's
+precision are preserved (BigInts are kept exact when they fit i64/u64, otherwise emitted as
+strings), and decimal literals written inside the --jaq filter expression itself are passed
+through verbatim (2.50 stays 2.50, scientific notation is kept as written).
 
 If the JSON data was provided using stdin then either use - or do not provide a file path.
 For example you may copy the JSON data above to your clipboard then run:
@@ -459,17 +463,18 @@ fn val_to_json_value(v: Val) -> Result<serde_json::Value, String> {
                 }
             },
             Num::BigInt(bi) => {
-                // Try i64/u64 directly without round-tripping through serde_json's
-                // f64 fallback, which would silently lose precision for values
-                // outside ±2^53.
-                let s = bi.to_string();
-                if let Ok(i) = s.parse::<i64>() {
+                // Use TryFrom (prelude) to avoid an unconditional to_string allocation
+                // in the in-range case. We only stringify when the value overflows u64
+                // and we need a verbatim digit-preserving fallback for the CSV cell.
+                // This also avoids serde_json's f64 round-trip, which would silently
+                // lose precision for values outside ±2^53.
+                if let Ok(i) = i64::try_from(&**bi) {
                     Ok(serde_json::Value::Number(i.into()))
-                } else if let Ok(u) = s.parse::<u64>() {
+                } else if let Ok(u) = u64::try_from(&**bi) {
                     Ok(serde_json::Value::Number(u.into()))
                 } else {
                     warn!("BigInt {bi} too large for JSON number, converting to string");
-                    Ok(serde_json::Value::String(s))
+                    Ok(serde_json::Value::String(bi.to_string()))
                 }
             },
             Num::Dec(s) => {

--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -99,9 +99,10 @@ price,fruit
 3.0,banana
 
 Note: Trailing zeroes in decimal numbers from the input data are truncated (2.50 becomes 2.5)
-because input numbers round-trip through f64. With --jaq, integer literals beyond f64's
-precision are preserved (BigInts are kept exact when they fit i64/u64, otherwise emitted as
-strings), and decimal literals written inside the --jaq filter expression itself are passed
+because JSON decimals (numbers with a fractional part or exponent) round-trip through f64.
+Plain integer tokens are preserved exactly (serde_json parses them as i64/u64). With --jaq,
+integers that don't fit i64/u64 are emitted verbatim as strings to avoid silent precision
+loss, and decimal literals written inside the --jaq filter expression itself are passed
 through verbatim (2.50 stays 2.50, scientific notation is kept as written).
 
 If the JSON data was provided using stdin then either use - or do not provide a file path.
@@ -473,7 +474,7 @@ fn val_to_json_value(v: Val) -> Result<serde_json::Value, String> {
                 } else if let Ok(u) = u64::try_from(&**bi) {
                     Ok(serde_json::Value::Number(u.into()))
                 } else {
-                    warn!("BigInt {bi} too large for JSON number, converting to string");
+                    warn!("BigInt {bi} out of range for i64/u64 JSON number, converting to string");
                     Ok(serde_json::Value::String(bi.to_string()))
                 }
             },


### PR DESCRIPTION
## Summary

Follow-up to PR #3794 addressing two findings from a symbolic review of the BigInt-precision changes.

- **USAGE doc accuracy**: the trailing-zeros note implied unconditional truncation, but the new code paths in PR #3794 preserve more than that. Rewrote to distinguish:
  - input data (still round-trips through f64 → trailing zeros lost on both paths),
  - `--jaq` BigInts (preserved exactly when they fit i64/u64; emitted as strings when larger),
  - decimal literals written **inside** the `--jaq` filter expression (`Num::Dec` → passed through verbatim).
- **`val_to_json_value` Num::BigInt arm**: replaced `bi.to_string()` + `parse::<i64>()`/`parse::<u64>()` with `i64::try_from(&**bi)` / `u64::try_from(&**bi)`. `num-bigint` implements `TryFrom<&BigInt>` for both via `num_traits::ToPrimitive`, and `TryFrom` is in the Rust prelude — no new dependency. The string allocation now only happens in the overflow-fallback branch where it's actually used as `Value::String`.
- `docs/help/json.md` regenerated via `qsv --generate-help-md`.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features` — clean.
- [x] `cargo t json -F all_features` — 205 passed; existing `json_jaq_bigint_precision`, `json_jaq_bigint_u64_precision`, and `json_jaq_runtime_error_surfaced` all green.
- [x] `cargo clippy -F all_features --bin qsv -- -D warnings` — clean.
- [x] Manual smokes:
  - Input `[{"price":2.50}]` → `2.5` on both `qsv json` and `qsv json --jaq '.[]'` (matches doc: input rounds through f64).
  - `--jaq '[{p: 2.50}]'` → output cell `2.50` (decimal literal in filter preserved).
  - `--jaq '.[]'` on `12345678901234567` (fits i64) → preserved exactly.
  - `--jaq '.[]'` on `12345678901234567890` (> i64::MAX, fits u64) → preserved exactly via the new `u64::try_from` arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)