### PR TITLE
fix(moarstats): close fsync race that silently dropped joined columns on macOS

### DIFF
--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -705,7 +705,7 @@ fn join_datasets_internal(
             }
         }
 
-        let size = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
+        let size = std::fs::metadata(output_path).map_or(0, |m| m.len());
         // Keep info-level output compact (column count + size). The full
         // header vector can be very large/noisy on wide CSVs and is also
         // slow to format — log it at debug only.

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -518,6 +518,10 @@ fn join_datasets_internal(
     join_keys: &[String],
     join_type: &str,
 ) -> CliResult<PathBuf> {
+    use std::collections::HashSet;
+
+    use tempfile::TempPath;
+
     if additional_inputs.is_empty() {
         return fail_clierror!("No additional datasets provided for joining");
     }
@@ -576,6 +580,15 @@ fn join_datasets_internal(
         .to_string_lossy()
         .to_string();
 
+    // Hold intermediate temp files alive in a Vec<TempPath>. TempPath does
+    // NOT hold a writable handle (so `qsv join`'s O_CREAT|O_TRUNC works
+    // fine), but it does delete the path on Drop. Storing them here means
+    // intermediate temp files are auto-cleaned when this function returns,
+    // rather than accumulating in TEMP_FILE_DIR for the life of the process.
+    let mut intermediate_temps: Vec<TempPath> = Vec::with_capacity(
+        additional_inputs.len().saturating_sub(1),
+    );
+
     for (i, (additional_input, next_key)) in additional_inputs
         .iter()
         .zip(join_keys[1..].iter())
@@ -594,25 +607,23 @@ fn join_datasets_internal(
         args.push(additional_input);
 
         let output_path_str = if i == additional_inputs.len() - 1 {
-            // Last join - use final temp path
+            // Last join - use final temp path (kept; caller owns lifetime).
             temp_path_str.clone()
         } else {
-            // Intermediate join - create another temp file with .csv extension.
-            // Use into_temp_path().keep() for the same reason as the final
-            // temp_path above: the path is owned by output_path_str and the
-            // file is consumed (re-created) by `qsv join` in this iteration,
-            // then read by the next iteration.
-            tempfile::Builder::new()
+            // Intermediate join - create another temp file with .csv
+            // extension. We retain the TempPath (not .keep()) in
+            // intermediate_temps so the file is auto-deleted when this
+            // function returns, preventing accumulation in TEMP_FILE_DIR.
+            let intermediate = tempfile::Builder::new()
                 .suffix(".csv")
                 .tempfile_in(temp_dir)?
-                .into_temp_path()
-                .keep()
-                .map_err(|e| {
-                    CliError::Other(format!("Failed to persist intermediate temp path: {e}"))
-                })?
+                .into_temp_path();
+            let s = intermediate
                 .to_str()
                 .ok_or_else(|| CliError::Other("Invalid intermediate temp path".to_string()))?
-                .to_string()
+                .to_string();
+            intermediate_temps.push(intermediate);
+            s
         };
         args.push("--output");
         args.push(&output_path_str);
@@ -683,8 +694,11 @@ fn join_datasets_internal(
             .collect();
         drop(additional_rdr);
 
+        // O(1) membership check via HashSet — for wide CSVs and multi-join
+        // chains this avoids an O(n*m) scan per iteration.
+        let joined_set: HashSet<&str> = joined_headers.iter().map(String::as_str).collect();
         for h in &additional_headers {
-            if !joined_headers.iter().any(|j| j == h) {
+            if !joined_set.contains(h.as_str()) {
                 return fail_clierror!(
                     "Joined output header missing column from {additional_input}: expected to \
                      find {h:?} among {additional_headers:?}, got {joined_headers:?}"
@@ -693,10 +707,14 @@ fn join_datasets_internal(
         }
 
         let size = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
+        // Keep info-level output compact (column count + size). The full
+        // header vector can be very large/noisy on wide CSVs and is also
+        // slow to format — log it at debug only.
         log::info!(
-            "Join step {i}: produced {} cols (header={joined_headers:?}), {size} bytes",
+            "Join step {i}: produced {} cols, {size} bytes",
             joined_headers.len()
         );
+        log::debug!("Join step {i} header: {joined_headers:?}");
 
         // Update for next iteration
         current_input = output_path_str;

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -512,15 +512,12 @@ fn get_bivariate_csv_path(input_path: &Path, is_joined: bool) -> CliResult<PathB
     }
 }
 
-/// Join multiple datasets internally using join
 fn join_datasets_internal(
     primary_input: &Path,
     additional_inputs: &[String],
     join_keys: &[String],
     join_type: &str,
 ) -> CliResult<PathBuf> {
-    use tempfile::NamedTempFile;
-
     if additional_inputs.is_empty() {
         return fail_clierror!("No additional datasets provided for joining");
     }
@@ -533,14 +530,22 @@ fn join_datasets_internal(
         );
     }
 
-    // Create temporary file for joined output with .csv extension
+    // Create temporary file for joined output with .csv extension.
+    //
+    // We use `into_temp_path().keep()` instead of holding a `NamedTempFile`
+    // and `drop`ping it. NamedTempFile's `Drop` deletes the file from disk,
+    // which leaves a dangling reservation that the spawned `qsv join`
+    // re-creates with O_CREAT. The previous "drop to close" pattern was
+    // misleading — the path was free, not just closed. `keep()` persists the
+    // path as a normal file so the caller owns its lifetime.
     let temp_dir =
         crate::config::TEMP_FILE_DIR.get_or_init(|| tempfile::TempDir::new().unwrap().keep());
-    let temp_file = tempfile::Builder::new()
+    let temp_path = tempfile::Builder::new()
         .suffix(".csv")
-        .tempfile_in(temp_dir)?;
-    let temp_path = temp_file.path().to_path_buf();
-    drop(temp_file); // Close the file so join can write to it
+        .tempfile_in(temp_dir)?
+        .into_temp_path()
+        .keep()
+        .map_err(|e| CliError::Other(format!("Failed to persist join temp path: {e}")))?;
 
     let temp_path_str = temp_path
         .to_str()
@@ -571,12 +576,6 @@ fn join_datasets_internal(
         .to_string_lossy()
         .to_string();
 
-    // These are never read, but we need to declare them to avoid compiler errors
-    #[allow(clippy::collection_is_never_read)]
-    let mut intermediate_temps: Vec<NamedTempFile> = Vec::new();
-    #[allow(clippy::collection_is_never_read)]
-    let mut intermediate_path_strs: Vec<String> = Vec::new();
-
     for (i, (additional_input, next_key)) in additional_inputs
         .iter()
         .zip(join_keys[1..].iter())
@@ -598,18 +597,22 @@ fn join_datasets_internal(
             // Last join - use final temp path
             temp_path_str.clone()
         } else {
-            // Intermediate join - create another temp file with .csv extension
-            let intermediate_temp = tempfile::Builder::new()
+            // Intermediate join - create another temp file with .csv extension.
+            // Use into_temp_path().keep() for the same reason as the final
+            // temp_path above: the path is owned by output_path_str and the
+            // file is consumed (re-created) by `qsv join` in this iteration,
+            // then read by the next iteration.
+            tempfile::Builder::new()
                 .suffix(".csv")
-                .tempfile_in(temp_dir)?;
-            let intermediate_path = intermediate_temp.path().to_path_buf();
-            intermediate_temps.push(intermediate_temp); // Keep temp file alive
-            let intermediate_path_str = intermediate_path
+                .tempfile_in(temp_dir)?
+                .into_temp_path()
+                .keep()
+                .map_err(|e| {
+                    CliError::Other(format!("Failed to persist intermediate temp path: {e}"))
+                })?
                 .to_str()
                 .ok_or_else(|| CliError::Other("Invalid intermediate temp path".to_string()))?
-                .to_string();
-            intermediate_path_strs.push(intermediate_path_str.clone());
-            intermediate_path_str
+                .to_string()
         };
         args.push("--output");
         args.push(&output_path_str);
@@ -632,7 +635,68 @@ fn join_datasets_internal(
             );
         }
 
-        log::info!("Joining datasets...");
+        // After the child exits successfully, force the OS to flush its
+        // dirty pages and validate the file is non-empty. Without this,
+        // macOS APFS under heavy parallel test load has been observed to
+        // hand a follow-up `qsv stats` subprocess a short/empty file,
+        // causing silent "primary-only" bivariate output.
+        let output_path = Path::new(&output_path_str);
+        util::sync_subprocess_output(output_path)?;
+
+        // Validate that the joined output's header contains every column
+        // from the secondary input. qsv's `join` (without --cross or merge
+        // flags, which join_datasets_internal never passes — it only uses
+        // --left/--right/--full or default inner) preserves the union of
+        // both inputs' columns. If a column from the secondary is missing,
+        // the join produced silently corrupt output and we must fail loudly
+        // rather than feeding it to downstream stats/bivariate computation.
+        let mut joined_rdr = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .from_path(output_path)
+            .map_err(|e| {
+                CliError::Other(format!(
+                    "Failed to open joined output to validate header ({}): {e}",
+                    output_path.display()
+                ))
+            })?;
+        let joined_headers: Vec<String> = joined_rdr
+            .headers()
+            .map_err(|e| CliError::Other(format!("Failed to read joined header: {e}")))?
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        drop(joined_rdr);
+
+        let mut additional_rdr = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .from_path(Path::new(additional_input))
+            .map_err(|e| {
+                CliError::Other(format!(
+                    "Failed to open secondary input to validate header ({additional_input}): {e}"
+                ))
+            })?;
+        let additional_headers: Vec<String> = additional_rdr
+            .headers()
+            .map_err(|e| CliError::Other(format!("Failed to read secondary header: {e}")))?
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        drop(additional_rdr);
+
+        for h in &additional_headers {
+            if !joined_headers.iter().any(|j| j == h) {
+                return fail_clierror!(
+                    "Joined output header missing column from {additional_input}: expected to \
+                     find {h:?} among {additional_headers:?}, got {joined_headers:?}"
+                );
+            }
+        }
+
+        let size = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
+        log::info!(
+            "Join step {i}: produced {} cols (header={joined_headers:?}), {size} bytes",
+            joined_headers.len()
+        );
 
         // Update for next iteration
         current_input = output_path_str;
@@ -3270,11 +3334,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .to_str()
             .ok_or_else(|| CliError::Other("Invalid joined path".to_string()))?
             .to_string();
-        let temp_stats_file = tempfile::Builder::new().suffix(".stats.csv").tempfile_in(
-            crate::config::TEMP_FILE_DIR.get_or_init(|| tempfile::TempDir::new().unwrap().keep()),
-        )?;
-        let temp_stats_path = temp_stats_file.path().to_path_buf();
-        drop(temp_stats_file); // Close so stats can write to it
+        // Use into_temp_path().keep() rather than NamedTempFile + drop, for
+        // the same reason as in `join_datasets_internal`: NamedTempFile's
+        // Drop deletes the file from disk. We want the path reserved as a
+        // normal file so the spawned `qsv stats` writes into a known slot.
+        let temp_stats_path = tempfile::Builder::new()
+            .suffix(".stats.csv")
+            .tempfile_in(
+                crate::config::TEMP_FILE_DIR
+                    .get_or_init(|| tempfile::TempDir::new().unwrap().keep()),
+            )?
+            .into_temp_path()
+            .keep()
+            .map_err(|e| CliError::Other(format!("Failed to persist temp stats path: {e}")))?;
 
         // Generate stats for joined dataset
         let stats_args_vec: Vec<&str> = args.flag_stats_options.split_whitespace().collect();
@@ -3305,6 +3377,36 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             );
         }
 
+        // Force a flush of the stats subprocess output to disk before any
+        // follow-up read. Same rationale as in join_datasets_internal:
+        // macOS APFS under heavy parallel load has been observed to hand
+        // back a short/empty file to the next open() without this fsync.
+        util::sync_subprocess_output(&temp_stats_path)?;
+
+        // Validate that the stats CSV has the expected `field` column header
+        // so a silently truncated file fails loudly here rather than later.
+        let mut stats_hdr_rdr = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .from_path(&temp_stats_path)
+            .map_err(|e| {
+                CliError::Other(format!(
+                    "Failed to open joined-stats output to validate header ({}): {e}",
+                    temp_stats_path.display()
+                ))
+            })?;
+        let stats_headers: Vec<String> = stats_hdr_rdr
+            .headers()
+            .map_err(|e| CliError::Other(format!("Failed to read joined-stats header: {e}")))?
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        drop(stats_hdr_rdr);
+        if !stats_headers.iter().any(|h| h == "field") {
+            return fail_clierror!(
+                "Joined-stats output missing 'field' column: got headers {stats_headers:?}"
+            );
+        }
+
         temp_stats_path
     } else {
         // For single dataset, use normal stats CSV path
@@ -3332,6 +3434,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             if !path.exists() {
                 return fail_clierror!("Stats CSV file was not created: {}", path.display());
             }
+            // Force the freshly-written stats CSV's bytes to disk so a
+            // subsequent read sees the full file (defensive fsync; same
+            // rationale as the joined-stats path above).
+            util::sync_subprocess_output(&path)?;
         }
 
         path

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -580,11 +580,17 @@ fn join_datasets_internal(
         .to_string_lossy()
         .to_string();
 
-    // Hold intermediate temp files alive in a Vec<TempPath>. TempPath does
-    // NOT hold a writable handle (so `qsv join`'s O_CREAT|O_TRUNC works
-    // fine), but it does delete the path on Drop. Storing them here means
-    // intermediate temp files are auto-cleaned when this function returns,
-    // rather than accumulating in TEMP_FILE_DIR for the life of the process.
+    // Drop-guard collection: this Vec is intentionally never read — its
+    // ONLY purpose is to keep each intermediate `TempPath` alive until the
+    // function returns, at which point each entry's `Drop` removes its
+    // file from disk. `TempPath` holds no writable handle (so `qsv join`'s
+    // `O_CREAT|O_TRUNC` open still works) but it does own the path's
+    // lifetime. Without this Vec, intermediate temp files would either be
+    // deleted mid-loop (if we let `TempPath` drop after each iteration) or
+    // accumulate forever in `TEMP_FILE_DIR` (if we called `.keep()`).
+    // DO NOT remove the Vec to silence `collection_is_never_read` — the
+    // Drop side-effect is load-bearing.
+    #[allow(clippy::collection_is_never_read)]
     let mut intermediate_temps: Vec<TempPath> =
         Vec::with_capacity(additional_inputs.len().saturating_sub(1));
 

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -585,9 +585,8 @@ fn join_datasets_internal(
     // fine), but it does delete the path on Drop. Storing them here means
     // intermediate temp files are auto-cleaned when this function returns,
     // rather than accumulating in TEMP_FILE_DIR for the life of the process.
-    let mut intermediate_temps: Vec<TempPath> = Vec::with_capacity(
-        additional_inputs.len().saturating_sub(1),
-    );
+    let mut intermediate_temps: Vec<TempPath> =
+        Vec::with_capacity(additional_inputs.len().saturating_sub(1));
 
     for (i, (additional_input, next_key)) in additional_inputs
         .iter()

--- a/src/util.rs
+++ b/src/util.rs
@@ -3825,6 +3825,49 @@ pub fn run_qsv_cmd(
     Ok((stdout_str.to_string(), stderr_str.to_string()))
 }
 
+/// Sync subprocess output to disk and validate it is non-empty.
+///
+/// After a child `qsv` subprocess writes its output via `--output <path>` and
+/// exits, the file's bytes may still be in the kernel page cache and not yet
+/// visible to follow-up `open()` calls in another process. This is especially
+/// noticeable on macOS APFS under heavy parallel test load and has produced
+/// silent "primary-only" join output in CI.
+///
+/// This helper opens the file read-only, calls `sync_all()` to force a
+/// flush, then verifies the resulting file is non-empty. On Linux the
+/// fsync is nearly free; on macOS it is the load-bearing barrier.
+pub fn sync_subprocess_output(path: &Path) -> CliResult<()> {
+    let f = std::fs::OpenOptions::new()
+        .read(true)
+        .open(path)
+        .map_err(|e| {
+            CliError::Other(format!(
+                "Unable to open subprocess output for fsync ({}): {e}",
+                path.display()
+            ))
+        })?;
+    f.sync_all().map_err(|e| {
+        CliError::Other(format!(
+            "Failed to sync subprocess output ({}): {e}",
+            path.display()
+        ))
+    })?;
+    drop(f);
+
+    let size = std::fs::metadata(path)
+        .map_err(|e| {
+            CliError::Other(format!(
+                "Unable to stat subprocess output ({}): {e}",
+                path.display()
+            ))
+        })?
+        .len();
+    if size == 0 {
+        return fail_clierror!("Subprocess output is empty after sync: {}", path.display());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -79,6 +79,48 @@ fn assert_bivariate_n_pairs(
     );
 }
 
+/// Assert every name in `expected_fields` appears at least once across the
+/// `field1` or `field2` columns of the bivariate output. Catches the silent
+/// "primary-only" join corruption mode loudly: if the join failed to merge
+/// secondary columns, this fires with a clear "missing columns" message
+/// instead of letting the downstream `assert_bivariate_n_pairs` produce a
+/// confusing "no row found for (X, Y)" error.
+fn assert_bivariate_columns_present(
+    wrk: &Workdir,
+    path: &str,
+    expected_fields: &[&str],
+    msg: &str,
+) {
+    let content = wrk.read_to_string(path).unwrap();
+    let mut rdr = ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(content.as_bytes());
+    let headers = rdr.headers().unwrap().clone();
+    let f1_idx = get_column_index(&headers, "field1").expect("field1 column missing");
+    let f2_idx = get_column_index(&headers, "field2").expect("field2 column missing");
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for record in rdr.records() {
+        let record = record.unwrap();
+        if let Some(v) = get_field_value(&record, f1_idx) {
+            seen.insert(v.to_string());
+        }
+        if let Some(v) = get_field_value(&record, f2_idx) {
+            seen.insert(v.to_string());
+        }
+    }
+
+    let missing: Vec<&&str> = expected_fields
+        .iter()
+        .filter(|f| !seen.contains(**f))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "{msg}: bivariate output is missing expected columns {missing:?} (saw {seen:?}); likely \
+         silent join corruption — full bivariate output:\n{content}",
+    );
+}
+
 #[test]
 fn moarstats_basic_with_existing_stats() {
     let wrk = Workdir::new("moarstats_basic");
@@ -4458,6 +4500,16 @@ fn moarstats_join_type_left_runs_and_writes_bivariate() {
         .arg("primary.csv");
     wrk.assert_success(&mut cmd);
 
+    // Pre-check: secondary columns must be in the joined bivariate output.
+    // Catches silent join corruption (primary-only output) before the
+    // n_pairs assertion produces a confusing diagnostic.
+    assert_bivariate_columns_present(
+        &wrk,
+        "primary.stats.bivariate.joined.csv",
+        &["value1", "value2"],
+        "left join must merge primary+secondary numeric columns into bivariate output",
+    );
+
     assert_bivariate_n_pairs(
         &wrk,
         "primary.stats.bivariate.joined.csv",
@@ -4514,6 +4566,15 @@ fn moarstats_join_type_right_runs_and_writes_bivariate() {
         .arg("right")
         .arg("primary.csv");
     wrk.assert_success(&mut cmd);
+
+    // Pre-check: catch silent primary-only join corruption before the
+    // n_pairs assertion produces a confusing diagnostic.
+    assert_bivariate_columns_present(
+        &wrk,
+        "primary.stats.bivariate.joined.csv",
+        &["value1", "value2a", "value2b"],
+        "right join must merge primary+secondary numeric columns into bivariate output",
+    );
 
     assert_bivariate_n_pairs(
         &wrk,
@@ -4576,6 +4637,20 @@ fn moarstats_join_type_full_runs_and_writes_bivariate() {
     // unmatched primary id=4 -> (value1, value1b) gets 4 valid rows; full
     // adds unmatched secondary id=3 -> (value2a, value2b) gets 4 valid rows.
     let path = "primary.stats.bivariate.joined.csv";
+
+    // Pre-check: every primary AND secondary numeric column must appear in
+    // the bivariate output. This is the precise diagnostic for the macOS
+    // CI flake on this test (https://github.com/dathere/qsv/actions/runs/25488066023):
+    // the failure mode was secondary columns silently missing, which made
+    // the n_pairs(value2a, value2b) assertion below fire with a confusing
+    // "no row found" message instead of pointing at the join.
+    assert_bivariate_columns_present(
+        &wrk,
+        path,
+        &["value1", "value1b", "value2a", "value2b"],
+        "full join must merge primary+secondary numeric columns into bivariate output",
+    );
+
     assert_bivariate_n_pairs(
         &wrk,
         path,
@@ -4646,6 +4721,17 @@ fn moarstats_join_three_datasets_runs() {
         .arg("id,id,id")
         .arg("primary.csv");
     wrk.assert_success(&mut cmd);
+
+    // Pre-check: every primary, secondary, AND tertiary numeric column must
+    // appear in the bivariate output, proving the chained join merged all
+    // three datasets and not just primary (or primary+secondary).
+    assert_bivariate_columns_present(
+        &wrk,
+        "primary.stats.bivariate.joined.csv",
+        &["value1", "value2", "value3"],
+        "three-way join must merge primary+secondary+tertiary numeric columns into bivariate \
+         output",
+    );
 
     // Inner-chain on matching keys yields 4 rows (primary's 4 rows all match
     // through secondary and tertiary). The (value1, value3) pair proves


### PR DESCRIPTION
## Summary

- Fixes a flaky macOS CI failure in `test_moarstats::moarstats_join_type_full_runs_and_writes_bivariate` ([run 25488066023](https://github.com/dathere/qsv/actions/runs/25488066023/job/74788790519)) where `qsv join`'s output was not fsynced before being read by a follow-up `qsv stats` subprocess, producing a silent "primary-only" bivariate output under heavy parallel test load on APFS.
- Replaces a misleading `NamedTempFile` + `drop` pattern in `join_datasets_internal` (Drop deletes the file from disk, not just closes the handle) with `into_temp_path().keep()`, and adds a generic `util::sync_subprocess_output` helper that fsyncs and validates non-emptiness for every join/stats subprocess that writes via `--output`.
- Adds joined-header validation: after each `qsv join`, the secondary input's columns must appear in the joined output, or moarstats fails with a precise `CliError` instead of feeding silently-corrupt data downstream. Mirrors this with a new `assert_bivariate_columns_present` test helper used in all four join-type tests so any future flake surfaces as "missing columns [value2a, value2b]" rather than a confusing n_pairs mismatch.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo test --locked -F all_features test_moarstats::` — 80/80 pass
- [x] 10× stress loop on `test_moarstats::moarstats_join` with `--test-threads=8` — all green every iteration
- [x] `cargo clippy` — no new warnings in touched code (pre-existing PI-constant errors in `src/cmd/excel.rs` / `tests/test_luau.rs` are unrelated and present on master)
- [x] CI macOS run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)