### PR TITLE
perf(frequency): hint UTF-8 failure as cold path in ignore-case hot loop

### DIFF
--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -240,6 +240,7 @@ Common options:
                            CSV into memory using CONSERVATIVE heuristics.
 "#;
 
+use core::hint::cold_path;
 use std::{fs, io, str::FromStr, sync::OnceLock};
 
 use crossbeam_channel;
@@ -2711,6 +2712,7 @@ impl Args {
                             field_buffer.extend_from_slice(string_buf.as_bytes());
                             weighted_add(map, field_buffer, weight);
                         } else {
+                            cold_path();
                             weighted_add(map, field, weight);
                         }
                     }
@@ -2723,6 +2725,7 @@ impl Args {
                             field_buffer.extend_from_slice(string_buf.as_bytes());
                             weighted_add(map, field_buffer, weight);
                         } else {
+                            cold_path();
                             weighted_add(map, trim_bs_whitespace(field), weight);
                         }
                     }
@@ -2858,6 +2861,7 @@ impl Args {
                             field_buffer.extend_from_slice(string_buf.as_bytes());
                             ftab.add_borrowed(field_buffer);
                         } else {
+                            cold_path();
                             ftab.add_borrowed(field);
                         }
                     }
@@ -2870,6 +2874,7 @@ impl Args {
                             field_buffer.extend_from_slice(string_buf.as_bytes());
                             ftab.add_borrowed(field_buffer);
                         } else {
+                            cold_path();
                             ftab.add_borrowed(trim_bs_whitespace(field));
                         }
                     }


### PR DESCRIPTION
## Summary
- In `ftables_weighted_internal` and `ftables_unweighted` (`src/cmd/frequency.rs`), the per-cell `process_field` closures branch on `if let Ok(s) = simdutf8::basic::from_utf8(field)` — the `Ok` arm dominates on real data, the `Err` arm is rare.
- Add `core::hint::cold_path()` (stable since Rust 1.92, MSRV here is 1.95) to the four `else` arms so LLVM keeps the hot UTF-8-success body contiguous in the instruction cache.
- 5 lines of code: one `use core::hint::cold_path;` import + four `cold_path();` calls. Behaviour unchanged — `cold_path()` is purely an optimization hint.

## Benchmark
1M-row NYC 311 sample (`NYC_311_SR_2010-2020-sample-1M.csv`, 514 MB, 41 cols), hyperfine 1.20, 10 runs after 2 warmups, on Apple Silicon. Outputs verified identical (`diff -q`) between baseline and coldpath builds.

| Invocation | Baseline | Coldpath | Ratio |
|---|---:|---:|---:|
| `frequency --ignore-case` | 4.399 ± 0.045 s | 4.139 ± 0.093 s | **1.06× faster** |
| `frequency --ignore-case --no-trim` | 4.089 ± 0.090 s | 4.053 ± 0.036 s | 1.01× (noise) |
| `frequency` (default, cache hit) | 1.880 ± 0.028 s | 1.864 ± 0.015 s | 1.01× (noise — paths not exercised) |

The 6% gain is concentrated on the trim + ignore-case variant because its hot-body (`util::to_lowercase_into(s.trim(), …)` + `extend_from_slice` + `add_borrowed`) is the largest of the four closure forms; isolating its icache layout yields the most leverage. The `--no-trim` and default paths show no detectable change (within σ), confirming zero regression.

## Test plan
- [x] `cargo build --release --locked --bin qsv -F all_features` — clean.
- [x] `cargo clippy --bin qsv -F all_features` — no new warnings vs `master`.
- [x] `cargo test -F all_features --test tests test_frequency` — 160 passed, 0 failed.
- [x] Hyperfine A/B as above (outputs match).
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)