### PR TITLE
refactor(stats): shrink and tidy WhichStats

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2152,8 +2152,8 @@ impl Args {
             mode:            self.flag_everything || self.flag_mode,
             typesonly:       self.flag_typesonly,
             percentiles:     self.flag_everything || self.flag_percentiles,
-            percentile_list: self.flag_percentile_list.clone().into_boxed_str(),
             use_weights:     self.flag_weight.is_some(),
+            percentile_list: self.flag_percentile_list.clone().into_boxed_str(),
         }
     }
 
@@ -2652,8 +2652,8 @@ struct WhichStats {
     mode:            bool,
     typesonly:       bool,
     percentiles:     bool,
-    percentile_list: Box<str>,
     use_weights:     bool,
+    percentile_list: Box<str>,
 }
 
 impl Commute for WhichStats {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2152,7 +2152,7 @@ impl Args {
             mode:            self.flag_everything || self.flag_mode,
             typesonly:       self.flag_typesonly,
             percentiles:     self.flag_everything || self.flag_percentiles,
-            percentile_list: self.flag_percentile_list.clone(),
+            percentile_list: self.flag_percentile_list.clone().into_boxed_str(),
             use_weights:     self.flag_weight.is_some(),
         }
     }
@@ -2652,7 +2652,7 @@ struct WhichStats {
     mode:            bool,
     typesonly:       bool,
     percentiles:     bool,
-    percentile_list: String,
+    percentile_list: Box<str>,
     use_weights:     bool,
 }
 
@@ -2693,7 +2693,7 @@ struct Stats {
     total_weight: f64, // 8 bytes - frequently updated for weighted stats
 
     // Configuration flags (accessed once during initialization, cold after init)
-    which: WhichStats, // 40 bytes - read-only after initialization
+    which: WhichStats, // 32 bytes - read-only after initialization
 
     // CACHE LINE 2+: Less frequently accessed but still important
     // Large Option types that may be None, grouped by usage pattern


### PR DESCRIPTION
## Summary

- Change `WhichStats::percentile_list` from `String` to `Box<str>`. The field is set once from the CLI flag and never mutated, so the unused capacity word is wasted. Shrinks `WhichStats` from 40 → 32 bytes and is serde-transparent (no change to the on-disk `<file>.stats.csv.json` cache format; reading old caches still works).
- Move `use_weights` above `percentile_list` so all 12 bool fields form a contiguous block with the variable-size `Box<str>` at the end. Source order has no runtime effect (`WhichStats` is `repr(Rust)`); purely a readability nit.

## Performance note

This is **not** a perf win — framed as `refactor`/`style` for that reason. Benchmarked on a 514 MB / 1M-row `NYC_311_SR_2010-2020-sample-1M.csv` (M4 Max, 10 runs each, `--force` to bypass cache):

| Workload | Before | After |
|----------|--------|-------|
| `stats` | 1.416 s ± 0.007 | 1.422 s ± 0.005 |
| `stats --everything` | 2.181 s ± 0.015 | 2.199 s ± 0.008 |

Both deltas are inside measurement noise. The theoretical cache-line argument (sub-cache-line spillover from `which: WhichStats` into `Stats`' second cache line) doesn't materialize, likely because `Stats` is `#[repr(C, align(64))]` and the 8 saved bytes get absorbed into existing tail padding, plus the bool reads are extremely well-predicted per column.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo clippy -F all_features --bin qsv -- -D warnings`
- [x] `cargo t stats -F all_features` — all 728 stats tests pass
- [x] Verified stats cache JSON file remains structurally compatible (serde matches by name on read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)