### PR TITLE
test(fetch,sample): bind to ephemeral port to fix flaky macOS CI

### DIFF
--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -786,7 +786,7 @@ fn fetchpost_custom_user_agent() {
     wrk.assert_success(&mut cmd);
 }
 
-use std::{sync::mpsc, thread};
+use std::{net::SocketAddr, sync::mpsc, thread};
 
 use actix_web::{
     App, HttpRequest, HttpServer, Responder, Result, dev::ServerHandle, middleware, rt, web,
@@ -813,21 +813,19 @@ async fn get_fullname(req: HttpRequest, name: web::Path<String>) -> Result<impl 
     Ok(web::Json(obj))
 }
 
-// convenience macros for changing test ip/port to use
-macro_rules! test_server {
-    () => {
-        "127.0.0.1:8081"
-    };
-}
+// Bind to 127.0.0.1 with an OS-assigned ephemeral port. Hardcoded ports
+// (this suite previously used 8081) collide on macOS CI runners with peer
+// integration-test binaries / lingering TIME_WAIT sockets and produce flaky
+// "Address already in use" failures. Each test reads the actual SocketAddr
+// from the channel and builds URLs against it via a local closure.
+const FETCH_TEST_BIND_HOST: &str = "127.0.0.1";
 
-macro_rules! test_url {
-    ($api_param:expr_2021) => {
-        concat!("http://", test_server!(), "/", $api_param)
-    };
-}
-
-/// start an Actix Webserver with Rate Limiting via Governor
-async fn run_webserver(tx: mpsc::Sender<ServerHandle>) -> std::io::Result<()> {
+/// start an Actix Webserver with Rate Limiting via Governor.
+/// Sends `Ok((handle, addr))` on success or `Err(msg)` on bind failure so
+/// tests fail fast with a clear error instead of timing out on `recv`.
+async fn run_webserver(
+    tx: mpsc::Sender<std::result::Result<(ServerHandle, SocketAddr), String>>,
+) -> std::io::Result<()> {
     use actix_governor::{Governor, GovernorConfigBuilder};
 
     // Allow bursts with up to five requests per IP address
@@ -839,7 +837,7 @@ async fn run_webserver(tx: mpsc::Sender<ServerHandle>) -> std::io::Result<()> {
         .unwrap();
 
     // server is server controller type, `dev::ServerHandle`
-    let server = HttpServer::new(move || {
+    let server_builder = HttpServer::new(move || {
         App::new()
             // enable logger
             .wrap(middleware::Logger::default())
@@ -847,30 +845,64 @@ async fn run_webserver(tx: mpsc::Sender<ServerHandle>) -> std::io::Result<()> {
             .wrap(Governor::new(&governor_conf))
             .service(web::resource("/user/{name}").route(web::get().to(get_fullname)))
             .service(web::resource("/").to(index))
-    })
-    .bind(test_server!())?
-    .run();
+    });
 
-    // send server controller to main thread
-    let _ = tx.send(server.handle());
+    // Port 0 -> OS picks an unused ephemeral port; addrs() then reports it.
+    let bound = match server_builder.bind((FETCH_TEST_BIND_HOST, 0)) {
+        Ok(b) => b,
+        Err(e) => {
+            let _ = tx.send(Err(format!("bind failed: {e}")));
+            return Err(e);
+        },
+    };
+
+    let addr = match bound.addrs().into_iter().next() {
+        Some(a) => a,
+        None => {
+            let _ = tx.send(Err("bind succeeded but no address was reported".to_string()));
+            return Err(std::io::Error::other(
+                "actix HttpServer::addrs() returned empty",
+            ));
+        },
+    };
+
+    let server = bound.run();
+
+    // send server controller + actual bound addr to main thread
+    let _ = tx.send(Ok((server.handle(), addr)));
 
     // run future
     server.await
 }
 
-#[test]
-#[serial]
-fn fetch_ratelimit() {
-    // start webserver with rate limiting
+/// Helper for `fetch_ratelimit` / `fetch_complex_url_template`: spawn the
+/// webserver thread, wait up to 10s for the bind to either succeed (returning
+/// `(handle, addr)`) or fail, panicking with a clear message otherwise.
+fn start_fetch_webserver() -> (ServerHandle, SocketAddr) {
     let (tx, rx) = mpsc::channel();
-
     println!("START Webserver ");
     thread::spawn(move || {
         let server_future = run_webserver(tx);
         rt::System::new().block_on(server_future)
     });
+    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(Ok(payload)) => payload,
+        Ok(Err(msg)) => panic!("test webserver failed to bind: {msg}"),
+        Err(e) => panic!("test webserver did not start within 10s ({e:?})"),
+    }
+}
 
-    let server_handle = rx.recv().expect("test webserver error");
+#[test]
+#[serial]
+fn fetch_ratelimit() {
+    // start webserver with rate limiting (OS-assigned ephemeral port)
+    let (server_handle, addr) = start_fetch_webserver();
+    // svec! only accepts &'static str, so we need a String-based row helper
+    // for any row that contains a runtime-built URL.
+    let url_row = |path: &str| vec![format!("http://{addr}/{path}")];
+    let url_pair = |path: &str, name: &str| {
+        vec![format!("http://{addr}/{path}"), name.to_string()]
+    };
 
     // proceed with usual unit test
     let wrk = Workdir::new("fetch");
@@ -878,29 +910,29 @@ fn fetch_ratelimit() {
         "data.csv",
         vec![
             svec!["URL"],
-            svec![test_url!("user/Smurfette")],
-            svec![test_url!("user/Papa")],
-            svec![test_url!("user/Clumsy")],
-            svec![test_url!("user/Brainy")],
-            svec![test_url!("user/Grouchy")],
-            svec![test_url!("user/Hefty")],
-            svec![test_url!("user/Greedy")],
-            svec![test_url!("user/Jokey")],
-            svec![test_url!("user/Chef")],
-            svec![test_url!("user/Vanity")],
-            svec![test_url!("user/Handy")],
-            svec![test_url!("user/Scaredy")],
-            svec![test_url!("user/Tracker")],
-            svec![test_url!("user/Sloppy")],
-            svec![test_url!("user/Harmony")],
-            svec![test_url!("user/Painter")],
-            svec![test_url!("user/Poet")],
-            svec![test_url!("user/Farmer")],
-            svec![test_url!("user/Natural")],
-            svec![test_url!("user/Snappy")],
-            svec![test_url!(
-                "user/The quick brown fox jumped over the lazy dog by the zigzag quarry site"
-            )],
+            url_row("user/Smurfette"),
+            url_row("user/Papa"),
+            url_row("user/Clumsy"),
+            url_row("user/Brainy"),
+            url_row("user/Grouchy"),
+            url_row("user/Hefty"),
+            url_row("user/Greedy"),
+            url_row("user/Jokey"),
+            url_row("user/Chef"),
+            url_row("user/Vanity"),
+            url_row("user/Handy"),
+            url_row("user/Scaredy"),
+            url_row("user/Tracker"),
+            url_row("user/Sloppy"),
+            url_row("user/Harmony"),
+            url_row("user/Painter"),
+            url_row("user/Poet"),
+            url_row("user/Farmer"),
+            url_row("user/Natural"),
+            url_row("user/Snappy"),
+            url_row(
+                "user/The quick brown fox jumped over the lazy dog by the zigzag quarry site",
+            ),
         ],
     );
 
@@ -917,32 +949,30 @@ fn fetch_ratelimit() {
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["URL", "Fullname"],
-        svec![test_url!("user/Smurfette"), "Smurfette Smurf"],
-        svec![test_url!("user/Papa"), "Papa Smurf"],
-        svec![test_url!("user/Clumsy"), "Clumsy Smurf"],
-        svec![test_url!("user/Brainy"), "Brainy Smurf"],
-        svec![test_url!("user/Grouchy"), "Grouchy Smurf"],
-        svec![test_url!("user/Hefty"), "Hefty Smurf"],
-        svec![test_url!("user/Greedy"), "Greedy Smurf"],
-        svec![test_url!("user/Jokey"), "Jokey Smurf"],
-        svec![test_url!("user/Chef"), "Chef Smurf"],
-        svec![test_url!("user/Vanity"), "Vanity Smurf"],
-        svec![test_url!("user/Handy"), "Handy Smurf"],
-        svec![test_url!("user/Scaredy"), "Scaredy Smurf"],
-        svec![test_url!("user/Tracker"), "Tracker Smurf"],
-        svec![test_url!("user/Sloppy"), "Sloppy Smurf"],
-        svec![test_url!("user/Harmony"), "Harmony Smurf"],
-        svec![test_url!("user/Painter"), "Painter Smurf"],
-        svec![test_url!("user/Poet"), "Poet Smurf"],
-        svec![test_url!("user/Farmer"), "Farmer Smurf"],
-        svec![test_url!("user/Natural"), "Natural Smurf"],
-        svec![test_url!("user/Snappy"), "Snappy Smurf"],
-        svec![
-            test_url!(
-                "user/The quick brown fox jumped over the lazy dog by the zigzag quarry site"
-            ),
-            "The quick brown fox jumped over the lazy dog by the zigzag quarry site Smurf"
-        ],
+        url_pair("user/Smurfette", "Smurfette Smurf"),
+        url_pair("user/Papa", "Papa Smurf"),
+        url_pair("user/Clumsy", "Clumsy Smurf"),
+        url_pair("user/Brainy", "Brainy Smurf"),
+        url_pair("user/Grouchy", "Grouchy Smurf"),
+        url_pair("user/Hefty", "Hefty Smurf"),
+        url_pair("user/Greedy", "Greedy Smurf"),
+        url_pair("user/Jokey", "Jokey Smurf"),
+        url_pair("user/Chef", "Chef Smurf"),
+        url_pair("user/Vanity", "Vanity Smurf"),
+        url_pair("user/Handy", "Handy Smurf"),
+        url_pair("user/Scaredy", "Scaredy Smurf"),
+        url_pair("user/Tracker", "Tracker Smurf"),
+        url_pair("user/Sloppy", "Sloppy Smurf"),
+        url_pair("user/Harmony", "Harmony Smurf"),
+        url_pair("user/Painter", "Painter Smurf"),
+        url_pair("user/Poet", "Poet Smurf"),
+        url_pair("user/Farmer", "Farmer Smurf"),
+        url_pair("user/Natural", "Natural Smurf"),
+        url_pair("user/Snappy", "Snappy Smurf"),
+        url_pair(
+            "user/The quick brown fox jumped over the lazy dog by the zigzag quarry site",
+            "The quick brown fox jumped over the lazy dog by the zigzag quarry site Smurf",
+        ),
     ];
     assert_eq!(got, expected);
 
@@ -954,16 +984,8 @@ fn fetch_ratelimit() {
 #[test]
 #[serial]
 fn fetch_complex_url_template() {
-    // start webserver with rate limiting
-    let (tx, rx) = mpsc::channel();
-
-    println!("START Webserver ");
-    thread::spawn(move || {
-        let server_future = run_webserver(tx);
-        rt::System::new().block_on(server_future)
-    });
-
-    let server_handle = rx.recv().unwrap();
+    // start webserver with rate limiting (OS-assigned ephemeral port)
+    let (server_handle, addr) = start_fetch_webserver();
 
     // proceed with usual unit test
     let wrk = Workdir::new("fetch_complex_template");
@@ -995,11 +1017,7 @@ fn fetch_complex_url_template() {
     );
     let mut cmd = wrk.command("fetch");
     cmd.arg("--url-template")
-        .arg(concat!(
-            "http://",
-            test_server!(),
-            "/user/{first_name}%20{color}"
-        ))
+        .arg(format!("http://{addr}/user/{{first_name}}%20{{color}}"))
         .arg("--new-column")
         .arg("Fullname")
         .arg("--jaq")

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -900,9 +900,7 @@ fn fetch_ratelimit() {
     // svec! only accepts &'static str, so we need a String-based row helper
     // for any row that contains a runtime-built URL.
     let url_row = |path: &str| vec![format!("http://{addr}/{path}")];
-    let url_pair = |path: &str, name: &str| {
-        vec![format!("http://{addr}/{path}"), name.to_string()]
-    };
+    let url_pair = |path: &str, name: &str| vec![format!("http://{addr}/{path}"), name.to_string()];
 
     // proceed with usual unit test
     let wrk = Workdir::new("fetch");
@@ -930,9 +928,7 @@ fn fetch_ratelimit() {
             url_row("user/Farmer"),
             url_row("user/Natural"),
             url_row("user/Snappy"),
-            url_row(
-                "user/The quick brown fox jumped over the lazy dog by the zigzag quarry site",
-            ),
+            url_row("user/The quick brown fox jumped over the lazy dog by the zigzag quarry site"),
         ],
     );
 

--- a/tests/test_sample.rs
+++ b/tests/test_sample.rs
@@ -2046,20 +2046,18 @@ fn sample_timeseries_adaptive_both() {
 //   * --delimiter is honored on the streaming path.
 // =============================================================================
 
-use std::{sync::mpsc, thread};
+use std::{net::SocketAddr, sync::mpsc, thread};
 
 use actix_web::{App, HttpResponse, HttpServer, dev::ServerHandle, rt, web};
 use serial_test::serial;
 
-// Single source of truth: the bind host literal and port. Distinct from
-// test_fetch.rs (which uses 8081) so the two suites don't clash when run in
-// parallel across integration-test binaries.
+// Bind to 127.0.0.1 with an OS-assigned ephemeral port (port 0). Hardcoded
+// ports collide on macOS CI runners (TIME_WAIT after teardown, peer
+// integration-test binaries holding the port) and produce flaky
+// "Address already in use" failures in the sample suite. The actual bound
+// SocketAddr is captured via HttpServer::addrs() and threaded back to each
+// test through SampleWebServer so URLs can be built against it.
 const SAMPLE_TEST_BIND_HOST: &str = "127.0.0.1";
-const SAMPLE_TEST_PORT: u16 = 8082;
-
-fn sample_test_url(path: &str) -> String {
-    format!("http://{SAMPLE_TEST_BIND_HOST}:{SAMPLE_TEST_PORT}/{path}")
-}
 
 // Header field 0 contains a quoted newline (per RFC 4180). The OLD streaming
 // header parser split on the first raw `\n`, which would land INSIDE the
@@ -2102,12 +2100,12 @@ async fn serve_large_csv() -> HttpResponse {
         .body(large_csv_body())
 }
 
-// Channel payload: Ok(handle) on a successful bind, Err(msg) if bind() failed
-// (e.g. "Address already in use"). Sending Result instead of just the handle
-// means a failed bind surfaces a real error to start() instead of leaving the
-// receiver to time out.
+// Channel payload: Ok((handle, addr)) on a successful bind (addr carries the
+// OS-assigned ephemeral port), Err(msg) if bind() failed. Sending Result
+// instead of just the handle means a failed bind surfaces a real error to
+// start() instead of leaving the receiver to time out.
 async fn run_sample_webserver(
-    tx: mpsc::Sender<Result<ServerHandle, String>>,
+    tx: mpsc::Sender<Result<(ServerHandle, SocketAddr), String>>,
 ) -> std::io::Result<()> {
     let server_builder = HttpServer::new(|| {
         App::new()
@@ -2117,7 +2115,9 @@ async fn run_sample_webserver(
         // anything else -> 404 (handled by actix-web default)
     });
 
-    let bound = match server_builder.bind((SAMPLE_TEST_BIND_HOST, SAMPLE_TEST_PORT)) {
+    // Port 0 -> OS picks an unused ephemeral port; addrs() then reports the
+    // actual SocketAddr we landed on.
+    let bound = match server_builder.bind((SAMPLE_TEST_BIND_HOST, 0)) {
         Ok(b) => b,
         Err(e) => {
             let _ = tx.send(Err(format!("bind failed: {e}")));
@@ -2125,8 +2125,18 @@ async fn run_sample_webserver(
         },
     };
 
+    let addr = match bound.addrs().into_iter().next() {
+        Some(a) => a,
+        None => {
+            let _ = tx.send(Err("bind succeeded but no address was reported".to_string()));
+            return Err(std::io::Error::other(
+                "actix HttpServer::addrs() returned empty",
+            ));
+        },
+    };
+
     let server = bound.run();
-    let _ = tx.send(Ok(server.handle()));
+    let _ = tx.send(Ok((server.handle(), addr)));
     server.await
 }
 
@@ -2136,6 +2146,7 @@ async fn run_sample_webserver(
 // test, producing confusing follow-on failures.
 struct SampleWebServer {
     handle: Option<ServerHandle>,
+    addr:   SocketAddr,
 }
 
 impl SampleWebServer {
@@ -2149,14 +2160,23 @@ impl SampleWebServer {
         // recv_timeout (rather than recv) so a failed bind that the server
         // thread can't surface in time doesn't hang the test forever.
         match rx.recv_timeout(std::time::Duration::from_secs(10)) {
-            Ok(Ok(handle)) => Self {
+            Ok(Ok((handle, addr))) => Self {
                 handle: Some(handle),
+                addr,
             },
             Ok(Err(msg)) => panic!("test webserver failed to bind: {msg}"),
             Err(e) => {
                 panic!("test webserver did not start within 10s ({e:?})")
             },
         }
+    }
+
+    /// Build a URL against the actual bound (ephemeral) port. The leading
+    /// slash on the path is optional — both `"foo.csv"` and `"/foo.csv"`
+    /// produce the same URL.
+    fn url(&self, path: &str) -> String {
+        let path = path.strip_prefix('/').unwrap_or(path);
+        format!("http://{}/{path}", self.addr)
     }
 }
 
@@ -2207,13 +2227,13 @@ fn parse_csv_stdout(stdout: &[u8]) -> Vec<Vec<String>> {
 #[serial]
 fn sample_bernoulli_url_quoted_newline_header() {
     // RAII guard: server is torn down even if the test panics below.
-    let _server = SampleWebServer::start();
+    let server = SampleWebServer::start();
 
     let wrk = Workdir::new("sample_bernoulli_url_quoted_nl");
     let mut cmd = wrk.command("sample");
     cmd.args(["--bernoulli", "--seed", "42"])
         .arg("0.999")
-        .arg(sample_test_url("quoted_nl_header.csv"));
+        .arg(server.url("quoted_nl_header.csv"));
 
     // Run once, assert success, and parse stdout from the same execution
     // — surfaces qsv's stderr on failure and doesn't double-hit the fixture.
@@ -2248,14 +2268,14 @@ fn sample_bernoulli_url_quoted_newline_header() {
 #[test]
 #[serial]
 fn sample_bernoulli_url_max_size_truncation() {
-    let _server = SampleWebServer::start();
+    let server = SampleWebServer::start();
 
     let wrk = Workdir::new("sample_bernoulli_url_max_size");
     let mut cmd = wrk.command("sample");
     cmd.args(["--bernoulli", "--seed", "42"])
         .args(["--max-size", "1"])
         .arg("0.5")
-        .arg(sample_test_url("large.csv"));
+        .arg(server.url("large.csv"));
 
     // Single run — the previous double-run pattern doubled the ~1.2 MiB
     // download AND meant the stdout we parsed was from a different execution
@@ -2303,13 +2323,13 @@ fn sample_bernoulli_url_max_size_truncation() {
 #[test]
 #[serial]
 fn sample_bernoulli_url_404_fails_fast() {
-    let _server = SampleWebServer::start();
+    let server = SampleWebServer::start();
 
     let wrk = Workdir::new("sample_bernoulli_url_404");
     let mut cmd = wrk.command("sample");
     cmd.args(["--bernoulli", "--seed", "42"])
         .arg("0.5")
-        .arg(sample_test_url("does_not_exist.csv"));
+        .arg(server.url("does_not_exist.csv"));
 
     // .error_for_status() should turn the 404 into an Err in the streaming
     // path, so qsv exits with non-zero. Without that, the HTML 404 body
@@ -2320,14 +2340,14 @@ fn sample_bernoulli_url_404_fails_fast() {
 #[test]
 #[serial]
 fn sample_bernoulli_url_custom_delimiter() {
-    let _server = SampleWebServer::start();
+    let server = SampleWebServer::start();
 
     let wrk = Workdir::new("sample_bernoulli_url_tsv");
     let mut cmd = wrk.command("sample");
     cmd.args(["--bernoulli", "--seed", "42"])
         .args(["--delimiter", "\t"])
         .arg("0.999")
-        .arg(sample_test_url("data.tsv"));
+        .arg(server.url("data.tsv"));
 
     // qsv's writer also honors --delimiter, so output is tab-separated.
     // read_stdout()'s CSV parser would treat that as a single comma-field, so


### PR DESCRIPTION
## Summary

- The actix-web test servers in `tests/test_fetch.rs` (port 8081) and `tests/test_sample.rs` (port 8082) bind to hardcoded ports. On macOS GitHub runners this produces intermittent `Address already in use (os error 48)` failures from peer integration-test binaries and TIME_WAIT sockets — e.g. [run 25470381157](https://github.com/dathere/qsv/actions/runs/25470381157/job/74732835126), and similar flakes on master and other unrelated branches over the past day.
- Switch both suites to port `0` (OS-assigned ephemeral) and thread the actual bound `SocketAddr` back to each test through the existing `mpsc` channel, so URLs are built against the real port at runtime. `SampleWebServer` gains a `url(path)` accessor; `test_fetch.rs` gets a small `start_fetch_webserver()` helper and runtime `format!()` URL construction in place of the old `test_server!` / `test_url!` `concat!` macros.

## Test plan

- [x] `cargo check --tests -F all_features` — clean
- [x] `cargo test -F all_features --test tests test_sample::sample_bernoulli_url -- --test-threads=1` — 4/4 passed × 4 consecutive runs (locally on macOS)
- [x] `cargo test -F all_features --test tests test_fetch -- --test-threads=1` — 41 passed, 1 ignored (pre-existing `zippotam.us` skip)
- [x] `cargo clippy -F all_features --tests` — 381 messages before and after; no new lints introduced
- [ ] CI: confirm `macOS - Polars` passes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)