### PR TITLE
snappy: preserve validate error, guard decompress ratio on stdin

### DIFF
--- a/src/cmd/snappy.rs
+++ b/src/cmd/snappy.rs
@@ -95,6 +95,13 @@ impl From<gzp::GzpError> for CliError {
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
+    // reject stdin for `validate` early, before any reader setup
+    if args.cmd_validate && args.arg_input.is_none() {
+        return fail_incorrectusage_clierror!(
+            "stdin is not supported by the snappy validate subcommand."
+        );
+    }
+
     let input_bytes;
 
     // create a temporary file to write the download file to
@@ -174,24 +181,27 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     } else if args.cmd_decompress {
         let decompressed_bytes = decompress(input_reader, output_writer)?;
         if !args.flag_quiet {
-            let compression_ratio = decompressed_bytes as f64 / input_bytes as f64;
-            winfo!(
-                "Decompression successful. Compressed bytes: {}, Decompressed bytes: {}, \
-                 Compression ratio: {:.3}:1",
-                indicatif::HumanBytes(input_bytes),
-                indicatif::HumanBytes(decompressed_bytes),
-                compression_ratio,
-            );
+            // input_bytes is 0 when reading from stdin; avoid div-by-zero (+inf)
+            if input_bytes > 0 {
+                let compression_ratio = decompressed_bytes as f64 / input_bytes as f64;
+                winfo!(
+                    "Decompression successful. Compressed bytes: {}, Decompressed bytes: {}, \
+                     Compression ratio: {:.3}:1",
+                    indicatif::HumanBytes(input_bytes),
+                    indicatif::HumanBytes(decompressed_bytes),
+                    compression_ratio,
+                );
+            } else {
+                winfo!(
+                    "Decompression successful. Decompressed bytes: {}",
+                    indicatif::HumanBytes(decompressed_bytes),
+                );
+            }
         }
     } else if args.cmd_validate {
-        if args.arg_input.is_none() {
-            return fail_incorrectusage_clierror!(
-                "stdin is not supported by the snappy validate subcommand."
-            );
-        }
-        let Ok(decompressed_bytes) = validate(input_reader) else {
-            return fail_clierror!("Not a valid snappy file.");
-        };
+        // propagate validate()'s error verbatim — it carries the underlying
+        // FrameDecoder reason (truncated, bad magic, checksum mismatch, ...)
+        let decompressed_bytes = validate(input_reader)?;
         if !args.flag_quiet {
             let compression_ratio = decompressed_bytes as f64 / input_bytes as f64;
             winfo!(

--- a/src/cmd/snappy.rs
+++ b/src/cmd/snappy.rs
@@ -282,6 +282,6 @@ fn validate<R: Read>(src: R) -> CliResult<u64> {
     let mut sink = io::sink();
     match io::copy(&mut src, &mut sink) {
         Ok(decompressed_bytes) => Ok(decompressed_bytes),
-        Err(err) => fail_clierror!("Error validating snappy file: {err:?}"),
+        Err(err) => fail_clierror!("Error validating snappy file: {err}"),
     }
 }

--- a/src/cmd/snappy.rs
+++ b/src/cmd/snappy.rs
@@ -203,16 +203,25 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // FrameDecoder reason (truncated, bad magic, checksum mismatch, ...)
         let decompressed_bytes = validate(input_reader)?;
         if !args.flag_quiet {
-            let compression_ratio = decompressed_bytes as f64 / input_bytes as f64;
-            winfo!(
-                "Valid snappy file. Compressed bytes: {}, Decompressed bytes: {}, Compression \
-                 ratio: {:.3}:1, Space savings: {} - {:.2}%",
-                indicatif::HumanBytes(input_bytes),
-                indicatif::HumanBytes(decompressed_bytes),
-                compression_ratio,
-                indicatif::HumanBytes(decompressed_bytes.saturating_sub(input_bytes)),
-                (1.0 - (input_bytes as f64 / decompressed_bytes as f64)) * 100.0
-            );
+            // mirror the decompress branch: a 0-byte input file would
+            // produce 0/0 = NaN ratios, so guard symmetrically.
+            if input_bytes > 0 {
+                let compression_ratio = decompressed_bytes as f64 / input_bytes as f64;
+                winfo!(
+                    "Valid snappy file. Compressed bytes: {}, Decompressed bytes: {}, Compression \
+                     ratio: {:.3}:1, Space savings: {} - {:.2}%",
+                    indicatif::HumanBytes(input_bytes),
+                    indicatif::HumanBytes(decompressed_bytes),
+                    compression_ratio,
+                    indicatif::HumanBytes(decompressed_bytes.saturating_sub(input_bytes)),
+                    (1.0 - (input_bytes as f64 / decompressed_bytes as f64)) * 100.0
+                );
+            } else {
+                winfo!(
+                    "Valid snappy file. Decompressed bytes: {}",
+                    indicatif::HumanBytes(decompressed_bytes),
+                );
+            }
         }
     } else if args.cmd_check {
         let check_ok = check(input_reader);

--- a/tests/test_snappy.rs
+++ b/tests/test_snappy.rs
@@ -144,6 +144,77 @@ fn snappy_validate() {
 }
 
 #[test]
+fn snappy_validate_stdin_rejected() {
+    // `snappy validate` requires a file/URL <input>; passing stdin must
+    // fail with an "incorrect usage" error before any reader setup.
+    let wrk = Workdir::new("snappy_validate_stdin_rejected");
+
+    let mut cmd = wrk.command("snappy");
+    cmd.arg("validate")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    // write nothing; just close stdin so the child sees EOF
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("stdin is not supported by the snappy validate subcommand"),
+        "expected stdin-not-supported error, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn snappy_decompress_stdin_no_inf_ratio() {
+    // When decompressing from stdin, input_bytes is unknown (0). The status
+    // message must NOT print an infinite/NaN compression ratio.
+    use std::io::Write as _;
+
+    let wrk = Workdir::new("snappy_decompress_stdin_no_inf");
+
+    // Get a real .sz file, then pipe its bytes through stdin.
+    let sz_path = wrk.load_test_file("boston311-100.csv.sz");
+    let sz_bytes = std::fs::read(&sz_path).unwrap();
+
+    let mut cmd = wrk.command("snappy");
+    cmd.arg("decompress")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    std::thread::spawn(move || {
+        stdin.write_all(&sz_bytes).unwrap();
+    });
+
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // No infinite or NaN ratio should leak into the user-visible status line.
+    assert!(
+        !stderr.contains("inf") && !stderr.contains("NaN"),
+        "decompress-from-stdin emitted a non-finite ratio in stderr: {stderr}"
+    );
+    // The fallback message should be used instead.
+    if !stderr.is_empty() {
+        assert!(
+            stderr.contains("Decompression successful"),
+            "expected fallback decompress-success message, got stderr: {stderr}"
+        );
+        assert!(
+            !stderr.contains("Compression ratio"),
+            "stdin path should skip the Compression ratio line, got stderr: {stderr}"
+        );
+    }
+}
+
+#[test]
 fn snappy_validate_invalid() {
     let wrk = Workdir::new("snappy_validate_invalid");
 

--- a/tests/test_snappy.rs
+++ b/tests/test_snappy.rs
@@ -196,22 +196,20 @@ fn snappy_decompress_stdin_no_inf_ratio() {
     assert!(output.status.success());
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // No infinite or NaN ratio should leak into the user-visible status line.
+    // The fallback message must always appear on the stdin path; the test is
+    // pointless if we let an empty stderr pass.
     assert!(
-        !stderr.contains("inf") && !stderr.contains("NaN"),
-        "decompress-from-stdin emitted a non-finite ratio in stderr: {stderr}"
+        stderr.contains("Decompression successful"),
+        "expected fallback decompress-success message, got stderr: {stderr}"
     );
-    // The fallback message should be used instead.
-    if !stderr.is_empty() {
-        assert!(
-            stderr.contains("Decompression successful"),
-            "expected fallback decompress-success message, got stderr: {stderr}"
-        );
-        assert!(
-            !stderr.contains("Compression ratio"),
-            "stdin path should skip the Compression ratio line, got stderr: {stderr}"
-        );
-    }
+    // The fallback path must skip the "Compression ratio" line entirely —
+    // that's exactly how we avoid emitting a non-finite ratio. Asserting the
+    // line is absent is precise; substring-matching "inf" is fragile (would
+    // collide with words like "info"/"infile") and only worked by accident.
+    assert!(
+        !stderr.contains("Compression ratio"),
+        "stdin path should skip the Compression ratio line, got stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Validate path now uses `?` to propagate `validate()`'s error verbatim — the underlying `FrameDecoder` reason (truncated input, bad magic, checksum mismatch, ...) is no longer flattened into a generic "Not a valid snappy file."
- Decompress info-message guards `input_bytes > 0` to avoid emitting a `+inf` compression ratio when reading from stdin; falls back to a shorter message in that case.
- Moved the validate stdin guard to the top of `run`, before any reader/temp-file setup, so the constraint is enforced before side effects.

## Test plan
- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo t snappy -F all_features` — 19/19 snappy-related tests pass
- [x] `cargo clippy -F all_features --bin qsv -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)