### PR TITLE
perf(moarstats): hint rare branches with core::hint::cold_path()

### DIFF
--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -354,6 +354,8 @@ use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use qsv_dateparser::parse_with_preference;
 use rayon::prelude::*;
 use serde::Deserialize;
+use core::hint::cold_path;
+
 use simdutf8::basic::from_utf8;
 use stats::{atkinson, gini, kurtosis};
 use threadpool::ThreadPool;
@@ -1970,10 +1972,12 @@ where
 
             // Parse the value based on field type
             numeric_value = if field_info.field_type.is_date_or_datetime() {
-                // Convert bytes to string for date parsing
+                // Convert bytes to string for date parsing. UTF-8 decode failure
+                // is exceptional in CSV data — mark as cold for branch prediction.
                 if let Ok(value_str) = from_utf8(value_bytes) {
                     parse_date_to_days(value_str, prefer_dmy)
                 } else {
+                    cold_path();
                     None
                 }
             } else {
@@ -1987,6 +1991,7 @@ where
             // Get mutable reference to stats for this field
             // safety: chunk_stats is pre-populated with all field names
             let Some(stats) = chunk_stats.get_mut(field_name) else {
+                cold_path();
                 debug_assert!(false, "chunk_stats missing expected key: {field_name}");
                 continue;
             };
@@ -2303,6 +2308,7 @@ where
 
             // safety: chunk_stats is pre-populated with all field pair indices
             let Some(stats) = chunk_stats.get_mut(&(*idx1, *idx2)) else {
+                cold_path();
                 debug_assert!(false, "chunk_stats missing expected key: ({idx1}, {idx2})");
                 continue;
             };
@@ -2313,6 +2319,7 @@ where
             // columns into a per-record HashMap.
             let numeric_value_x = if field1_info.field_type.is_date_or_datetime() {
                 let Ok(x_str) = from_utf8(value_bytes_x) else {
+                    cold_path();
                     continue;
                 };
                 if let Some(cached) = date_cache.get(x_str) {
@@ -2328,6 +2335,7 @@ where
 
             let numeric_value_y = if field2_info.field_type.is_date_or_datetime() {
                 let Ok(y_str) = from_utf8(value_bytes_y) else {
+                    cold_path();
                     continue;
                 };
                 if let Some(cached) = date_cache.get(y_str) {
@@ -2357,6 +2365,7 @@ where
                 let (Ok(x_str_ref), Ok(y_str_ref)) =
                     (from_utf8(value_bytes_x), from_utf8(value_bytes_y))
                 else {
+                    cold_path();
                     continue;
                 };
                 // NOTE: this is not true string interning — each lookup still yields

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -338,6 +338,7 @@ Common options:
     -o, --output <file>    Write output to <file> instead of overwriting the stats CSV file.
 "#;
 
+use core::hint::cold_path;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -354,8 +355,6 @@ use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use qsv_dateparser::parse_with_preference;
 use rayon::prelude::*;
 use serde::Deserialize;
-use core::hint::cold_path;
-
 use simdutf8::basic::from_utf8;
 use stats::{atkinson, gini, kurtosis};
 use threadpool::ThreadPool;


### PR DESCRIPTION
## Summary
- Adds `core::hint::cold_path()` hints to exceptional branches inside the per-record hot loops of `count_chunk_outliers` and `compute_chunk_bivariate`, matching the pattern already used in `stats.rs`, `frequency.rs`, and `validate.rs`.
- Hinted branches: UTF-8 decode failures on CSV byte cells (virtually always valid UTF-8) and `chunk_stats.get_mut` safety guards already paired with `debug_assert!(false, ...)`.
- Deliberately skipped: leaf `compute_*` finalizer helpers (called O(columns), not in a tight loop), `is_empty()` checks in `parse_float_opt*` / `parse_date_to_days` (empty cells are common in real CSVs), and the outlier-bucket if/else chain (whole purpose of that loop is counting outliers — can't assume "normal" is hot).

## Test plan
- [x] `cargo build --locked --bin qsv -F all_features` — clean
- [x] `cargo test moarstats -F all_features` — 88 passed, 0 failed
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)