### PR TITLE
fix(moarstats): open subprocess output with write access for fsync (Windows)

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -3833,12 +3833,17 @@ pub fn run_qsv_cmd(
 /// noticeable on macOS APFS under heavy parallel test load and has produced
 /// silent "primary-only" join output in CI.
 ///
-/// This helper opens the file read-only, calls `sync_all()` to force a
-/// flush, then verifies the resulting file is non-empty. On Linux the
-/// fsync is nearly free; on macOS it is the load-bearing barrier.
+/// Opens the file with WRITE access (no truncate, no create — just a writable
+/// handle), calls `sync_all()` to force a flush, then verifies the resulting
+/// file is non-empty.
+///
+/// Why write access: on Windows, `sync_all()` is implemented via
+/// `FlushFileBuffers`, which rejects read-only handles with "Access is
+/// denied" (os error 5). Opening with `.write(true)` works on Linux/macOS too
+/// and doesn't modify the file as long as `truncate`/`create` are not set.
 pub fn sync_subprocess_output(path: &Path) -> CliResult<()> {
     let f = std::fs::OpenOptions::new()
-        .read(true)
+        .write(true)
         .open(path)
         .map_err(|e| {
             CliError::Other(format!(


### PR DESCRIPTION
## Summary

Follow-up to #3830. The newly-added \`util::sync_subprocess_output\` opened the file read-only and called \`sync_all()\`. On Windows, that maps to \`FlushFileBuffers\`, which rejects read-only handles with \"Access is denied\" (os error 5) — breaking moarstats on the Windows Lite CI run.

Switching to \`.write(true)\` (no \`truncate\`, no \`create\`, no \`append\`) gives a writable handle suitable for \`FlushFileBuffers\` on Windows and is a safe no-op for the file contents on Linux/macOS.

Failing run: https://github.com/dathere/qsv/actions/runs/25492014192/job/74802155053

## Test plan

- [x] \`cargo build --locked --bin qsv -F all_features\`
- [x] \`cargo test --locked -F all_features test_moarstats::\` — 80/80 pass on macOS
- [x] Windows / Windows Lite CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)