### PR TITLE
mcp: harden loader, executor, concurrency, and audit logging

### DIFF
--- a/.claude/skills/src/bm25-search.ts
+++ b/.claude/skills/src/bm25-search.ts
@@ -128,6 +128,14 @@ export class ToolSearchIndex {
     // Perform BM25 search
     const results = this.engine.search(query);
 
+    if (results.length === 0) {
+      // Emitted when the query has content but BM25 yields no results — most
+      // commonly because every token was a stopword (e.g., "the and or").
+      console.error(
+        `[BM25] No matches for query "${query.slice(0, 80)}" — query may consist entirely of stopwords or unindexed terms`,
+      );
+    }
+
     // Convert results back to QsvSkill objects
     // wink-bm25 returns array of [docId, score] tuples where docId is a string
     const matchedSkills: QsvSkill[] = [];

--- a/.claude/skills/src/concurrency.ts
+++ b/.claude/skills/src/concurrency.ts
@@ -197,6 +197,10 @@ export const _testConcurrency = {
     activeOperationCount = 0;
     slotWaiters.length = 0;
   },
+  // Upper bound is intentionally generous — backpressure logic begins to
+  // amortize poorly past a few thousand queued waiters; 10_000 is a sanity
+  // ceiling that catches typos (e.g., setting size to 1e9) without
+  // constraining any realistic stress test.
   setMaxQueueSize: (n: number) => {
     if (!Number.isInteger(n) || n < 1 || n > 10_000) {
       throw new Error(`setMaxQueueSize: value must be an integer in [1, 10000], got ${n}`);

--- a/.claude/skills/src/concurrency.ts
+++ b/.claude/skills/src/concurrency.ts
@@ -197,6 +197,11 @@ export const _testConcurrency = {
     activeOperationCount = 0;
     slotWaiters.length = 0;
   },
-  setMaxQueueSize: (n: number) => { MAX_QUEUE_SIZE = n; },
+  setMaxQueueSize: (n: number) => {
+    if (!Number.isInteger(n) || n < 1 || n > 10_000) {
+      throw new Error(`setMaxQueueSize: value must be an integer in [1, 10000], got ${n}`);
+    }
+    MAX_QUEUE_SIZE = n;
+  },
   getMaxQueueSize: () => MAX_QUEUE_SIZE,
 };

--- a/.claude/skills/src/executor.ts
+++ b/.claude/skills/src/executor.ts
@@ -150,13 +150,21 @@ export async function runQsvSimple(
       proc.stdout!.on("data", (chunk) => {
         if (stdoutTruncated) return;
         const data = chunk.toString();
-        if (stdout.length + data.length <= DEFAULT_MAX_OUTPUT_SIZE) {
-          stdout += data;
+        const combined = stdout + data;
+        if (combined.length <= DEFAULT_MAX_OUTPUT_SIZE) {
+          stdout = combined;
         } else {
-          // Keep as much of the new chunk as fits — slicing the previous
-          // stdout alone would discard the most recently produced bytes,
-          // which are usually the most relevant for diagnostics.
-          stdout = (stdout + data).slice(0, DEFAULT_MAX_OUTPUT_SIZE) + "\n[STDOUT TRUNCATED]";
+          // Preserve the most recently produced bytes for diagnostics by
+          // keeping the tail of the combined output and reserving space for
+          // the truncation marker within the configured output budget.
+          const truncationMarker = "\n[STDOUT TRUNCATED]";
+          const availableOutputSize = Math.max(
+            DEFAULT_MAX_OUTPUT_SIZE - truncationMarker.length,
+            0,
+          );
+          stdout = availableOutputSize === 0
+            ? truncationMarker.slice(-DEFAULT_MAX_OUTPUT_SIZE)
+            : combined.slice(-availableOutputSize) + truncationMarker;
           stdoutTruncated = true;
         }
       });

--- a/.claude/skills/src/executor.ts
+++ b/.claude/skills/src/executor.ts
@@ -153,7 +153,10 @@ export async function runQsvSimple(
         if (stdout.length + data.length <= DEFAULT_MAX_OUTPUT_SIZE) {
           stdout += data;
         } else {
-          stdout = stdout.slice(0, DEFAULT_MAX_OUTPUT_SIZE) + "\n[STDOUT TRUNCATED]";
+          // Keep as much of the new chunk as fits — slicing the previous
+          // stdout alone would discard the most recently produced bytes,
+          // which are usually the most relevant for diagnostics.
+          stdout = (stdout + data).slice(0, DEFAULT_MAX_OUTPUT_SIZE) + "\n[STDOUT TRUNCATED]";
           stdoutTruncated = true;
         }
       });

--- a/.claude/skills/src/executor.ts
+++ b/.claude/skills/src/executor.ts
@@ -121,6 +121,7 @@ export async function runQsvSimple(
 
     let stdout = "";
     let stderr = "";
+    let stdoutTruncated = false;
     let finalized = false;
 
     // Single finalization path: clears timer, calls onExit exactly once,
@@ -146,7 +147,16 @@ export async function runQsvSimple(
     }, timeoutMs);
 
     if (captureStdout) {
-      proc.stdout!.on("data", (chunk) => { stdout += chunk.toString(); });
+      proc.stdout!.on("data", (chunk) => {
+        if (stdoutTruncated) return;
+        const data = chunk.toString();
+        if (stdout.length + data.length <= DEFAULT_MAX_OUTPUT_SIZE) {
+          stdout += data;
+        } else {
+          stdout = stdout.slice(0, DEFAULT_MAX_OUTPUT_SIZE) + "\n[STDOUT TRUNCATED]";
+          stdoutTruncated = true;
+        }
+      });
     }
     proc.stderr!.on("data", (chunk) => {
       const data = chunk.toString();

--- a/.claude/skills/src/loader.ts
+++ b/.claude/skills/src/loader.ts
@@ -96,17 +96,26 @@ export class SkillLoader {
     const files = await readdir(this.skillsDir);
     const jsonFiles = files.filter((f) => f.endsWith(".json"));
 
-    // Load all skill files in parallel
+    // Load all skill files in parallel. Per-file failures (read or JSON parse
+    // errors) must not reject the whole Promise.all — a single corrupt file
+    // (e.g., partial write during `qsv --update-mcp-skills`) would otherwise
+    // leave the server with no skills loaded.
     const loadResults = await Promise.all(
       jsonFiles.map(async (file) => {
         const skillPath = join(this.skillsDir, file);
-        const content = await readFile(skillPath, "utf-8");
-        const parsed: unknown = JSON.parse(content);
-        if (!isValidSkillShape(parsed)) {
-          console.warn(`[Loader] Skipping invalid skill file ${file}: missing required fields`);
+        try {
+          const content = await readFile(skillPath, "utf-8");
+          const parsed: unknown = JSON.parse(content);
+          if (!isValidSkillShape(parsed)) {
+            console.warn(`[Loader] Skipping invalid skill file ${file}: missing required fields`);
+            return null;
+          }
+          return parsed;
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : String(error);
+          console.warn(`[Loader] Skipping unreadable skill file ${file}: ${msg}`);
           return null;
         }
-        return parsed;
       }),
     );
 

--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -769,7 +769,7 @@ class QsvMcpServer {
             }
           }
           const errorMessage = rawErr !== undefined
-            ? (MAX_ARGS_LOG_LEN > 0 && rawErr.length > MAX_ARGS_LOG_LEN
+            ? (rawErr.length > MAX_ARGS_LOG_LEN
                 ? rawErr.slice(0, MAX_ARGS_LOG_LEN) + "…[truncated]"
                 : rawErr)
             : undefined;

--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -661,8 +661,15 @@ class QsvMcpServer {
       const startTime = Date.now();
       const invocationId = randomUUID();
 
-      // Extract and remove _reason before forwarding args
-      const reason = typeof args?._reason === "string" ? args._reason : name;
+      // Extract and remove _reason before forwarding args.
+      // _reason is user-supplied free text — truncate it before logging so a
+      // pathological 10 MB string can't bloat audit logs or hit OS arg-length
+      // limits when forwarded to `qsv log`.
+      const MAX_REASON_LEN = 1024;
+      const rawReason = typeof args?._reason === "string" ? args._reason : name;
+      const reason = rawReason.length > MAX_REASON_LEN
+        ? rawReason.slice(0, MAX_REASON_LEN) + "…[truncated]"
+        : rawReason;
       const toolArgs = args
         ? Object.fromEntries(
             Object.entries(args).filter(([k]) => k !== "_reason"),
@@ -743,9 +750,28 @@ class QsvMcpServer {
         // Record pipeline step for reproducibility manifest
         if (this.pipelineManifest && name.startsWith("qsv_")) {
           const meta = (result as Record<string | symbol, unknown>)[PIPELINE_METADATA] as PipelineMetadata | undefined;
-          const rawErr = isError ? ((result as { content?: Array<{ text?: string }> }).content?.[0]?.text ?? "") : undefined;
+          // CallToolResult.content is a discriminated union — narrow on type==="text"
+          // before extracting .text so non-text content (image/resource) doesn't
+          // produce an empty audit-log error message.
+          let rawErr: string | undefined;
+          if (isError) {
+            const contentArr = (result as { content?: unknown }).content;
+            if (Array.isArray(contentArr)) {
+              const firstText = contentArr.find(
+                (c): c is { type: "text"; text: string } =>
+                  !!c && typeof c === "object" &&
+                  (c as { type?: unknown }).type === "text" &&
+                  typeof (c as { text?: unknown }).text === "string",
+              );
+              rawErr = firstText?.text ?? "";
+            } else {
+              rawErr = "";
+            }
+          }
           const errorMessage = rawErr !== undefined
-            ? (rawErr.length > MAX_ARGS_LOG_LEN ? rawErr.slice(0, MAX_ARGS_LOG_LEN) + "…[truncated]" : rawErr)
+            ? (MAX_ARGS_LOG_LEN > 0 && rawErr.length > MAX_ARGS_LOG_LEN
+                ? rawErr.slice(0, MAX_ARGS_LOG_LEN) + "…[truncated]"
+                : rawErr)
             : undefined;
           // For qsv_command, derive the actual tool name from args so
           // classifyKind/isDeterministic work correctly on the underlying command.
@@ -924,9 +950,10 @@ class QsvMcpServer {
       if (config.enableMcpApps && this.clientSupportsApps()) {
         const candidates = await this.workingDirManager.discoverDirectories();
         const currentDir = this.filesystemProvider.getWorkingDirectory();
-        // structuredContent is an MCP Apps extension not yet in the SDK's
-        // CallToolResult type. Cast to satisfy the compiler while still
-        // delivering the payload to App-capable clients.
+        // structuredContent is part of CallToolResult in current MCP SDK; the
+        // cast preserves both content and structuredContent so App-capable
+        // clients receive the payload while the response remains
+        // ListTools-compatible for older clients.
         return {
           content: [{ type: "text" as const, text: "Opening interactive directory picker..." }],
           structuredContent: {
@@ -934,7 +961,10 @@ class QsvMcpServer {
             knownDirs: candidates,
             homeDir: homedir(),
           },
-        } as { content: Array<{ type: "text"; text: string }> };
+        } as unknown as {
+          content: Array<{ type: "text"; text: string }>;
+          structuredContent: { currentPath: string; knownDirs: unknown; homeDir: string };
+        };
       }
 
       // 2. Try interactive elicitation form

--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -961,9 +961,9 @@ class QsvMcpServer {
             knownDirs: candidates,
             homeDir: homedir(),
           },
-        } as unknown as {
+        } as {
           content: Array<{ type: "text"; text: string }>;
-          structuredContent: { currentPath: string; knownDirs: unknown; homeDir: string };
+          structuredContent: { currentPath: string; knownDirs: typeof candidates; homeDir: string };
         };
       }
 

--- a/.claude/skills/src/tool-handlers.ts
+++ b/.claude/skills/src/tool-handlers.ts
@@ -336,6 +336,17 @@ function buildDescribegptArgs(
 }
 
 /**
+ * Format a single-line "skipped" note for moarstats auto-enrichment failures.
+ * Caps the reason at 120 chars and falls back to "unknown error" when the
+ * input is empty.
+ */
+function formatMoarstatsSkip(rawReason: string): string {
+  const firstLine = rawReason.trim().split("\n")[0].slice(0, 120);
+  const reason = firstLine || "unknown error";
+  return `\n\n⚠️  moarstats auto-enrichment skipped: ${reason}`;
+}
+
+/**
  * Handle execution of a qsv tool
  */
 export async function handleToolCall(
@@ -682,14 +693,12 @@ export async function handleToolCall(
             moarstatsNote = `\n\n📊 Auto-enriched stats cache with moarstats (~25 additional columns, ${duration}ms)`;
             console.error(`[MCP Tools] moarstats auto-enrichment succeeded (${duration}ms)`);
           } else {
-            const reason = (moarstatsResult.stderr || "").trim().split("\n")[0]?.slice(0, 120) || "unknown error";
-            moarstatsNote = `\n\n⚠️  moarstats auto-enrichment skipped: ${reason}`;
+            moarstatsNote = formatMoarstatsSkip(moarstatsResult.stderr || "");
             console.error(`[MCP Tools] moarstats auto-enrichment failed: ${moarstatsResult.stderr}`);
           }
         }
       } catch (error: unknown) {
-        const reason = getErrorMessage(error).split("\n")[0]?.slice(0, 120) || "unknown error";
-        moarstatsNote = `\n\n⚠️  moarstats auto-enrichment skipped: ${reason}`;
+        moarstatsNote = formatMoarstatsSkip(getErrorMessage(error));
         console.error(`[MCP Tools] moarstats auto-enrichment error:`, getErrorMessage(error));
       }
     }

--- a/.claude/skills/src/tool-handlers.ts
+++ b/.claude/skills/src/tool-handlers.ts
@@ -341,7 +341,9 @@ function buildDescribegptArgs(
  * input is empty.
  */
 function formatMoarstatsSkip(rawReason: string): string {
-  const firstLine = rawReason.trim().split("\n")[0].slice(0, 120);
+  const trimmed = rawReason.trim();
+  const newlineIdx = trimmed.indexOf("\n");
+  const firstLine = (newlineIdx === -1 ? trimmed : trimmed.slice(0, newlineIdx)).slice(0, 120);
   const reason = firstLine || "unknown error";
   return `\n\n⚠️  moarstats auto-enrichment skipped: ${reason}`;
 }

--- a/.claude/skills/src/tool-handlers.ts
+++ b/.claude/skills/src/tool-handlers.ts
@@ -216,7 +216,10 @@ async function processAgentResponses(
     } else {
       const agentResponse = llmResponses.find((r) => r.kind === phase.kind);
       if (!agentResponse) {
-        return errorResult(`Missing response for phase "${phase.kind}"`);
+        const provided = llmResponses.map((r) => `"${r.kind}"`).join(", ") || "(none)";
+        return errorResult(
+          `Missing response for phase "${phase.kind}". Provided kinds: ${provided}.`,
+        );
       }
       phaseResponses.push({
         kind: phase.kind,
@@ -679,10 +682,14 @@ export async function handleToolCall(
             moarstatsNote = `\n\n📊 Auto-enriched stats cache with moarstats (~25 additional columns, ${duration}ms)`;
             console.error(`[MCP Tools] moarstats auto-enrichment succeeded (${duration}ms)`);
           } else {
+            const reason = (moarstatsResult.stderr || "").trim().split("\n")[0]?.slice(0, 120) || "unknown error";
+            moarstatsNote = `\n\n⚠️  moarstats auto-enrichment skipped: ${reason}`;
             console.error(`[MCP Tools] moarstats auto-enrichment failed: ${moarstatsResult.stderr}`);
           }
         }
       } catch (error: unknown) {
+        const reason = getErrorMessage(error).split("\n")[0]?.slice(0, 120) || "unknown error";
+        moarstatsNote = `\n\n⚠️  moarstats auto-enrichment skipped: ${reason}`;
         console.error(`[MCP Tools] moarstats auto-enrichment error:`, getErrorMessage(error));
       }
     }

--- a/.claude/skills/src/update-checker.ts
+++ b/.claude/skills/src/update-checker.ts
@@ -204,6 +204,16 @@ export class UpdateChecker {
    * Check for available updates from GitHub releases
    */
   async checkGitHubReleases(signal?: AbortSignal): Promise<string | null> {
+    // Defense-in-depth: even when callers don't pass an AbortSignal, ensure the
+    // fetch can't hang indefinitely (e.g., DNS or TCP stalls during startup).
+    let internalTimer: NodeJS.Timeout | undefined;
+    let effectiveSignal = signal;
+    if (!effectiveSignal) {
+      const controller = new AbortController();
+      internalTimer = setTimeout(() => controller.abort(), 10_000);
+      internalTimer.unref?.();
+      effectiveSignal = controller.signal;
+    }
     try {
       // Use Node.js built-in fetch (available in Node 18+)
       const response = await fetch(
@@ -213,7 +223,7 @@ export class UpdateChecker {
             Accept: "application/vnd.github.v3+json",
             "User-Agent": "qsv-mcp-server",
           },
-          signal,
+          signal: effectiveSignal,
         },
       );
 
@@ -241,6 +251,8 @@ export class UpdateChecker {
     } catch (error: unknown) {
       console.error("[UpdateChecker] Failed to check GitHub releases:", error);
       return null;
+    } finally {
+      if (internalTimer) clearTimeout(internalTimer);
     }
   }
 
@@ -269,6 +281,11 @@ export class UpdateChecker {
       // NaN > 0 and NaN < 0 are both false, so unparsable versions
       // are safely ignored (no recommendations emitted).
       const comparison = compareVersions(currentQsvVersion, skillsVersion);
+      if (Number.isNaN(comparison)) {
+        console.warn(
+          `[UpdateChecker] Could not compare versions "${currentQsvVersion}" vs "${skillsVersion}" — skipping recommendation`,
+        );
+      }
       if (comparison > 0) {
         recommendations.push(
           `⚠️  qsv binary (${currentQsvVersion}) is newer than skills (${skillsVersion})`,

--- a/.claude/skills/src/update-checker.ts
+++ b/.claude/skills/src/update-checker.ts
@@ -211,7 +211,7 @@ export class UpdateChecker {
     if (!effectiveSignal) {
       const controller = new AbortController();
       internalTimer = setTimeout(() => controller.abort(), 10_000);
-      internalTimer.unref?.();
+      internalTimer.unref();
       effectiveSignal = controller.signal;
     }
     try {

--- a/.claude/skills/tests/loader.test.ts
+++ b/.claude/skills/tests/loader.test.ts
@@ -4,7 +4,20 @@
 
 import test from "node:test";
 import assert from "node:assert";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { SkillLoader } from "../src/loader.js";
+
+// Minimal valid skill shape per isValidSkillShape() in loader.ts
+const minimalSkillJson = (name: string) =>
+  JSON.stringify({
+    name,
+    description: `${name} test skill`,
+    version: "1.0.0",
+    category: "test",
+    command: { subcommand: name.replace(/^qsv-/, "") },
+  });
 
 test("SkillLoader initializes without errors", () => {
   const loader = new SkillLoader();
@@ -202,6 +215,53 @@ test("loadByNames handles concurrent calls safely", async () => {
   // Verify cache is correct after concurrent loads
   const cachedLoad = await loader.loadByNames(skillNames);
   assert.strictEqual(cachedLoad.size, skillNames.length, "Cache should work");
+});
+
+test("loadAll skips malformed JSON files and loads remaining valid skills", async () => {
+  // Build a temp skills dir with several valid skills and one malformed file.
+  // The malformed file would otherwise reject the Promise.all in doLoadAll.
+  // BM25 consolidation requires a small minimum corpus, hence 3 valid skills.
+  const tempDir = await mkdtemp(join(tmpdir(), "qsv-loader-test-"));
+  try {
+    await writeFile(join(tempDir, "qsv-count.json"), minimalSkillJson("qsv-count"));
+    await writeFile(join(tempDir, "qsv-headers.json"), minimalSkillJson("qsv-headers"));
+    await writeFile(join(tempDir, "qsv-stats.json"), minimalSkillJson("qsv-stats"));
+    await writeFile(join(tempDir, "qsv-broken.json"), "{ this is not valid json");
+
+    const loader = new SkillLoader(tempDir);
+    const loaded = await loader.loadAll();
+
+    assert.ok(loaded.has("qsv-count"), "Valid skill qsv-count should still load");
+    assert.ok(loaded.has("qsv-headers"), "Valid skill qsv-headers should still load");
+    assert.ok(loaded.has("qsv-stats"), "Valid skill qsv-stats should still load");
+    assert.ok(!loaded.has("qsv-broken"), "Malformed file should be skipped, not crash");
+    assert.strictEqual(loader.isAllLoaded(), true, "isAllLoaded should be true after partial success");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadAll skips skill files missing required fields", async () => {
+  // A syntactically-valid JSON file that doesn't match the QsvSkill shape
+  // should be skipped without affecting other skills.
+  const tempDir = await mkdtemp(join(tmpdir(), "qsv-loader-test-"));
+  try {
+    await writeFile(join(tempDir, "qsv-count.json"), minimalSkillJson("qsv-count"));
+    await writeFile(join(tempDir, "qsv-headers.json"), minimalSkillJson("qsv-headers"));
+    await writeFile(join(tempDir, "qsv-stats.json"), minimalSkillJson("qsv-stats"));
+    await writeFile(
+      join(tempDir, "qsv-bogus.json"),
+      JSON.stringify({ not_a_skill: true }),
+    );
+
+    const loader = new SkillLoader(tempDir);
+    const loaded = await loader.loadAll();
+
+    assert.ok(loaded.has("qsv-count"), "Valid skill should still load");
+    assert.ok(!loaded.has("qsv-bogus"), "Shape-invalid skill should be skipped");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("loadAll handles concurrent calls safely", async () => {

--- a/.claude/skills/tests/update-checker.test.ts
+++ b/.claude/skills/tests/update-checker.test.ts
@@ -190,13 +190,13 @@ test('checkGitHubReleases internal timeout returns null when fetch never resolve
     });
   }) as typeof fetch;
 
+  // Pre-abort the signal so fetch rejects immediately without depending on a
+  // timer firing during the test's event loop window (CI runners can park
+  // unrefed timers and stall the test).
+  const controller = new AbortController();
+  controller.abort();
   try {
     const checker = new UpdateChecker();
-    // Patch the 10s default down to a short interval for the test by
-    // pre-aborting via an external signal — this exercises the same code path
-    // (fetch handles the AbortSignal) without waiting 10s.
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 50).unref();
     const result = await checker.checkGitHubReleases(controller.signal);
     assert.strictEqual(result, null, "Aborted fetch should return null, not throw");
   } finally {

--- a/.claude/skills/tests/update-checker.test.ts
+++ b/.claude/skills/tests/update-checker.test.ts
@@ -167,6 +167,44 @@ test('extension mode skips MCP server version check', { skip: !QSV_AVAILABLE }, 
   assert.strictEqual(result.versions.mcpServerVersion, 'extension');
 });
 
+test('checkGitHubReleases internal timeout returns null when fetch never resolves', async () => {
+  // Stub global fetch to honor the AbortSignal but never resolve otherwise.
+  const originalFetch = globalThis.fetch;
+  // Suppress the expected "[UpdateChecker] Failed to check GitHub releases:"
+  // log line so test output stays clean — we re-assert the return value below.
+  const originalConsoleError = console.error;
+  console.error = () => {};
+  globalThis.fetch = ((_url: string, init?: { signal?: AbortSignal }) => {
+    return new Promise((_resolve, reject) => {
+      if (init?.signal) {
+        const signal = init.signal;
+        const onAbort = () => {
+          const err = new Error("aborted");
+          (err as Error & { name: string }).name = "AbortError";
+          reject(err);
+        };
+        if (signal.aborted) onAbort();
+        else signal.addEventListener("abort", onAbort, { once: true });
+      }
+      // Otherwise, never resolve.
+    });
+  }) as typeof fetch;
+
+  try {
+    const checker = new UpdateChecker();
+    // Patch the 10s default down to a short interval for the test by
+    // pre-aborting via an external signal — this exercises the same code path
+    // (fetch handles the AbortSignal) without waiting 10s.
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 50).unref();
+    const result = await checker.checkGitHubReleases(controller.signal);
+    assert.strictEqual(result, null, "Aborted fetch should return null, not throw");
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
+  }
+});
+
 if (!QSV_AVAILABLE) {
   console.log('\n  UpdateChecker tests requiring qsv binary were skipped - qsv not available');
   console.log(`   Current validation: ${JSON.stringify(config.qsvValidation, null, 2)}`);


### PR DESCRIPTION
## Summary

Reviewed the qsv MCP Server (`.claude/skills/`, v19.1.1) using Serena for symbol-aware navigation and Context7 for current `@modelcontextprotocol/sdk` docs, then applied fixes for the verified findings. A subsequent roborev review surfaced 6 LOW polish items, also addressed.

### High-impact fixes
- **loader.ts** — wrap per-file read/parse in `try/catch` so a single corrupt `qsv-*.json` (e.g., partial write during `--update-mcp-skills`) no longer rejects the whole `Promise.all` and leaves the server with no skills loaded.
- **executor.ts** — bound stdout accumulation in `runQsvSimple` with `DEFAULT_MAX_OUTPUT_SIZE`, mirroring the existing stderr cap; truncation preserves the trailing bytes of the overflowing chunk (typically the most diagnostic).
- **update-checker.ts** — add a 10s internal `AbortController` fallback in `checkGitHubReleases` so callers without a signal can't hang on DNS/TCP stalls; warn when `compareVersions` returns `NaN`.

### Medium / polish
- **mcp-server.ts** — narrow `CallToolResult.content` on `type === "text"` before reading `.text` in audit logging; properly type the `structuredContent` directory-picker response; truncate user-supplied `_reason`.
- **tool-handlers.ts** — phase-3 missing-kind error lists provided kinds; moarstats auto-enrichment failures now surface a `⚠️ skipped` note in the response (was stderr-only); shared via `formatMoarstatsSkip` helper.
- **concurrency.ts** — validate `_testConcurrency.setMaxQueueSize` input range with a comment on why 10k is the ceiling.
- **bm25-search.ts** — log when a query yields zero matches (catches all-stopword queries).

### Verification

- `npm run build` — clean (only pre-existing low-level `Server` deprecation warnings, unrelated)
- `npm test` — **654 pass, 0 fail, 5 skipped** (env-gated)

## Test plan

- [ ] CI build green
- [ ] `npm test` from `.claude/skills/` passes locally
- [ ] Manual: drop a malformed `qsv/qsv-broken.json`, start the server, confirm warning logged and other skills load
- [ ] Manual: run a sqlp query producing >50 MB stdout with `captureStdout: true`, confirm bounded with `[STDOUT TRUNCATED]` sentinel

🤖 Generated with [Claude Code](https://claude.com/claude-code)