### PR TITLE
mcp: fix examples parser alignment and pipe-prefixed commands

### DIFF
--- a/.claude/skills/qsv/qsv-exclude.json
+++ b/.claude/skills/qsv/qsv-exclude.json
@@ -98,7 +98,11 @@
       "command": "qsv exclude --ignore-case id records.csv id previously-processed.csv"
     },
     {
-      "description": "Read records.csv from stdin Chain exclude with sort to create a new sorted records file without previously processed records",
+      "description": "Read records.csv from stdin",
+      "command": "cat records.csv | qsv exclude id - id previously-processed.csv"
+    },
+    {
+      "description": "Chain exclude with sort to create a new sorted records file without previously processed records",
       "command": "qsv exclude id records.csv id previously-processed.csv |  qsv sort > new-sorted-records.csv"
     },
     {

--- a/.claude/skills/qsv/qsv-split.json
+++ b/.claude/skills/qsv/qsv-split.json
@@ -97,7 +97,11 @@
       "command": "qsv split outdir --kb-size 1000 input.csv"
     },
     {
-      "description": "Read from stdin and create files like 0.csv, 1000.csv, etc. in the directory 'mysplitoutput', creating it if it does not exist. Split into 10 chunks. Files are named with the zero-based starting row index of each chunk (e.g. 0.csv, N.csv, 2N.csv, ...) in the directory 'outdir'.",
+      "description": "Read from stdin and create files like 0.csv, 1000.csv, etc. in the directory 'mysplitoutput', creating it if it does not exist.",
+      "command": "cat in.csv | qsv split mysplitoutput -s 1000"
+    },
+    {
+      "description": "Split into 10 chunks. Files are named with the zero-based starting row index of each chunk (e.g. 0.csv, N.csv, 2N.csv, ...) in the directory 'outdir'.",
       "command": "qsv split outdir --chunks 10 input.csv"
     },
     {

--- a/.claude/skills/qsv/qsv-sqlp.json
+++ b/.claude/skills/qsv/qsv-sqlp.json
@@ -148,7 +148,7 @@
     },
     {
       "description": "Use dollar-quoting to avoid escaping reserved characters in literals.",
-      "command": "qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane's horse \"Twinkle\"$SomeTag$'"
+      "command": "qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane'\\''s horse \"Twinkle\"$SomeTag$'"
     },
     {
       "description": "Unions and Joins are supported.",

--- a/.claude/skills/qsv/qsv-sqlp.json
+++ b/.claude/skills/qsv/qsv-sqlp.json
@@ -140,87 +140,135 @@
   "examples": [
     {
       "description": "enclose column names with spaces in double quotes",
-      "command": "qsv sqlp data.csv 'select col1, col2 as friendlyname from data' --format parquet --output data.parquet"
+      "command": "qsv sqlp data.csv 'select \"col 1\", \"col 2\" from data'"
     },
     {
       "description": "Use dollar-quoting to avoid escaping reserved characters in literals.",
-      "command": "qsv sqlp data.csv data2.csv 'SELECT col1 FROM data WHERE col1 IN (SELECT col2 FROM data2)'"
+      "command": "qsv sqlp data.csv \"SELECT * FROM data WHERE col1 = $$O'Reilly$$\""
     },
     {
-      "description": "Unions and Joins are supported.",
+      "description": "Use dollar-quoting to avoid escaping reserved characters in literals.",
       "command": "qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane's horse \"Twinkle\"$SomeTag$'"
     },
     {
+      "description": "Unions and Joins are supported.",
+      "command": "qsv sqlp data1.csv data2.csv 'SELECT * FROM data1 UNION ALL BY NAME SELECT * FROM data2'"
+    },
+    {
       "description": "use \"_t_N\" aliases to refer to input files, where N is the 1-based index of the input file/s. For example, _t_1 refers to the first input file, _t_2 refers to the second input file, and so on.",
-      "command": "qsv sqlp tbl_a.csv tbl_b.csv tbl_c.csv \"SELECT * FROM tbl_a  RIGHT ANTI JOIN tbl_b USING (b)  LEFT SEMI JOIN tbl_c USING (c)\""
+      "command": "qsv sqlp data.csv data2.csv 'select * from _t_1 join _t_2 on _t_1.colname = _t_2.colname'"
     },
     {
       "description": "Natural Joins are supported too! (https://www.w3resource.com/sql/joins/natural-join.php)",
-      "command": "qsv sqlp tbl1.csv \"SELECT x FROM tbl1 WHERE x IN (SELECT y FROM tbl1)\""
-    },
-    {
-      "description": "Use a SQL script to run a long, complex SQL query or to run SEVERAL SQL queries. When running several queries, each query needs to be separated by a semicolon, the last query will be returned as the result. Typically, earlier queries are used to create tables that can be used in later queries. Note that scripts support single-line comments starting with '--' so feel free to add comments to your script. In long, complex scripts that produce multiple temporary tables, note that you can use `truncate table <table_name>;` to free up memory used by temporary tables. Otherwise, the memory used by the temporary tables won't be freed until the script finishes. See test_sqlp/sqlp_boston311_sql_script() for an example.",
       "command": "qsv sqlp data1.csv data2.csv data3.csv  \"SELECT COLUMNS('^[^:]+$') FROM data1 NATURAL JOIN data2 NATURAL JOIN data3 ORDER BY COMPANY_ID\""
     },
     {
-      "description": "use Common Table Expressions (CTEs) using WITH to simplify complex queries",
+      "description": "Use a SQL script to run a long, complex SQL query or to run SEVERAL SQL queries. When running several queries, each query needs to be separated by a semicolon, the last query will be returned as the result. Typically, earlier queries are used to create tables that can be used in later queries. Note that scripts support single-line comments starting with '--' so feel free to add comments to your script. In long, complex scripts that produce multiple temporary tables, note that you can use `truncate table <table_name>;` to free up memory used by temporary tables. Otherwise, the memory used by the temporary tables won't be freed until the script finishes. See test_sqlp/sqlp_boston311_sql_script() for an example.",
       "command": "qsv sqlp data.csv data2.csv data3.csv data4.csv script.sql --format json --output data.json"
     },
     {
-      "description": "CASE statement",
+      "description": "use Common Table Expressions (CTEs) using WITH to simplify complex queries",
       "command": "qsv sqlp people.csv \"WITH millennials AS (SELECT * FROM people WHERE age >= 25 and age <= 40)  SELECT * FROM millennials WHERE STARTS_WITH(name,'C')\""
     },
     {
-      "description": "spaceship operator: \"<=>\" (three-way comparison operator) returns -1 if left < right, 0 if left == right, 1 if left > right https://en.wikipedia.org/wiki/Three-way_comparison#Spaceship_operator",
+      "description": "CASE statement",
+      "command": "qsv sqlp data.csv \"select CASE WHEN col1 > 10 THEN 'foo' WHEN col1 > 5 THEN 'bar' ELSE 'baz' END from data\""
+    },
+    {
+      "description": "CASE statement",
       "command": "qsv sqlp data.csv \"select CASE col*5 WHEN 10 THEN 'foo' WHEN 5 THEN 'bar' ELSE 'baz' END from _t_1\""
     },
     {
-      "description": "support ^@ (\"starts with\"), and ~~ (like) ,~~* (ilike),!~~ (not like),!~~* (not ilike) operators",
+      "description": "spaceship operator: \"<=>\" (three-way comparison operator) returns -1 if left < right, 0 if left == right, 1 if left > right https://en.wikipedia.org/wiki/Three-way_comparison#Spaceship_operator",
       "command": "qsv sqlp data.csv data2.csv \"select data.c2 <=> data2.c2 from data join data2 on data.c1 = data2.c1\""
     },
     {
-      "description": "support SELECT * ILIKE wildcard syntax select all columns from customers where the column contains 'a' followed by an 'e' with any characters (or no characters), in between, case-insensitive if customers.csv has columns LastName, FirstName, Address, City, State, Zip this query will return all columns for all rows except the columns that don't contain 'a' followed by an 'e' - i.e. except City and Zip",
+      "description": "support ^@ (\"starts with\"), and ~~ (like) ,~~* (ilike),!~~ (not like),!~~* (not ilike) operators",
+      "command": "qsv sqlp data.csv \"select * from data WHERE col1 ^@ 'foo'\""
+    },
+    {
+      "description": "support ^@ (\"starts with\"), and ~~ (like) ,~~* (ilike),!~~ (not like),!~~* (not ilike) operators",
+      "command": "qsv sqlp data.csv \"select c1 ^@ 'a' AS c1_starts_with_a from data\""
+    },
+    {
+      "description": "support ^@ (\"starts with\"), and ~~ (like) ,~~* (ilike),!~~ (not like),!~~* (not ilike) operators",
       "command": "qsv sqlp data.csv \"select c1 ~~* '%B' AS c1_ends_with_b_caseinsensitive from data\""
     },
     {
-      "description": "regex operators: \"~\" (contains pattern, case-sensitive); \"~*\" (contains pattern, case-insensitive) \"!~\" (does not contain pattern, case-sensitive); \"!~*\" (does not contain pattern, case-insensitive)",
+      "description": "support SELECT * ILIKE wildcard syntax select all columns from customers where the column contains 'a' followed by an 'e' with any characters (or no characters), in between, case-insensitive if customers.csv has columns LastName, FirstName, Address, City, State, Zip this query will return all columns for all rows except the columns that don't contain 'a' followed by an 'e' - i.e. except City and Zip",
       "command": "qsv sqlp customers.csv \"SELECT * ILIKE '%a%e%' FROM customers ORDER BY LastName, FirstName\""
     },
     {
-      "description": "regexp_like function: regexp_like(<string>, <pattern>, <optional flags>) returns true if <string> matches <pattern>, false otherwise <optional flags> can be one or more of the following: 'c' (case-sensitive - default), 'i' (case-insensitive), 'm' (multiline)",
+      "description": "regex operators: \"~\" (contains pattern, case-sensitive); \"~*\" (contains pattern, case-insensitive) \"!~\" (does not contain pattern, case-sensitive); \"!~*\" (does not contain pattern, case-insensitive)",
+      "command": "qsv sqlp data.csv \"select * from data WHERE col1 ~ '^foo' AND col2 > 10\""
+    },
+    {
+      "description": "regex operators: \"~\" (contains pattern, case-sensitive); \"~*\" (contains pattern, case-insensitive) \"!~\" (does not contain pattern, case-sensitive); \"!~*\" (does not contain pattern, case-insensitive)",
       "command": "qsv sqlp data.csv \"select * from data WHERE col1 !~* 'bar$' AND col2 > 10\""
     },
     {
-      "description": "case-insensitive regexp_like",
+      "description": "regexp_like function: regexp_like(<string>, <pattern>, <optional flags>) returns true if <string> matches <pattern>, false otherwise <optional flags> can be one or more of the following: 'c' (case-sensitive - default), 'i' (case-insensitive), 'm' (multiline)",
       "command": "qsv sqlp data.csv \"select * from data WHERE regexp_like(col1, '^foo') AND col2 > 10\""
     },
     {
-      "description": "regexp match using a literal pattern",
+      "description": "case-insensitive regexp_like",
       "command": "qsv sqlp data.csv \"select * from data WHERE regexp_like(col1, '^foo', 'i') AND col2 > 10\""
     },
     {
-      "description": "regexp match using patterns from another column",
+      "description": "regexp match using a literal pattern",
       "command": "qsv sqlp data.csv \"select idx,val from data WHERE val regexp '^foo'\""
     },
     {
-      "description": "use Parquet, JSONL and Arrow files in SQL queries",
+      "description": "regexp match using patterns from another column",
       "command": "qsv sqlp data.csv \"select idx,val from data WHERE val regexp pattern_col\""
     },
     {
-      "description": "you can also directly load CSVs using the Polars read_csv() SQL function. This is useful when you want to bypass the regular CSV parser (with SKIP_INPUT) and use Polars' multithreaded, mem-mapped CSV parser instead - making for dramatically faster queries at the cost of CSV parser configurability (i.e. limited to comma delimiter, no CSV comments, etc.).",
+      "description": "use Parquet, JSONL and Arrow files in SQL queries",
+      "command": "qsv sqlp data.csv \"select * from data join read_parquet('data2.parquet') as t2 ON data.c1 = t2.c1\""
+    },
+    {
+      "description": "use Parquet, JSONL and Arrow files in SQL queries",
+      "command": "qsv sqlp data.csv \"select * from data join read_ndjson('data2.jsonl') as t2 on data.c1 = t2.c1\""
+    },
+    {
+      "description": "use Parquet, JSONL and Arrow files in SQL queries",
+      "command": "qsv sqlp data.csv \"select * from data join read_ipc('data2.arrow') as t2 ON data.c1 = t2.c1\""
+    },
+    {
+      "description": "use Parquet, JSONL and Arrow files in SQL queries",
+      "command": "qsv sqlp SKIP_INPUT \"select * from read_parquet('data.parquet') order by col1 desc limit 100\""
+    },
+    {
+      "description": "use Parquet, JSONL and Arrow files in SQL queries",
       "command": "qsv sqlp SKIP_INPUT \"select * from read_ndjson('data.jsonl') as t1 join read_ipc('data.arrow') as t2 on t1.c1 = t2.c1\""
     },
     {
-      "description": "note that you can also use read_csv() to read compressed files directly gzip, zstd and zlib automatic decompression are supported",
+      "description": "you can also directly load CSVs using the Polars read_csv() SQL function. This is useful when you want to bypass the regular CSV parser (with SKIP_INPUT) and use Polars' multithreaded, mem-mapped CSV parser instead - making for dramatically faster queries at the cost of CSV parser configurability (i.e. limited to comma delimiter, no CSV comments, etc.).",
       "command": "qsv sqlp SKIP_INPUT \"select * from read_csv('data.csv') order by col1 desc limit 100\""
     },
     {
-      "description": "apart from using Polar's table functions, you can also use SKIP_INPUT when the SELECT statement doesn't require an input file",
+      "description": "note that you can also use read_csv() to read compressed files directly gzip, zstd and zlib automatic decompression are supported",
+      "command": "qsv sqlp SKIP_INPUT \"select * from read_csv('data.csv.gz')\""
+    },
+    {
+      "description": "note that you can also use read_csv() to read compressed files directly gzip, zstd and zlib automatic decompression are supported",
+      "command": "qsv sqlp SKIP_INPUT \"select * from read_csv('data.csv.zst')\""
+    },
+    {
+      "description": "note that you can also use read_csv() to read compressed files directly gzip, zstd and zlib automatic decompression are supported",
       "command": "qsv sqlp SKIP_INPUT \"select * from read_csv('data.csv.zlib')\""
     },
     {
-      "description": "use stdin as input",
+      "description": "apart from using Polar's table functions, you can also use SKIP_INPUT when the SELECT statement doesn't require an input file",
       "command": "qsv sqlp SKIP_INPUT \"SELECT 1 AS one, '2' AS two, 3.0 AS three\""
+    },
+    {
+      "description": "use stdin as input",
+      "command": "cat data.csv | qsv sqlp - 'select * from stdin'"
+    },
+    {
+      "description": "use stdin as input",
+      "command": "cat data.csv | qsv sqlp - data2.csv 'select * from stdin join data2 on stdin.col1 = data2.col1'"
     },
     {
       "description": "automatic snappy decompression/compression",

--- a/docs/help/sqlp.md
+++ b/docs/help/sqlp.md
@@ -59,7 +59,7 @@ qsv sqlp data.csv "SELECT * FROM data WHERE col1 = $$O'Reilly$$"
 ```
 
 ```console
-qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane's horse "Twinkle"$SomeTag$'
+qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane'\''s horse "Twinkle"$SomeTag$'
 ```
 
 > Unions and Joins are supported.

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -28,7 +28,7 @@ Examples:
   # Use dollar-quoting to avoid escaping reserved characters in literals.
   https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
   $ qsv sqlp data.csv "SELECT * FROM data WHERE col1 = $$O'Reilly$$"
-  $ qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane's horse "Twinkle"$SomeTag$'
+  $ qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane'\''s horse "Twinkle"$SomeTag$'
 
   # Unions and Joins are supported.
   $ qsv sqlp data1.csv data2.csv 'SELECT * FROM data1 UNION ALL BY NAME SELECT * FROM data2'

--- a/src/mcp_skills_gen.rs
+++ b/src/mcp_skills_gen.rs
@@ -1084,16 +1084,15 @@ impl UsageParser {
         let mut current_command = String::new();
         let mut in_continuation = false;
 
-        let flush =
-            |examples: &mut Vec<Example>, current_command: &mut String, active: &str| {
-                if !current_command.is_empty() && !active.is_empty() {
-                    examples.push(Example {
-                        description: active.trim().to_string(),
-                        command:     current_command.trim().to_string(),
-                    });
-                }
-                current_command.clear();
-            };
+        let flush = |examples: &mut Vec<Example>, current_command: &mut String, active: &str| {
+            if !current_command.is_empty() && !active.is_empty() {
+                examples.push(Example {
+                    description: active.trim().to_string(),
+                    command:     current_command.trim().to_string(),
+                });
+            }
+            current_command.clear();
+        };
 
         for line in lines.iter().skip(start_idx + 1) {
             let trimmed = line.trim();

--- a/src/mcp_skills_gen.rs
+++ b/src/mcp_skills_gen.rs
@@ -1074,10 +1074,26 @@ impl UsageParser {
             return examples;
         };
 
-        // Collect lines until we hit an end marker or next section
-        let mut current_description = String::new();
+        // staged_description: accumulated from `#` comment lines, awaiting a command.
+        // active_description: the topic description applied to the current run of commands;
+        // it persists across consecutive commands (without intervening blank/comment) so
+        // multiple example commands can share the same description. Cleared on blank
+        // lines (topic separator) and replaced when a new staged description is taken.
+        let mut staged_description = String::new();
+        let mut active_description = String::new();
         let mut current_command = String::new();
         let mut in_continuation = false;
+
+        let flush =
+            |examples: &mut Vec<Example>, current_command: &mut String, active: &str| {
+                if !current_command.is_empty() && !active.is_empty() {
+                    examples.push(Example {
+                        description: active.trim().to_string(),
+                        command:     current_command.trim().to_string(),
+                    });
+                }
+                current_command.clear();
+            };
 
         for line in lines.iter().skip(start_idx + 1) {
             let trimmed = line.trim();
@@ -1095,23 +1111,17 @@ impl UsageParser {
                 break;
             }
 
-            // Skip empty lines (but finalize any pending example)
+            // Blank line: topic separator. Flush any pending command and reset state.
             if trimmed.is_empty() {
-                if !current_command.is_empty() && !current_description.is_empty() {
-                    examples.push(Example {
-                        description: current_description.trim().to_string(),
-                        command:     current_command.trim().to_string(),
-                    });
-                    current_description.clear();
-                    current_command.clear();
-                }
+                flush(&mut examples, &mut current_command, &active_description);
+                staged_description.clear();
+                active_description.clear();
                 in_continuation = false;
                 continue;
             }
 
-            // Handle line continuation
+            // Handle line continuation (a previous command ended with `\`)
             if in_continuation {
-                // Remove the trailing backslash from previous line if present
                 if current_command.ends_with('\\') {
                     current_command.pop();
                     current_command.push(' ');
@@ -1121,46 +1131,43 @@ impl UsageParser {
                 continue;
             }
 
-            // Comment line (description for next command)
+            // Comment line — describes the next command(s).
             if trimmed.starts_with('#') {
-                let comment_text = trimmed.trim_start_matches('#').trim();
-                if !current_description.is_empty() {
-                    current_description.push(' ');
+                // If a comment block starts after a command was already paired with
+                // a description, flush that command first so the new comment doesn't
+                // leak into it.
+                if !current_command.is_empty() {
+                    flush(&mut examples, &mut current_command, &active_description);
+                    active_description.clear();
                 }
-                current_description.push_str(comment_text);
+                let comment_text = trimmed.trim_start_matches('#').trim();
+                if !staged_description.is_empty() {
+                    staged_description.push(' ');
+                }
+                staged_description.push_str(comment_text);
                 continue;
             }
 
-            // Command line
-            if trimmed.starts_with("$ qsv") || trimmed.starts_with("qsv ") {
-                // Finalize previous example if we have one
-                if !current_command.is_empty() && !current_description.is_empty() {
-                    examples.push(Example {
-                        description: current_description.trim().to_string(),
-                        command:     current_command.trim().to_string(),
-                    });
-                    current_description.clear();
-                    current_command.clear();
+            // Command line. Recognize plain `qsv ...`, `$ qsv ...`, and pipe-prefixed
+            // forms like `cat foo.csv | qsv ...` so stdin examples are not dropped.
+            let stripped_dollar = trimmed.strip_prefix("$ ").unwrap_or(trimmed);
+            let is_command = stripped_dollar.starts_with("qsv ")
+                || stripped_dollar.contains("| qsv ")
+                || stripped_dollar.contains("|qsv ");
+            if is_command {
+                // Flush any previous command using the existing active description.
+                flush(&mut examples, &mut current_command, &active_description);
+                // If a new description has been staged since the last command, take it.
+                if !staged_description.is_empty() {
+                    active_description = std::mem::take(&mut staged_description);
                 }
-
-                // Start new command, removing leading "$ " if present
-                let cmd = if trimmed.starts_with("$ ") {
-                    trimmed.trim_start_matches("$ ")
-                } else {
-                    trimmed
-                };
-                current_command = cmd.to_string();
+                current_command = stripped_dollar.to_string();
                 in_continuation = trimmed.ends_with('\\');
             }
         }
 
-        // Don't forget the last example
-        if !current_command.is_empty() && !current_description.is_empty() {
-            examples.push(Example {
-                description: current_description.trim().to_string(),
-                command:     current_command.trim().to_string(),
-            });
-        }
+        // Final flush
+        flush(&mut examples, &mut current_command, &active_description);
 
         examples
     }


### PR DESCRIPTION
## Summary
- Fix off-by-one in `extract_examples` (`src/mcp_skills_gen.rs`) where `#` comments were attaching to the *previous* command instead of the following one — visible across the entire `qsv-sqlp.json` examples block.
- Recognize pipe-prefixed command lines (`cat foo.csv | qsv ...`) so stdin examples in `qsv-exclude.json` and `qsv-split.json` are no longer dropped (and their descriptions no longer leak into the next entry).
- Persist topic descriptions across consecutive commands without intervening blank/comment lines so multi-command examples (e.g. sqlp dollar-quoting, CASE statements) all get the right description.
- Regenerate affected skill JSONs via `qsv --update-mcp-skills`.

Addresses roborev job 1871. The other two findings in that review (`qsv-fmt --ascii` U+001A, `qsv-headers --intersect`) were verified false positives — U+001A matches `b'\x1a'` in `fmt.rs`, and `--intersect` was intentionally removed in commit `0e9fc3a5d`.

## Test plan
- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo clippy -F all_features --bin qsv` (clean)
- [x] `qsv --update-mcp-skills` regenerates JSONs cleanly
- [x] `npm test` in `.claude/skills/` (657 pass)
- [x] Manually verified `qsv-sqlp.json`, `qsv-exclude.json`, `qsv-split.json` examples are aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)