### PR TITLE
fix(moarstats): retry on stats coverage mismatch + fsync joined CSV parent dir

### DIFF
--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -3308,6 +3308,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         let joined_path =
             join_datasets_internal(input_path, &additional_inputs, &join_keys, join_type)?;
+        // Belt-and-suspenders: fsync the joined CSV's parent directory so the
+        // directory entry is durable for the follow-up `qsv stats` subprocess.
+        // `fsync(file)` on Linux doesn't flush parent dir metadata, and rare
+        // FS/timing edge cases have correlated with the subprocess seeing a
+        // partial view of the joined CSV (CI run 25545197594).
+        if let Some(parent) = joined_path.parent() {
+            util::sync_directory(parent)?;
+        }
         temp_joined_path = Some(joined_path);
         temp_joined_path.as_ref().unwrap()
     } else {
@@ -3384,50 +3392,114 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .map_err(|e| CliError::Other(format!("Failed to get current executable path: {e:?}")))?
             .to_string_lossy()
             .to_string();
-        let mut cmd = Command::new(&qsv_path);
-        cmd.arg("stats")
-            .args(&stats_cmd_args)
-            .arg(&actual_input_path_str);
-        let output = cmd
-            .output()
-            .map_err(|e| CliError::Other(format!("Error while executing stats command: {e:?}")))?;
-        if !output.status.success() {
-            return fail_clierror!(
-                "Command stats failed: Output {{ status: {:?}, stdout: {:?}, stderr: {:?} }}",
-                output.status,
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
 
-        // Force a flush of the stats subprocess output to disk before any
-        // follow-up read. Same rationale as in join_datasets_internal:
-        // macOS APFS under heavy parallel load has been observed to hand
-        // back a short/empty file to the next open() without this fsync.
-        util::sync_subprocess_output(&temp_stats_path)?;
+        // Run `qsv stats` on the joined CSV, fsync its output, and read
+        // back the stats output's `field` column values. Returns the set
+        // of columns the stats subprocess produced records for.
+        let run_stats_subprocess = || -> CliResult<std::collections::HashSet<String>> {
+            let mut cmd = Command::new(&qsv_path);
+            cmd.arg("stats")
+                .args(&stats_cmd_args)
+                .arg(&actual_input_path_str);
+            let output = cmd.output().map_err(|e| {
+                CliError::Other(format!("Error while executing stats command: {e:?}"))
+            })?;
+            if !output.status.success() {
+                return fail_clierror!(
+                    "Command stats failed: Output {{ status: {:?}, stdout: {:?}, stderr: {:?} }}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            // Force a flush of the stats subprocess output to disk before
+            // any follow-up read. Same rationale as in
+            // `join_datasets_internal`: macOS APFS under heavy parallel
+            // load has been observed to hand back a short/empty file to
+            // the next open() without this fsync.
+            util::sync_subprocess_output(&temp_stats_path)?;
 
-        // Validate that the stats CSV has the expected `field` column header
-        // so a silently truncated file fails loudly here rather than later.
-        let mut stats_hdr_rdr = csv::ReaderBuilder::new()
-            .has_headers(true)
-            .from_path(&temp_stats_path)
-            .map_err(|e| {
+            let mut rdr = csv::ReaderBuilder::new()
+                .has_headers(true)
+                .from_path(&temp_stats_path)
+                .map_err(|e| {
+                    CliError::Other(format!(
+                        "Failed to open joined-stats output to validate header ({}): {e}",
+                        temp_stats_path.display()
+                    ))
+                })?;
+            let hdrs: Vec<String> = rdr
+                .headers()
+                .map_err(|e| CliError::Other(format!("Failed to read joined-stats header: {e}")))?
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect();
+            let field_idx = hdrs.iter().position(|h| h == "field").ok_or_else(|| {
                 CliError::Other(format!(
-                    "Failed to open joined-stats output to validate header ({}): {e}",
-                    temp_stats_path.display()
+                    "Joined-stats output missing 'field' column: got headers {hdrs:?}"
                 ))
             })?;
-        let stats_headers: Vec<String> = stats_hdr_rdr
-            .headers()
-            .map_err(|e| CliError::Other(format!("Failed to read joined-stats header: {e}")))?
+            Ok(rdr
+                .records()
+                .filter_map(std::result::Result::ok)
+                .filter_map(|r| r.get(field_idx).map(ToString::to_string))
+                .collect())
+        };
+
+        // Read the joined CSV's column names so we can verify the stats
+        // subprocess produced a record for each one.
+        let joined_input_headers: Vec<String> = {
+            let mut joined_rdr = csv::ReaderBuilder::new()
+                .has_headers(true)
+                .from_path(actual_input_path)
+                .map_err(|e| {
+                    CliError::Other(format!(
+                        "Failed to open joined CSV to validate stats coverage ({}): {e}",
+                        actual_input_path.display()
+                    ))
+                })?;
+            joined_rdr
+                .headers()
+                .map_err(|e| CliError::Other(format!("Failed to read joined CSV header: {e}")))?
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect()
+        };
+
+        // Run `qsv stats` and verify coverage. On the rare Linux page-cache
+        // race (CI run 25545197594) the subprocess has been observed to
+        // produce stats for fewer columns than the joined CSV actually has.
+        // Retry once silently with a re-fsync of the joined CSV; if the
+        // mismatch persists, fail loud.
+        let mut stats_field_values = run_stats_subprocess()?;
+        let mut missing: Vec<String> = joined_input_headers
             .iter()
-            .map(std::string::ToString::to_string)
+            .filter(|h| !stats_field_values.contains(h.as_str()))
+            .cloned()
             .collect();
-        drop(stats_hdr_rdr);
-        if !stats_headers.iter().any(|h| h == "field") {
-            return fail_clierror!(
-                "Joined-stats output missing 'field' column: got headers {stats_headers:?}"
+        if !missing.is_empty() {
+            log::warn!(
+                "Joined-stats subprocess output missing columns {missing:?}; re-syncing joined \
+                 CSV and retrying stats once"
             );
+            util::sync_subprocess_output(actual_input_path)?;
+            stats_field_values = run_stats_subprocess()?;
+            missing = joined_input_headers
+                .iter()
+                .filter(|h| !stats_field_values.contains(h.as_str()))
+                .cloned()
+                .collect();
+            if !missing.is_empty() {
+                return fail_clierror!(
+                    "Joined-stats subprocess output is still missing stats records for columns \
+                     {missing:?} after one retry: joined CSV has {} columns \
+                     ({joined_input_headers:?}), but stats output's `field` column only contains \
+                     {} of them ({stats_field_values:?}). Stats output: {}",
+                    joined_input_headers.len(),
+                    stats_field_values.len(),
+                    temp_stats_path.display()
+                );
+            }
         }
 
         temp_stats_path

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -3314,7 +3314,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // FS/timing edge cases have correlated with the subprocess seeing a
         // partial view of the joined CSV (CI run 25545197594).
         if let Some(parent) = joined_path.parent() {
-            util::sync_directory(parent)?;
+            util::sync_directory(parent);
         }
         temp_joined_path = Some(joined_path);
         temp_joined_path.as_ref().unwrap()
@@ -3439,11 +3439,27 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     "Joined-stats output missing 'field' column: got headers {hdrs:?}"
                 ))
             })?;
-            Ok(rdr
-                .records()
-                .filter_map(std::result::Result::ok)
-                .filter_map(|r| r.get(field_idx).map(ToString::to_string))
-                .collect())
+            // Propagate CSV parse errors instead of silently dropping
+            // them — a malformed/truncated stats row must surface as
+            // "failed to parse row N" rather than as a downstream
+            // "missing columns" assertion (which is exactly the
+            // confusing diagnostic mode this fix is trying to eliminate).
+            let mut field_values: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for (row_idx, rec) in rdr.records().enumerate() {
+                let rec = rec.map_err(|e| {
+                    CliError::Other(format!(
+                        "Failed to parse joined-stats row {row} from {path}: {e}",
+                        row = row_idx + 1, /* +1 so row numbering matches a human reader (header
+                                            * is row 0) */
+                        path = temp_stats_path.display()
+                    ))
+                })?;
+                if let Some(v) = rec.get(field_idx) {
+                    field_values.insert(v.to_string());
+                }
+            }
+            Ok(field_values)
         };
 
         // Read the joined CSV's column names so we can verify the stats

--- a/src/util.rs
+++ b/src/util.rs
@@ -3873,37 +3873,56 @@ pub fn sync_subprocess_output(path: &Path) -> CliResult<()> {
     Ok(())
 }
 
-/// Fsync the directory at `path` so its directory entry metadata is durable.
+/// Best-effort fsync of the directory at `path` so its directory entry
+/// metadata is durable.
 ///
 /// `fsync(file)` on Linux does NOT flush the parent directory's metadata.
-/// While this primarily matters for crash safety, some FS configurations
+/// While that primarily matters for crash safety, some FS configurations
 /// (overlayfs, fuse, network mounts) and edge-case timing have been seen
 /// to affect read-after-write visibility for newly-created files when a
-/// follow-up process opens them via path lookup. Belt-and-suspenders.
+/// follow-up process opens them via path lookup. This helper is layered
+/// on top of the file-level `sync_subprocess_output` and exists purely
+/// as a belt-and-suspenders guard.
 ///
-/// No-op on non-unix targets: on Windows, `FlushFileBuffers` does not
-/// accept directory handles, so calling it would error.
-pub fn sync_directory(path: &Path) -> CliResult<()> {
+/// Errors are intentionally NOT propagated:
+/// - Directory fsync is not supported uniformly across Linux filesystems (FAT, some
+///   FUSE/overlay/network mounts return `EINVAL`/`EOPNOTSUPP`).
+/// - Even when supported, the caller has already gone through the file-level fsync; failing the
+///   whole operation because the directory fsync errored would punish environments that don't
+///   support it.
+///
+/// Errors are logged at debug level. No-op on non-unix targets (on Windows,
+/// `FlushFileBuffers` does not accept directory handles).
+pub fn sync_directory(path: &Path) {
     #[cfg(unix)]
     {
-        let f = std::fs::File::open(path).map_err(|e| {
-            CliError::Other(format!(
-                "Unable to open directory for fsync ({}): {e}",
-                path.display()
-            ))
-        })?;
-        f.sync_all().map_err(|e| {
-            CliError::Other(format!(
-                "Failed to fsync directory ({}): {e}",
-                path.display()
-            ))
-        })?;
+        // Best-effort: directory fsync is not supported uniformly across
+        // Linux filesystems (FAT, some FUSE/overlay/network mounts return
+        // EINVAL/EOPNOTSUPP). Since this is a defensive guard layered on
+        // top of the file-level fsync, an error here must NOT fail the
+        // caller — log at debug and continue.
+        match std::fs::File::open(path) {
+            Ok(f) => {
+                if let Err(e) = f.sync_all() {
+                    log::debug!(
+                        "sync_directory: fsync of {} returned {e} (continuing — not all FS \
+                         configurations support directory fsync)",
+                        path.display()
+                    );
+                }
+            },
+            Err(e) => {
+                log::debug!(
+                    "sync_directory: open of {} returned {e} (continuing — best-effort guard)",
+                    path.display()
+                );
+            },
+        }
     }
     #[cfg(not(unix))]
     {
         let _ = path; // suppress unused-variable warning on Windows
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -3913,6 +3932,24 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_sync_directory_smoke() {
+        // sync_directory is best-effort by design: success paths must
+        // return normally, and error paths (missing dir, FS that doesn't
+        // support directory fsync) must NOT panic or propagate. This
+        // smoke test covers both branches.
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Existing directory: should succeed (or silently no-op if the
+        // backing FS doesn't support it).
+        sync_directory(dir.path());
+
+        // Non-existent path: should still return without panicking;
+        // the open() error is logged and swallowed.
+        sync_directory(&dir.path().join("definitely_does_not_exist"));
+    }
 
     #[test]
     fn test_hash_blake3_file() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3873,6 +3873,39 @@ pub fn sync_subprocess_output(path: &Path) -> CliResult<()> {
     Ok(())
 }
 
+/// Fsync the directory at `path` so its directory entry metadata is durable.
+///
+/// `fsync(file)` on Linux does NOT flush the parent directory's metadata.
+/// While this primarily matters for crash safety, some FS configurations
+/// (overlayfs, fuse, network mounts) and edge-case timing have been seen
+/// to affect read-after-write visibility for newly-created files when a
+/// follow-up process opens them via path lookup. Belt-and-suspenders.
+///
+/// No-op on non-unix targets: on Windows, `FlushFileBuffers` does not
+/// accept directory handles, so calling it would error.
+pub fn sync_directory(path: &Path) -> CliResult<()> {
+    #[cfg(unix)]
+    {
+        let f = std::fs::File::open(path).map_err(|e| {
+            CliError::Other(format!(
+                "Unable to open directory for fsync ({}): {e}",
+                path.display()
+            ))
+        })?;
+        f.sync_all().map_err(|e| {
+            CliError::Other(format!(
+                "Failed to fsync directory ({}): {e}",
+                path.display()
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path; // suppress unused-variable warning on Windows
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;

--- a/tools/repro_moarstats_linux_flake.sh
+++ b/tools/repro_moarstats_linux_flake.sh
@@ -68,6 +68,8 @@ echo
 # pressure the page cache. Mimics the heavy parallel I/O load CI sees when
 # many tests run together. Disabled by default; enable with DD_LOAD=1.
 DD_PIDS=()
+LOAD_DIR=""
+FIFO_DIR=""
 cleanup() {
     if [ "${#DD_PIDS[@]}" -gt 0 ]; then
         for pid in "${DD_PIDS[@]}"; do
@@ -75,6 +77,13 @@ cleanup() {
         done
     fi
     wait 2>/dev/null || true
+    # Remove any temp resources we created. Guarded so we never rm -rf "".
+    if [ -n "$LOAD_DIR" ] && [ -d "$LOAD_DIR" ]; then
+        rm -rf "$LOAD_DIR"
+    fi
+    if [ -n "$FIFO_DIR" ] && [ -d "$FIFO_DIR" ]; then
+        rm -rf "$FIFO_DIR"
+    fi
 }
 trap cleanup EXIT INT TERM
 
@@ -177,8 +186,22 @@ EOF
         # Concatenate the field1 and field2 columns from the bivariate
         # output and check that value2a + value2b appear at least once.
         # awk is used to avoid pulling in csvlens/qsv for the check.
-        if ! awk -F, '
-                NR == 1 { for (i=1; i<=NF; i++) if ($i=="field1") f1=i; else if ($i=="field2") f2=i; next }
+        # Distinct exit codes:
+        #   0  -> coverage OK
+        #   2  -> bivariate header is malformed (missing field1/field2);
+        #         classified as FAIL_OTHER, not FAIL_OLD_BIVARIATE, since
+        #         it points at a different bug than column-drop.
+        #   1  -> coverage check failed (value2a or value2b absent).
+        awk -F, '
+                NR == 1 {
+                    for (i=1; i<=NF; i++)
+                        if ($i=="field1") f1=i; else if ($i=="field2") f2=i
+                    if (!f1 || !f2) {
+                        printf "biv header malformed: f1=%s f2=%s headers=%s\n", f1, f2, $0 > "/dev/stderr"
+                        exit 2
+                    }
+                    next
+                }
                 { seen[$f1]=1; seen[$f2]=1 }
                 END {
                     if (!("value2a" in seen) || !("value2b" in seen)) {
@@ -187,12 +210,23 @@ EOF
                         exit 1
                     }
                 }
-            ' "$biv" >/dev/null 2>"$wd/biv_check.stderr"; then
-            echo "FAIL_OLD_BIVARIATE worker=$worker_id iter=$iter wd=$wd"
-            cp -r "$wd" "$OUT_DIR/fail_old_biv_w${worker_id}_i${iter}_$(date +%s)"
-            rm -rf "$wd"
-            continue
-        fi
+            ' "$biv" >/dev/null 2>"$wd/biv_check.stderr"
+        awk_rc=$?
+        case "$awk_rc" in
+            0) ;; # pass
+            2)
+                echo "FAIL_OTHER worker=$worker_id iter=$iter step=biv_header_malformed wd=$wd"
+                cp -r "$wd" "$OUT_DIR/fail_other_w${worker_id}_i${iter}_$(date +%s)"
+                rm -rf "$wd"
+                continue
+                ;;
+            *)
+                echo "FAIL_OLD_BIVARIATE worker=$worker_id iter=$iter wd=$wd"
+                cp -r "$wd" "$OUT_DIR/fail_old_biv_w${worker_id}_i${iter}_$(date +%s)"
+                rm -rf "$wd"
+                continue
+                ;;
+        esac
 
         echo "PASS worker=$worker_id iter=$iter"
         if [ "$KEEP_PASSING_LOGS" != "1" ]; then
@@ -201,8 +235,12 @@ EOF
     done
 }
 
-# Spawn workers in parallel and aggregate results.
-RESULTS_FIFO="$(mktemp -u -t qsv_repro_fifo_XXXXXX)"
+# Spawn workers in parallel and aggregate results. Use a real tempdir for
+# the FIFO (avoiding `mktemp -u`, which is inherently racy — the name can
+# be claimed between allocation and `mkfifo`). The dir is cleaned up by
+# the EXIT trap.
+FIFO_DIR="$(mktemp -d -t qsv_repro_fifo_XXXXXX)"
+RESULTS_FIFO="$FIFO_DIR/results"
 mkfifo "$RESULTS_FIFO"
 
 (
@@ -237,7 +275,7 @@ while IFS= read -r line; do
     fi
 done <"$RESULTS_FIFO"
 
-rm -f "$RESULTS_FIFO"
+# FIFO_DIR is removed by the cleanup trap.
 
 echo
 echo "=== Summary ==="

--- a/tools/repro_moarstats_linux_flake.sh
+++ b/tools/repro_moarstats_linux_flake.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# Reproduce harness for the Linux-only flake on
+#   test_moarstats::moarstats_join_type_full_runs_and_writes_bivariate
+# (qsv PR #3834 CI run 25545197594).
+#
+# Build a qsv binary on the branch fix/moarstats-linux-stats-validation
+# (or master + the fix cherry-picked) with all_features, then run this
+# script on the same Ubuntu VM as CI:
+#
+#   QSV_BIN=/path/to/qsv ./tools/repro_moarstats_linux_flake.sh
+#
+# What it does:
+#   - Replicates the failing test's exact qsv invocations as a shell loop:
+#       qsv stats --everything primary.csv
+#       qsv moarstats --bivariate --join-inputs secondary.csv \
+#           --join-keys id,id --join-type full primary.csv
+#     then inspects primary.stats.bivariate.joined.csv for value2a/value2b.
+#   - Runs N parallel workers, each looping ITERS times, to mimic CI's
+#     concurrent test load (which is what surfaced the macOS flake).
+#   - Optionally runs background I/O churn (DD_LOAD=1) to push page-cache
+#     pressure, which is the most plausible Linux-specific trigger.
+#   - Classifies each failure into one of three buckets:
+#       (a) NEW_DIAGNOSTIC — the fix's strict validation fired
+#         ("Joined-stats subprocess output is missing stats records…").
+#         This *confirms* the root cause is the qsv-stats-on-joined-CSV
+#         subprocess handoff, not the join itself.
+#       (b) OLD_BIVARIATE_MISSING — the bivariate output is missing
+#         value2a/value2b columns and the strict validation did NOT fire.
+#         This means the joined CSV itself was corrupted (or the parent's
+#         second header re-read also saw the truncation), pointing at
+#         join_datasets_internal rather than the subprocess handoff.
+#       (c) OTHER — qsv exited non-zero for some other reason, or output
+#         was not produced. Dump and stop.
+#
+# Output: per-failure log under $OUT_DIR; final summary line.
+#
+# Don't expect this to reproduce on macOS. The flake is Linux-specific.
+
+set -u
+
+QSV_BIN="${QSV_BIN:-qsv}"
+WORKERS="${WORKERS:-8}"
+ITERS="${ITERS:-200}"        # iterations per worker -> WORKERS*ITERS total
+DD_LOAD="${DD_LOAD:-0}"      # 1 = run background I/O churn
+OUT_DIR="${OUT_DIR:-$PWD/repro_logs_$(date +%Y%m%d_%H%M%S)}"
+KEEP_PASSING_LOGS="${KEEP_PASSING_LOGS:-0}"
+
+mkdir -p "$OUT_DIR"
+
+if ! command -v "$QSV_BIN" >/dev/null 2>&1 && [ ! -x "$QSV_BIN" ]; then
+    echo "ERROR: qsv binary not found at: $QSV_BIN" >&2
+    echo "Set QSV_BIN to the absolute path of your built qsv binary." >&2
+    exit 2
+fi
+
+QSV_BIN_ABS="$(command -v "$QSV_BIN" || readlink -f "$QSV_BIN")"
+echo "qsv binary:      $QSV_BIN_ABS"
+echo "qsv version:     $("$QSV_BIN_ABS" --version 2>&1 | head -1)"
+echo "workers:         $WORKERS"
+echo "iters/worker:    $ITERS"
+echo "total runs:      $((WORKERS * ITERS))"
+echo "dd background:   $DD_LOAD"
+echo "log dir:         $OUT_DIR"
+echo
+
+# Background I/O churn: writes/reads/syncs random files in a scratch dir to
+# pressure the page cache. Mimics the heavy parallel I/O load CI sees when
+# many tests run together. Disabled by default; enable with DD_LOAD=1.
+DD_PIDS=()
+cleanup() {
+    if [ "${#DD_PIDS[@]}" -gt 0 ]; then
+        for pid in "${DD_PIDS[@]}"; do
+            kill "$pid" 2>/dev/null || true
+        done
+    fi
+    wait 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+if [ "$DD_LOAD" = "1" ]; then
+    LOAD_DIR="$(mktemp -d -t qsv_repro_load_XXXXXX)"
+    echo "Starting background I/O load in $LOAD_DIR ..."
+    for i in 1 2 3 4; do
+        (
+            while true; do
+                f="$LOAD_DIR/churn_${i}_$RANDOM"
+                dd if=/dev/urandom of="$f" bs=64K count=64 status=none 2>/dev/null
+                sync "$f" 2>/dev/null || sync
+                cat "$f" >/dev/null 2>&1
+                rm -f "$f"
+            done
+        ) &
+        DD_PIDS+=("$!")
+    done
+fi
+
+# One worker run: replicates the failing test for $ITERS iterations.
+# Emits "PASS"/"FAIL_NEW_DIAGNOSTIC"/"FAIL_OLD_BIVARIATE"/"FAIL_OTHER" lines
+# to stdout (one per iteration), and dumps full context to $OUT_DIR on
+# failure.
+run_worker() {
+    local worker_id="$1"
+    local iter
+    local wd
+    local rc
+    local biv
+    local moarstats_log
+
+    for iter in $(seq 1 "$ITERS"); do
+        wd="$(mktemp -d -t qsv_repro_w${worker_id}_i${iter}_XXXXXX)"
+
+        # Mirror tests/test_moarstats.rs:4589+ exactly.
+        cat >"$wd/primary.csv" <<'EOF'
+id,value1,value1b
+1,10,100
+2,20,200
+4,40,400
+1,10,100
+EOF
+        cat >"$wd/secondary.csv" <<'EOF'
+id,value2a,value2b
+1,1000,10000
+2,2000,20000
+3,3000,30000
+EOF
+
+        # Step 1: baseline stats (test runs this first; matches wrk.command).
+        # Run from $wd so qsv-emitted side files (primary.stats.csv,
+        # primary.stats.csv.jsonl) land in $wd, mirroring the integration
+        # test's Workdir behavior.
+        ( cd "$wd" && "$QSV_BIN_ABS" stats --everything primary.csv ) \
+                >"$wd/stats.stdout" 2>"$wd/stats.stderr"
+        rc=$?
+        if [ "$rc" -ne 0 ]; then
+            echo "FAIL_OTHER worker=$worker_id iter=$iter step=stats rc=$rc wd=$wd"
+            cp -r "$wd" "$OUT_DIR/fail_other_w${worker_id}_i${iter}_$(date +%s)"
+            rm -rf "$wd"
+            continue
+        fi
+
+        # Step 2: moarstats with full join + bivariate. CWD is $wd so the
+        # relative --join-inputs secondary.csv resolves correctly (the
+        # spawned qsv join subprocess inherits CWD from the parent).
+        moarstats_log="$wd/moarstats.stderr"
+        ( cd "$wd" && "$QSV_BIN_ABS" moarstats \
+                --bivariate \
+                --join-inputs secondary.csv \
+                --join-keys id,id \
+                --join-type full \
+                primary.csv ) \
+                >"$wd/moarstats.stdout" 2>"$moarstats_log"
+        rc=$?
+        if [ "$rc" -ne 0 ]; then
+            # Did the new strict-coverage validation fire? Root-cause-confirming.
+            if grep -q "Joined-stats subprocess output is missing stats records" \
+                    "$moarstats_log" 2>/dev/null; then
+                echo "FAIL_NEW_DIAGNOSTIC worker=$worker_id iter=$iter rc=$rc wd=$wd"
+                cp -r "$wd" "$OUT_DIR/fail_new_w${worker_id}_i${iter}_$(date +%s)"
+            else
+                echo "FAIL_OTHER worker=$worker_id iter=$iter rc=$rc wd=$wd"
+                cp -r "$wd" "$OUT_DIR/fail_other_w${worker_id}_i${iter}_$(date +%s)"
+            fi
+            rm -rf "$wd"
+            continue
+        fi
+
+        # Step 3: inspect bivariate output. Matches assert_bivariate_columns_present.
+        biv="$wd/primary.stats.bivariate.joined.csv"
+        if [ ! -f "$biv" ]; then
+            echo "FAIL_OTHER worker=$worker_id iter=$iter step=missing_biv wd=$wd"
+            cp -r "$wd" "$OUT_DIR/fail_other_w${worker_id}_i${iter}_$(date +%s)"
+            rm -rf "$wd"
+            continue
+        fi
+
+        # Concatenate the field1 and field2 columns from the bivariate
+        # output and check that value2a + value2b appear at least once.
+        # awk is used to avoid pulling in csvlens/qsv for the check.
+        if ! awk -F, '
+                NR == 1 { for (i=1; i<=NF; i++) if ($i=="field1") f1=i; else if ($i=="field2") f2=i; next }
+                { seen[$f1]=1; seen[$f2]=1 }
+                END {
+                    if (!("value2a" in seen) || !("value2b" in seen)) {
+                        for (k in seen) printf "%s,", k
+                        print ""
+                        exit 1
+                    }
+                }
+            ' "$biv" >/dev/null 2>"$wd/biv_check.stderr"; then
+            echo "FAIL_OLD_BIVARIATE worker=$worker_id iter=$iter wd=$wd"
+            cp -r "$wd" "$OUT_DIR/fail_old_biv_w${worker_id}_i${iter}_$(date +%s)"
+            rm -rf "$wd"
+            continue
+        fi
+
+        echo "PASS worker=$worker_id iter=$iter"
+        if [ "$KEEP_PASSING_LOGS" != "1" ]; then
+            rm -rf "$wd"
+        fi
+    done
+}
+
+# Spawn workers in parallel and aggregate results.
+RESULTS_FIFO="$(mktemp -u -t qsv_repro_fifo_XXXXXX)"
+mkfifo "$RESULTS_FIFO"
+
+(
+    for w in $(seq 1 "$WORKERS"); do
+        run_worker "$w" &
+    done
+    wait
+) >"$RESULTS_FIFO" &
+
+PASS=0
+FAIL_NEW=0
+FAIL_OLD=0
+FAIL_OTHER=0
+
+while IFS= read -r line; do
+    case "$line" in
+        PASS\ *) PASS=$((PASS+1)) ;;
+        FAIL_NEW_DIAGNOSTIC\ *)
+            FAIL_NEW=$((FAIL_NEW+1))
+            echo "*** $line" ;;
+        FAIL_OLD_BIVARIATE\ *)
+            FAIL_OLD=$((FAIL_OLD+1))
+            echo "*** $line" ;;
+        FAIL_OTHER\ *)
+            FAIL_OTHER=$((FAIL_OTHER+1))
+            echo "*** $line" ;;
+    esac
+    # Live progress every 100 results.
+    total=$((PASS + FAIL_NEW + FAIL_OLD + FAIL_OTHER))
+    if [ $((total % 100)) -eq 0 ] && [ "$total" -gt 0 ]; then
+        echo "  progress: $total runs (pass=$PASS new_diag=$FAIL_NEW old_biv=$FAIL_OLD other=$FAIL_OTHER)"
+    fi
+done <"$RESULTS_FIFO"
+
+rm -f "$RESULTS_FIFO"
+
+echo
+echo "=== Summary ==="
+echo "  total runs           : $((PASS + FAIL_NEW + FAIL_OLD + FAIL_OTHER))"
+echo "  pass                 : $PASS"
+echo "  FAIL_NEW_DIAGNOSTIC  : $FAIL_NEW   (root cause confirmed: subprocess CSV->stats handoff)"
+echo "  FAIL_OLD_BIVARIATE   : $FAIL_OLD   (bivariate dropped columns despite strict check passing)"
+echo "  FAIL_OTHER           : $FAIL_OTHER  (qsv error / missing output / etc.)"
+echo "  log dir              : $OUT_DIR"
+echo
+
+if [ "$FAIL_NEW" -gt 0 ]; then
+    echo "ROOT CAUSE CONFIRMED: the qsv stats subprocess (run on the joined CSV"
+    echo "by moarstats) is producing stats for fewer columns than the joined CSV"
+    echo "actually contains. The fix should target the subprocess handoff:"
+    echo "  - re-fsync the joined CSV right before spawning qsv stats, or"
+    echo "  - posix_fadvise(POSIX_FADV_DONTNEED) the joined CSV before spawn,"
+    echo "  - or retry qsv stats on coverage-mismatch."
+    echo
+    echo "Inspect a sample failure under: $OUT_DIR/fail_new_*"
+    exit 1
+fi
+
+if [ "$FAIL_OLD" -gt 0 ]; then
+    echo "DIFFERENT ROOT CAUSE: bivariate output dropped value2a/value2b but the"
+    echo "strict coverage check did NOT fire. The joined CSV likely re-truncated"
+    echo "between the parent's coverage re-read and the bivariate computation,"
+    echo "OR the bivariate writer itself is the culprit. Investigate"
+    echo "join_datasets_internal and the bivariate writer in src/cmd/moarstats.rs."
+    echo
+    echo "Inspect a sample failure under: $OUT_DIR/fail_old_biv_*"
+    exit 1
+fi
+
+if [ "$FAIL_OTHER" -gt 0 ]; then
+    echo "Unexpected failures (qsv error / missing output). See $OUT_DIR/fail_other_*"
+    exit 1
+fi
+
+echo "All runs passed. Increase WORKERS, ITERS, or set DD_LOAD=1 and rerun."
+exit 0


### PR DESCRIPTION
## Summary

Two conservative guards for the Linux-only flake on `test_moarstats::moarstats_join_type_full_runs_and_writes_bivariate` (CI run [25545197594](https://github.com/dathere/qsv/actions/runs/25545197594), surfaced via PR #3834 — that PR only touches `describegpt` and is a bystander).

The macOS fix in #3830 and Windows fix in #3831 hardened the parent-side fsync. Linux still surfaces the same symptom — bivariate output missing secondary columns — at a much lower frequency. The most plausible remaining gap is the `qsv stats`-on-joined-CSV subprocess handoff: the spawned child has been observed to produce stats records for fewer columns than the joined CSV actually has.

### Guard 1 — retry once on stats-coverage mismatch (`src/cmd/moarstats.rs`)

After `qsv stats` runs on the joined CSV:

- Cross-check that every column in the joined CSV's header appears in the stats output's `field` column.
- On mismatch, re-fsync the joined CSV and re-run `qsv stats` once.
- Only fail loud if the mismatch persists after the retry.

This self-heals the rare race silently (with a `log::warn!` for visibility in CI logs) and surfaces a precise error if a different root cause ever appears in the future.

### Guard 2 — fsync the joined CSV's parent directory (`src/util.rs`)

`fsync(file)` on Linux doesn't flush parent-directory metadata. While that primarily matters for crash safety, rare FS/timing edge cases (overlayfs, fuse, network mounts) can affect read-after-write visibility for newly-created files when a follow-up process opens them via path lookup.

New helper `util::sync_directory(path)`:

- Unix: opens the directory and calls `sync_all()`.
- Windows: no-op (dir-handle `FlushFileBuffers` errors).

Called once on the joined CSV's parent dir right after `join_datasets_internal` returns.

### Repro harness — `tools/repro_moarstats_linux_flake.sh`

Parallel-worker shell harness that replicates the failing test as a shell loop, optionally adds page-cache pressure (`DD_LOAD=1`), and classifies failures into:
- `FAIL_NEW_DIAGNOSTIC` — strict coverage check fired after retry → confirms subprocess CSV→stats handoff is the root cause.
- `FAIL_OLD_BIVARIATE` — bivariate output dropped columns and the strict check did NOT fire → points elsewhere.
- `FAIL_OTHER` — qsv error / missing output.

Usage on an Ubuntu VM:
```bash
QSV_BIN=$PWD/target/debug/qsv WORKERS=4 ITERS=500 DD_LOAD=1 \
    ./tools/repro_moarstats_linux_flake.sh
```

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features` clean (macOS).
- [x] `cargo clippy --locked --bin qsv -F all_features -- -D warnings` clean.
- [x] `cargo t -F all_features --test tests test_moarstats::` — 80/80 pass at `--test-threads=8`.
- [x] Failing test in a 30× serial stress loop on macOS — all pass.
- [ ] CI green on Linux + Windows + macOS workflows.
- [ ] (Optional) `tools/repro_moarstats_linux_flake.sh` on an Ubuntu VM (4 vCPU, `DD_LOAD=1`, ≥2000 runs) — expect either no failures, or `FAIL_NEW_DIAGNOSTIC = 0` with `log::warn!` messages indicating the retry path triggered and self-healed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)