### PR TITLE
cleanup: rename fail_oom_clierror; surface geocode update-check error cause

### DIFF
--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -103,7 +103,7 @@ macro_rules! fail_encoding_clierror {
 }
 
 /// write to stderr and log::error, using CliError::OutOfMemory
-macro_rules! fail_OOM_clierror {
+macro_rules! fail_oom_clierror {
     ($($t:tt)*) => {{
         use log::error;
         use crate::CliError;

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -887,8 +887,8 @@ async fn geocode_main(args: Args) -> CliResult<()> {
                     Some(m) => {
                         let created_at = util::format_systemtime(m.created_at, "%+");
                         eprintln!("Created at: {created_at}");
-                        if updater.has_updates(&m).await.map_err(|_| {
-                            CliError::Network("Geonames update check failed.".to_string())
+                        if updater.has_updates(&m).await.map_err(|e| {
+                            CliError::Network(format!("Geonames update check failed: {e}"))
                         })? {
                             winfo!(
                                 "Updates available at Geonames.org. Use `qsv geocode \
@@ -927,8 +927,8 @@ async fn geocode_main(args: Args) -> CliResult<()> {
                     let Some(m) = metadata else {
                         return fail_incorrectusage_clierror!("Invalid Geonames index file.");
                     };
-                    if updater.has_updates(&m).await.map_err(|_| {
-                        CliError::Network("Geonames update check failed.".to_string())
+                    if updater.has_updates(&m).await.map_err(|e| {
+                        CliError::Network(format!("Geonames update check failed: {e}"))
                     })? {
                         winfo!("Updates available at Geonames.org.");
                         display_rebuild_instructions(

--- a/src/util.rs
+++ b/src/util.rs
@@ -1006,7 +1006,7 @@ pub fn mem_file_check(
             fs::metadata(path).map_err(|e| format!("Failed to get file size: {e}"))?;
         let fsize = file_metadata.len();
         if fsize > max_avail_mem {
-            return fail_OOM_clierror!(
+            return fail_oom_clierror!(
                 "Not enough memory to process the file. qsv running in non-streaming {mode} mode. \
                  Total memory: {total_mem} Available memory: {avail_mem}. Free swap: {free_swap} \
                  Max Available memory/Max input file size: {max_avail_mem}. \


### PR DESCRIPTION
## Summary
- Rename `fail_OOM_clierror!` to `fail_oom_clierror!` for snake_case consistency with the other `fail_*_clierror!` macros (`fail_clierror!`, `fail_incorrectusage_clierror!`, `fail_encoding_clierror!`). One call site updated in `src/util.rs::mem_file_check`.
- In `src/cmd/geocode.rs`, the two `updater.has_updates(...).await.map_err(|_| ...)` sites discarded the reqwest error and reported a generic "Geonames update check failed." Capture the error and include its message so timeouts, DNS failures, HTTP errors, etc. are visible to the user and in logs.

Both findings came out of a `/symbolic-review` of `src/clitypes.rs`.

## Test plan
- [x] `cargo build --locked --bin qsv -F all_features` — clean
- [x] `cargo build --locked --bin qsvlite -F lite` — clean (pre-existing warnings only)
- [x] `cargo build --locked --bin qsvdp -F datapusher_plus` — clean (pre-existing warnings only)
- [x] `cargo clippy --locked -F all_features --bin qsv` — clean
- [ ] Optional: exercise `qsv geocode index-check` / `index-update` against an unreachable Geonames host to confirm the reqwest cause now appears in the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)