### PR TITLE
reverse: avoid u64 underflow on indexed reverse

### DIFF
--- a/src/cmd/reverse.rs
+++ b/src/cmd/reverse.rs
@@ -55,12 +55,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // we're reading the file in reverse streaming
         rconfig.write_headers(&mut rdr, &mut wtr)?;
         let mut record = csv::ByteRecord::new();
-        let mut pos = idx_file.count().saturating_sub(1);
-
-        while idx_file.seek(pos).is_ok() {
+        // iterate record indices from last to first; using a bounded reverse
+        // range avoids u64 underflow when pos reaches 0 (which panics in
+        // debug builds with overflow checks enabled).
+        for pos in (0..idx_file.count()).rev() {
+            idx_file.seek(pos)?;
             idx_file.read_byte_record(&mut record)?;
             wtr.write_byte_record(&record)?;
-            pos -= 1;
         }
     } else {
         // we don't have an index, we need to read the entire file into memory

--- a/tests/test_reverse.rs
+++ b/tests/test_reverse.rs
@@ -121,3 +121,60 @@ fn prop_reverse_no_headers_indexed() {
     }
     qcheck(p as fn(CsvData) -> bool);
 }
+
+// Regression test for the indexed-reverse u64 underflow.
+// The original bug wrote correct output to stdout and then panicked on
+// `pos -= 1` after reading record 0; debug builds exit non-zero, but the
+// `prop_reverse_*_indexed` property tests only diff stdout via
+// `read_stdout` and so missed it. This test asserts the exit status is
+// success in addition to checking the output, covering the minimal
+// 1-data-row case that originally triggered the panic, plus a multi-row
+// case for both `--no-headers` on and off.
+#[test]
+fn reverse_indexed_asserts_success() {
+    // 1-row indexed CSV with headers — the minimal panic-triggering case.
+    let wrk = Workdir::new("reverse_indexed_asserts_success_1row");
+    wrk.create_indexed("in.csv", vec![svec!["h1", "h2"], svec!["a", "b"]]);
+    let mut cmd = wrk.command("reverse");
+    cmd.arg("in.csv");
+    wrk.assert_success(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["h1", "h2"], svec!["a", "b"]];
+    assert_eq!(got, expected);
+
+    // Multi-row indexed CSV with headers.
+    let wrk = Workdir::new("reverse_indexed_asserts_success_multi");
+    wrk.create_indexed(
+        "in.csv",
+        vec![
+            svec!["h1", "h2"],
+            svec!["a", "1"],
+            svec!["b", "2"],
+            svec!["c", "3"],
+        ],
+    );
+    let mut cmd = wrk.command("reverse");
+    cmd.arg("in.csv");
+    wrk.assert_success(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["h1", "h2"],
+        svec!["c", "3"],
+        svec!["b", "2"],
+        svec!["a", "1"],
+    ];
+    assert_eq!(got, expected);
+
+    // Multi-row indexed CSV with --no-headers.
+    let wrk = Workdir::new("reverse_indexed_asserts_success_no_headers");
+    wrk.create_indexed(
+        "in.csv",
+        vec![svec!["a", "1"], svec!["b", "2"], svec!["c", "3"]],
+    );
+    let mut cmd = wrk.command("reverse");
+    cmd.arg("--no-headers").arg("in.csv");
+    wrk.assert_success(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![svec!["c", "3"], svec!["b", "2"], svec!["a", "1"]];
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
## Summary
- The indexed branch in `qsv reverse` decremented `pos: u64` after writing record 0, which panics in debug builds with overflow checks (`attempt to subtract with overflow at src/cmd/reverse.rs:63`) right after all rows have been flushed. Release builds were unaffected only because the wrapped `u64::MAX` is rejected by `Indexed::seek`.
- The existing `prop_reverse_*_indexed` property tests passed because they only diff stdout (which is correct — the panic happens after all output is written), not exit status.
- Replaced the manual decrement loop with a bounded reverse range `for pos in (0..idx_file.count()).rev()`, which can never underflow.

### Repro (before fix)
```
$ printf "a,b\n1,2\n" > /tmp/rev.csv
$ target/debug/qsv index /tmp/rev.csv
$ target/debug/qsv reverse /tmp/rev.csv
a,b
1,2
thread 'main' panicked at src/cmd/reverse.rs:63:13:
attempt to subtract with overflow
```

### After fix
Same input produces the same output with exit code 0; no panic.

## Test plan
- [x] `cargo build --bin qsv -F all_features` succeeds
- [x] `cargo t -F all_features reverse` — 24 passed, 0 failed
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` clean
- [x] Manual repro on indexed 1-row CSV: panic gone, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)