### PR TITLE
feat(stats,frequency): opt-in Apache DataSketches modes — HLL cardinality, Frequent Items top-K

### DIFF
--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -3750,6 +3750,14 @@ impl Args {
         // by the time run() dispatches here. Reading it directly avoids depending
         // on NULL_VAL.set() ordering (the FI dispatch happens before that init in
         // run()) and guarantees exact↔FI label parity.
+        //
+        // Invariant: the only `NULL_VAL.set(...)` site in this module is at the top
+        // of `run()` (a single setter — verifiable by grepping `NULL_VAL\.set` in
+        // this file), and it sets `NULL_VAL` from
+        // `args.flag_null_text.as_bytes().to_vec()` — the same bytes we read here.
+        // So `NULL_VAL` and `self.flag_null_text` are byte-identical once
+        // `NULL_VAL` is populated. If a future change adds another `NULL_VAL.set`
+        // site that uses a different source, revisit this comment.
         let null_label: Vec<u8> = self.flag_null_text.as_bytes().to_vec();
 
         let mut row_buffer: csv::ByteRecord = csv::ByteRecord::with_capacity(200, sel_len);

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -88,6 +88,21 @@ frequency options:
                             e.g. --limit -2 will only return values with an
                             occurrence count >= 2.
                             [default: 10]
+    --sketch-method <m>     Algorithm used to compute the frequency table.
+                            Choices: 'exact' (default) tracks every distinct value
+                            in a HashMap; 'frequent_items' uses the Apache
+                            DataSketches Frequent Items (Misra-Gries) sketch to
+                            track top-K heavy hitters with bounded error and
+                            constant memory. The frequent_items mode rejects
+                            asc, weight, ignore-case, no-trim, frequency-jsonl,
+                            stats-filter, and json/pretty-json/toon output; the
+                            frequency cache is bypassed. Counts are estimates.
+                            [default: exact]
+    --sketch-map-size <n>   Maximum map size for the Frequent Items sketch.
+                            Must be a power of two and at least 8. Larger values
+                            tighten error bounds at the cost of more memory.
+                            Only used when sketch-method is frequent_items.
+                            [default: 4096]
     -u, --unq-limit <arg>   If a column has all unique values, limit the
                             frequency table to a sample of N unique items.
                             Set to '0' to disable a unique_limit.
@@ -329,6 +344,8 @@ pub struct Args {
     pub flag_toon:                bool,
     pub flag_no_stats:            bool,
     pub flag_weight:              Option<String>,
+    pub flag_sketch_method:       String,
+    pub flag_sketch_map_size:     usize,
 }
 
 const NON_UTF8_ERR: &str = "<Non-UTF8 ERROR>";
@@ -654,6 +671,71 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         io::copy(&mut io::stdin(), &mut stdin_temp_file)?;
         args.arg_input = Some(stdin_temp_file.path().to_string_lossy().to_string());
         rconfig = args.rconfig();
+    }
+
+    // --sketch-method: dispatch to the Frequent Items path when requested. The FI
+    // path is intentionally narrow — many existing flags don't compose with a
+    // streaming sketch that only tracks heavy hitters. Reject the unsupported
+    // combinations early so users get a clear error instead of silently-wrong
+    // output.
+    args.flag_sketch_method = args.flag_sketch_method.to_lowercase();
+    match args.flag_sketch_method.as_str() {
+        "exact" => {},
+        "frequent_items" => {
+            if args.flag_asc {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items tracks heavy hitters only — least-frequent \
+                     items are not recoverable. Remove --asc or use --sketch-method exact."
+                );
+            }
+            if args.flag_weight.is_some() {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items operates on unit-weight streams. Use \
+                     --sketch-method exact for weighted frequencies."
+                );
+            }
+            if args.flag_ignore_case {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items does not support --ignore-case. Use \
+                     --sketch-method exact."
+                );
+            }
+            if args.flag_no_trim {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items does not support --no-trim. Use \
+                     --sketch-method exact."
+                );
+            }
+            if args.flag_frequency_jsonl {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items is not supported with --frequency-jsonl."
+                );
+            }
+            if is_json {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items does not support --json/--pretty-json/--toon \
+                     output. Use --sketch-method exact."
+                );
+            }
+            #[cfg(feature = "luau")]
+            if args.flag_stats_filter.is_some() {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items is not supported with --stats-filter."
+                );
+            }
+            let n = args.flag_sketch_map_size;
+            if n < 8 || !n.is_power_of_two() {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-map-size must be a power of two and >= 8, got {n}."
+                );
+            }
+            return args.run_frequent_items(&rconfig);
+        },
+        other => {
+            return fail_incorrectusage_clierror!(
+                "Invalid --sketch-method: {other}. Choose 'exact' or 'frequent_items'."
+            );
+        },
     }
 
     // Check if we have an index and will use parallel processing
@@ -3617,6 +3699,214 @@ impl Args {
             .map_err(|_| "Cannot set UNIQUE_COLUMNS")?;
 
         Ok((final_headers, final_sel, weight_col_idx))
+    }
+
+    /// Self-contained Frequent Items (Misra-Gries) processing path.
+    ///
+    /// Streams the input CSV once, maintaining one
+    /// `datasketches::frequencies::FrequentItemsSketch<Vec<u8>>` per selected column,
+    /// then emits the same CSV schema as the exact path
+    /// (`field,value,count,percentage,rank`) using the sketch's heavy-hitter list.
+    ///
+    /// This path is intentionally narrow:
+    ///   * Always unweighted, single-threaded — `run()` rejects `--weight` and the parallel/index
+    ///     dispatch is bypassed (FI sketches merge cleanly via `FrequentItemsSketch::merge`, but
+    ///     the MVP keeps everything sequential to limit blast radius).
+    ///   * No frequency cache — caller skips `try_output_from_cache` since the cache stores exact
+    ///     `Frequencies` state, not sketch state.
+    ///   * Unicode trim is the only normalization applied (matches the default exact path);
+    ///     `--ignore-case` and `--no-trim` are rejected upstream.
+    ///   * Counts are estimates. The `count` column carries the FI point estimate; its error is
+    ///     bounded by `sketch.maximum_error()` (which equals the stream length minus the active
+    ///     threshold). The "Other" row's count is `total_weight - sum(top_k_estimates)` and is
+    ///     therefore approximate.
+    fn run_frequent_items(&self, rconfig: &Config) -> CliResult<()> {
+        use datasketches::frequencies::{ErrorType, FrequentItemsSketch};
+
+        let mut rdr = rconfig.reader()?;
+        let (headers, sel, weight_col_idx) = self.sel_headers(&mut rdr)?;
+        debug_assert!(
+            weight_col_idx.is_none(),
+            "run_frequent_items reached with a weight column — run() should reject --weight"
+        );
+
+        let sel_len = sel.len();
+        let map_size = self.flag_sketch_map_size;
+        let mut sketches: Vec<FrequentItemsSketch<Vec<u8>>> = (0..sel_len)
+            .map(|_| FrequentItemsSketch::<Vec<u8>>::new(map_size))
+            .collect();
+
+        // Per-column non-null observation count, used as the percentage denominator
+        // when --pct-nulls is false (the default — null cells are excluded from the
+        // valid-percentage base). We track it ourselves rather than calling
+        // sketch.total_weight() because total_weight folds nulls in.
+        let mut nonnull_counts: Vec<u64> = vec![0; sel_len];
+        // Per-column null observation count (only populated when nulls are tracked).
+        let mut null_counts: Vec<u64> = vec![0; sel_len];
+
+        let flag_no_nulls = self.flag_no_nulls;
+        let null_label: Vec<u8> = NULL_VAL
+            .get()
+            .cloned()
+            .unwrap_or_else(|| b"(NULL)".to_vec());
+
+        let mut row_buffer: csv::ByteRecord = csv::ByteRecord::with_capacity(200, sel_len);
+        for row in rdr.byte_records() {
+            row_buffer.clone_from(&row?);
+            for (i, field) in sel.select(&row_buffer).enumerate() {
+                if field.is_empty() {
+                    if !flag_no_nulls {
+                        // Track empty cells as a sentinel value so they can show up as
+                        // a heavy hitter row labelled with --null-text. Use the empty
+                        // Vec<u8> as the sketch key — distinct from any real value.
+                        // safety: i < sel_len by construction.
+                        unsafe { sketches.get_unchecked_mut(i) }.update(Vec::new());
+                        unsafe { *null_counts.get_unchecked_mut(i) += 1 };
+                    }
+                    continue;
+                }
+                // Default trim (ignore-case + no-trim are rejected upstream).
+                let trimmed = trim_bs_whitespace(field);
+                if trimmed.is_empty() {
+                    if !flag_no_nulls {
+                        unsafe { sketches.get_unchecked_mut(i) }.update(Vec::new());
+                        unsafe { *null_counts.get_unchecked_mut(i) += 1 };
+                    }
+                    continue;
+                }
+                // safety: i < sel_len by construction; sketches/nonnull_counts
+                // are allocated with sel_len entries above.
+                unsafe { sketches.get_unchecked_mut(i) }.update(trimmed.to_vec());
+                unsafe { *nonnull_counts.get_unchecked_mut(i) += 1 };
+            }
+        }
+
+        // Build the writer and emit.
+        let mut wtr = Config::new(self.flag_output.as_ref()).writer()?;
+        wtr.write_record([
+            b"field".as_slice(),
+            b"value",
+            b"count",
+            b"percentage",
+            b"rank",
+        ])?;
+
+        // For percentage, mirror the default exact behavior: --pct-nulls=false uses
+        // the non-null count as the denominator (so the null row's percentage is
+        // empty), --pct-nulls=true folds nulls in.
+        let pct_nulls = self.flag_pct_nulls;
+        let abs_dec_places = self.flag_pct_dec_places.unsigned_abs() as u32;
+
+        // --limit semantics:
+        //   limit > 0   → keep first `limit` rows (top-K)
+        //   limit == 0  → keep everything the sketch returns
+        //   limit < 0   → keep rows with estimate >= |limit|
+        let limit = self.flag_limit;
+
+        // --no-other / --other-text "<NONE>" controls Other emission.
+        let emit_other = !self.flag_no_other && self.flag_other_text != "<NONE>";
+        let other_label = self.flag_other_text.as_bytes().to_vec();
+
+        let mut itoa_buf = itoa::Buffer::new();
+        let mut zmij_buf = zmij::Buffer::new();
+        let mut rank_buf = String::with_capacity(20);
+        let mut value_str = String::with_capacity(64);
+
+        let vis_whitespace = self.flag_vis_whitespace;
+        let no_headers = rconfig.no_headers;
+
+        for (i, header) in headers.iter().enumerate() {
+            let header_vec: Vec<u8> = if no_headers {
+                (i + 1).to_string().into_bytes()
+            } else {
+                header.to_vec()
+            };
+            // safety: sketches has sel_len entries, headers has sel_len after sel_headers.
+            let sketch = unsafe { sketches.get_unchecked(i) };
+            let nonnull_count = unsafe { *nonnull_counts.get_unchecked(i) };
+            let null_count = unsafe { *null_counts.get_unchecked(i) };
+            let pct_denom: f64 = if pct_nulls {
+                (nonnull_count + null_count) as f64
+            } else {
+                nonnull_count as f64
+            };
+
+            // NoFalsePositives ensures every emitted item's true count is >= lower_bound,
+            // so we never report a value that wasn't actually a heavy hitter.
+            let mut rows = sketch.frequent_items(ErrorType::NoFalsePositives);
+            // Already sorted by estimate descending.
+            // Apply --limit semantics on top of the sketch's natural ordering.
+            if limit > 0 {
+                rows.truncate(limit as usize);
+            } else if limit < 0 {
+                let min_count = limit.unsigned_abs() as u64;
+                rows.retain(|r| r.estimate() >= min_count);
+            }
+
+            let kept_estimate_sum: u64 = rows.iter().map(|r| r.estimate()).sum();
+
+            for (rank_idx, r) in rows.iter().enumerate() {
+                let item: &[u8] = r.item();
+                let display_bytes: Vec<u8> = if item.is_empty() {
+                    null_label.clone()
+                } else if vis_whitespace {
+                    value_str.clear();
+                    value_str.push_str(&util::visualize_whitespace(&String::from_utf8_lossy(item)));
+                    value_str.as_bytes().to_vec()
+                } else {
+                    item.to_vec()
+                };
+
+                let count = r.estimate();
+                let pct: f64 = if item.is_empty() && !pct_nulls {
+                    -1.0
+                } else if pct_denom > 0.0 {
+                    100.0 * (count as f64) / pct_denom
+                } else {
+                    0.0
+                };
+                let pct_str = self.format_percentage(pct, abs_dec_places);
+
+                rank_buf.clear();
+                if !item.is_empty() || pct_nulls {
+                    let rank_val = (rank_idx as u64) + 1;
+                    rank_buf.push_str(itoa_buf.format(rank_val));
+                }
+
+                wtr.write_record([
+                    header_vec.as_slice(),
+                    &display_bytes,
+                    itoa_buf.format(count).as_bytes(),
+                    pct_str.as_bytes(),
+                    rank_buf.as_bytes(),
+                ])?;
+            }
+
+            if emit_other {
+                let total = sketch.total_weight();
+                if total > kept_estimate_sum {
+                    let other_count = total - kept_estimate_sum;
+                    let pct: f64 = if pct_denom > 0.0 {
+                        100.0 * (other_count as f64) / pct_denom
+                    } else {
+                        0.0
+                    };
+                    let pct_str = self.format_percentage(pct, abs_dec_places);
+                    rank_buf.clear();
+                    let rank_val = (rows.len() as u64) + 1;
+                    rank_buf.push_str(zmij_buf.format(rank_val as f64));
+                    wtr.write_record([
+                        header_vec.as_slice(),
+                        other_label.as_slice(),
+                        itoa_buf.format(other_count).as_bytes(),
+                        pct_str.as_bytes(),
+                        rank_buf.as_bytes(),
+                    ])?;
+                }
+            }
+        }
+
+        Ok(wtr.flush()?)
     }
 }
 

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -3745,10 +3745,12 @@ impl Args {
         let mut null_counts: Vec<u64> = vec![0; sel_len];
 
         let flag_no_nulls = self.flag_no_nulls;
-        let null_label: Vec<u8> = NULL_VAL
-            .get()
-            .cloned()
-            .unwrap_or_else(|| b"(NULL)".to_vec());
+        // Reuse the same default-resolution path as the exact code: --null-text has
+        // its docopt default of "(NULL)", so self.flag_null_text is always populated
+        // by the time run() dispatches here. Reading it directly avoids depending
+        // on NULL_VAL.set() ordering (the FI dispatch happens before that init in
+        // run()) and guarantees exact↔FI label parity.
+        let null_label: Vec<u8> = self.flag_null_text.as_bytes().to_vec();
 
         let mut row_buffer: csv::ByteRecord = csv::ByteRecord::with_capacity(200, sel_len);
         for row in rdr.byte_records() {
@@ -3759,9 +3761,8 @@ impl Args {
                         // Track empty cells as a sentinel value so they can show up as
                         // a heavy hitter row labelled with --null-text. Use the empty
                         // Vec<u8> as the sketch key — distinct from any real value.
-                        // safety: i < sel_len by construction.
-                        unsafe { sketches.get_unchecked_mut(i) }.update(Vec::new());
-                        unsafe { *null_counts.get_unchecked_mut(i) += 1 };
+                        sketches[i].update(Vec::new());
+                        null_counts[i] += 1;
                     }
                     continue;
                 }
@@ -3769,15 +3770,13 @@ impl Args {
                 let trimmed = trim_bs_whitespace(field);
                 if trimmed.is_empty() {
                     if !flag_no_nulls {
-                        unsafe { sketches.get_unchecked_mut(i) }.update(Vec::new());
-                        unsafe { *null_counts.get_unchecked_mut(i) += 1 };
+                        sketches[i].update(Vec::new());
+                        null_counts[i] += 1;
                     }
                     continue;
                 }
-                // safety: i < sel_len by construction; sketches/nonnull_counts
-                // are allocated with sel_len entries above.
-                unsafe { sketches.get_unchecked_mut(i) }.update(trimmed.to_vec());
-                unsafe { *nonnull_counts.get_unchecked_mut(i) += 1 };
+                sketches[i].update(trimmed.to_vec());
+                nonnull_counts[i] += 1;
             }
         }
 
@@ -3808,7 +3807,6 @@ impl Args {
         let other_label = self.flag_other_text.as_bytes().to_vec();
 
         let mut itoa_buf = itoa::Buffer::new();
-        let mut zmij_buf = zmij::Buffer::new();
         let mut rank_buf = String::with_capacity(20);
         let mut value_str = String::with_capacity(64);
 
@@ -3821,10 +3819,9 @@ impl Args {
             } else {
                 header.to_vec()
             };
-            // safety: sketches has sel_len entries, headers has sel_len after sel_headers.
-            let sketch = unsafe { sketches.get_unchecked(i) };
-            let nonnull_count = unsafe { *nonnull_counts.get_unchecked(i) };
-            let null_count = unsafe { *null_counts.get_unchecked(i) };
+            let sketch = &sketches[i];
+            let nonnull_count = nonnull_counts[i];
+            let null_count = null_counts[i];
             let pct_denom: f64 = if pct_nulls {
                 (nonnull_count + null_count) as f64
             } else {
@@ -3893,8 +3890,12 @@ impl Args {
                     };
                     let pct_str = self.format_percentage(pct, abs_dec_places);
                     rank_buf.clear();
+                    // Match the per-item path: integer rank rendered via itoa, not
+                    // a float formatter. Otherwise the Other row's rank could
+                    // differ in format (trailing decimals, scientific notation)
+                    // from the rows above it.
                     let rank_val = (rows.len() as u64) + 1;
-                    rank_buf.push_str(zmij_buf.format(rank_val as f64));
+                    rank_buf.push_str(itoa_buf.format(rank_val));
                     wtr.write_record([
                         header_vec.as_slice(),
                         other_label.as_slice(),

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -94,9 +94,19 @@ frequency options:
                             DataSketches Frequent Items (Misra-Gries) sketch to
                             track top-K heavy hitters with bounded error and
                             constant memory. The frequent_items mode rejects
-                            asc, weight, ignore-case, no-trim, frequency-jsonl,
-                            stats-filter, and json/pretty-json/toon output; the
-                            frequency cache is bypassed. Counts are estimates.
+                            asc, weight, ignore-case, no-trim, other-sorted,
+                            null-sorted, frequency-jsonl, stats-filter, and
+                            json/pretty-json/toon output; the frequency cache is
+                            bypassed. Counts are estimates. The flags
+                            rank-strategy, lmt-threshold, and unq-limit are
+                            silently ignored under this mode (the sketch's
+                            natural ordering is top-K by estimate descending;
+                            tied counts use the sketch's hash-table iteration
+                            order). The 'Other' row format diverges from exact:
+                            label is the bare other-text (no unique-count suffix
+                            since the sketch cannot recover the true count of
+                            items not in the top-K); rank is 0 to match the
+                            exact convention.
                             [default: exact]
     --sketch-map-size <n>   Maximum map size for the Frequent Items sketch.
                             Must be a power of two and at least 8. Larger values
@@ -704,6 +714,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 return fail_incorrectusage_clierror!(
                     "--sketch-method frequent_items does not support --no-trim. Use \
                      --sketch-method exact."
+                );
+            }
+            if args.flag_other_sorted {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items does not support --other-sorted. The sketch \
+                     always emits the Other row at the end. Use --sketch-method exact."
+                );
+            }
+            if args.flag_null_sorted {
+                return fail_incorrectusage_clierror!(
+                    "--sketch-method frequent_items does not support --null-sorted. The sketch \
+                     ranks NULL alongside other values by estimate. Use --sketch-method exact."
                 );
             }
             if args.flag_frequency_jsonl {
@@ -3898,12 +3920,17 @@ impl Args {
                     };
                     let pct_str = self.format_percentage(pct, abs_dec_places);
                     rank_buf.clear();
-                    // Match the per-item path: integer rank rendered via itoa, not
-                    // a float formatter. Otherwise the Other row's rank could
-                    // differ in format (trailing decimals, scientific notation)
-                    // from the rows above it.
-                    let rank_val = (rows.len() as u64) + 1;
-                    rank_buf.push_str(itoa_buf.format(rank_val));
+                    // Match the exact path's Other-row convention: rank is "0"
+                    // (sentinel for synthetic rows like Other / *ALL_UNIQUE).
+                    // The exact path renders rank 0.0 as the integer "0" via
+                    // itoa (see emit_unweighted_csv_rows), so we do the same
+                    // here. The label intentionally diverges from exact —
+                    // the exact path emits "<other-text> (<unique_count>)" but
+                    // FI cannot recover the count of distinct items not in the
+                    // top-K (purged items aren't tracked), so we emit the bare
+                    // --other-text. This divergence is documented in the
+                    // --sketch-method help.
+                    rank_buf.push_str(itoa_buf.format(0_u64));
                     wtr.write_record([
                         header_vec.as_slice(),
                         other_label.as_slice(),

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -695,6 +695,8 @@ fn get_unique_values(
         flag_no_stats: false,
         flag_toon: false,
         flag_weight: None,
+        flag_sketch_method: "exact".to_string(),
+        flag_sketch_map_size: 4096,
     };
 
     // Bypass the stats cache while running our nested frequency pass.

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -234,8 +234,10 @@ stats options:
                                            * --infer-boolean forces exact (boolean
                                              inference needs cardinality == 2 exactness);
                                              a one-time warning is emitted.
-                                           * Results may differ slightly across runs with
-                                             different --jobs values.
+                                           * Reproducible across --jobs values: the
+                                             HLL union used at merge time is associative
+                                             and order-invariant, so chunk completion
+                                             order does not affect the final estimate.
                               [default: exact]
     --mode-cardinality-cap <n>  Bound mode-tracking memory on high-cardinality columns.
                               When > 0, if a column's mode tracker grows past <n>, qsv
@@ -252,8 +254,9 @@ stats options:
                                   downstream parsers expecting a plain integer; cap is
                                   opt-in only).
                               Under --cardinality-method approx, the cardinality column
-                              ignores this cap (HLL gives a precise estimate at fixed
-                              memory) — only mode/antimode columns are gated.
+                              ignores this cap (HLL gives an approximate estimate at
+                              fixed memory, ~1.5% RSE) — only mode/antimode columns
+                              are gated.
                               Useful on wide tables with many ID/UUID/timestamp columns
                               where tracking exact cardinality is wasted work.
                               [default: 0]

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -216,6 +216,27 @@ stats options:
                                            * Results may differ slightly across runs with
                                              different --jobs values.
                               [default: exact]
+    --cardinality-method <m>  Algorithm used to compute the --cardinality column. Choices:
+                                exact  - track every unique value in a HashMap/Unsorted
+                                         (current behavior). O(cardinality) memory per
+                                         column. Subject to --mode-cardinality-cap, which
+                                         emits the ">=<n>" sentinel on overflow.
+                                approx - use HyperLogLog (Apache DataSketches port,
+                                         lg_k=12). O(1) memory per column (~5KB),
+                                         ~1.5% relative standard error.
+                                         Notes:
+                                           * --mode-cardinality-cap no longer affects the
+                                             cardinality column under approx; the ">=<n>"
+                                             sentinel is never emitted.
+                                           * The cap STILL governs mode/antimode tracking
+                                             (mode columns still emit "*HIGH_CARDINALITY"
+                                             on overflow).
+                                           * --infer-boolean forces exact (boolean
+                                             inference needs cardinality == 2 exactness);
+                                             a one-time warning is emitted.
+                                           * Results may differ slightly across runs with
+                                             different --jobs values.
+                              [default: exact]
     --mode-cardinality-cap <n>  Bound mode-tracking memory on high-cardinality columns.
                               When > 0, if a column's mode tracker grows past <n>, qsv
                               drops it and emits sentinel values instead of exact modes
@@ -230,6 +251,9 @@ stats options:
                                 * cardinality column: ">=<n>" (the ">=" prefix DOES break
                                   downstream parsers expecting a plain integer; cap is
                                   opt-in only).
+                              Under --cardinality-method approx, the cardinality column
+                              ignores this cap (HLL gives a precise estimate at fixed
+                              memory) — only mode/antimode columns are gated.
                               Useful on wide tables with many ID/UUID/timestamp columns
                               where tracking exact cardinality is wasted work.
                               [default: 0]
@@ -402,6 +426,7 @@ pub struct Args {
     pub flag_percentiles:          bool,
     pub flag_percentile_list:      String,
     pub flag_quantile_method:      String,
+    pub flag_cardinality_method:   String,
     pub flag_mode_cardinality_cap: u64,
     pub flag_round:                u32,
     pub flag_nulls:                bool,
@@ -438,6 +463,7 @@ struct StatsArgs {
     flag_percentiles: bool,
     flag_percentile_list: String,
     flag_quantile_method: String,
+    flag_cardinality_method: String,
     flag_mode_cardinality_cap: u64,
     flag_round: u32,
     flag_nulls: bool,
@@ -527,6 +553,7 @@ impl StatsArgs {
             flag_percentiles: get_bool("flag_percentiles"),
             flag_percentile_list: get_str_or("flag_percentile_list", "5,10,40,60,90,95"),
             flag_quantile_method: get_str_or("flag_quantile_method", "exact"),
+            flag_cardinality_method: get_str_or("flag_cardinality_method", "exact"),
             flag_mode_cardinality_cap: get_u64("flag_mode_cardinality_cap"),
             flag_round: get_u64("flag_round") as u32,
             flag_nulls: get_bool("flag_nulls"),
@@ -1026,10 +1053,34 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // cannot re-enable it.
     }
 
+    // validate --cardinality-method (default "exact"; canonicalize to lowercase).
+    // The match is value-only; which_stats() reads flag_cardinality_method directly,
+    // so no local boolean is needed here — we only need to reject invalid input
+    // and mutate the field for canonical comparison downstream.
+    args.flag_cardinality_method = args.flag_cardinality_method.to_lowercase();
+    match args.flag_cardinality_method.as_str() {
+        "exact" | "approx" => {},
+        other => {
+            return fail_incorrectusage_clierror!(
+                "Invalid --cardinality-method: {other}. Choose 'exact' or 'approx'."
+            );
+        },
+    }
+
     // inferring boolean requires inferring cardinality
     if args.flag_infer_boolean {
         if !args.flag_cardinality {
             args.flag_cardinality = true;
+        }
+
+        // boolean inference checks cardinality == 2 exactly; HLL's ~1.5% relative error
+        // would corrupt that comparison. Force exact and warn.
+        if args.flag_cardinality_method == "approx" {
+            wwarn!(
+                "--infer-boolean requires exact cardinality; forcing --cardinality-method exact \
+                 for this run."
+            );
+            args.flag_cardinality_method = "exact".to_string();
         }
 
         // validate boolean patterns
@@ -1059,6 +1110,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         flag_percentiles: args.flag_percentiles,
         flag_percentile_list: args.flag_percentile_list.clone(),
         flag_quantile_method: args.flag_quantile_method.clone(),
+        flag_cardinality_method: args.flag_cardinality_method.clone(),
         flag_mode_cardinality_cap: args.flag_mode_cardinality_cap,
         flag_round: args.flag_round,
         flag_nulls: args.flag_nulls,
@@ -2226,6 +2278,10 @@ impl Args {
         // but we double-guard mad here in case which_stats is called from a path that
         // skipped run()'s validation (e.g. tests).
         let approx_quantiles = self.flag_quantile_method.eq_ignore_ascii_case("approx");
+        // approx_cardinality selects the HyperLogLog engine for the cardinality column.
+        // run() forces this off when --infer-boolean is set (boolean inference needs
+        // cardinality == 2 exactness), so the flag is safe to read directly here.
+        let approx_cardinality = self.flag_cardinality_method.eq_ignore_ascii_case("approx");
         WhichStats {
             include_nulls: self.flag_nulls,
             sum: !self.flag_typesonly,
@@ -2240,6 +2296,7 @@ impl Args {
             percentiles: self.flag_everything || self.flag_percentiles,
             use_weights: self.flag_weight.is_some(),
             approx_quantiles,
+            approx_cardinality,
             mode_cardinality_cap: self.flag_mode_cardinality_cap,
             percentile_list: self.flag_percentile_list.clone().into_boxed_str(),
         }
@@ -2746,6 +2803,11 @@ struct WhichStats {
     /// exclusive with `mad` and `use_weights`; validation in the module-level `run(argv: ...)`
     /// function rejects the bad combinations.
     approx_quantiles:     bool,
+    /// When true, use the Apache DataSketches HyperLogLog engine for the cardinality
+    /// column instead of the exact `Unsorted<Vec<u8>>` / `HashMap<Vec<u8>, f64>` tracker.
+    /// `--infer-boolean` forces this off in `run()` (HLL's ~1.5% RSE breaks
+    /// `cardinality == 2` checks). Independent of `approx_quantiles`.
+    approx_cardinality:   bool,
     /// When > 0, drop mode-tracking once a column accumulates more than this many samples
     /// (Unsorted::len() for unweighted modes, HashMap::len() for weighted). 0 = unbounded
     /// (today's behavior). When the cap fires, output emits `*HIGH_CARDINALITY` for mode
@@ -2801,6 +2863,36 @@ impl PartialEq for TDigestSlot {
     }
 }
 
+/// Wrapper around `datasketches::hll::HllSketch` so the `Stats` struct can keep its
+/// derived `Clone`, `PartialEq`, `Serialize`, `Deserialize` impls without forcing the
+/// upstream `HllSketch` (which only derives `Clone`/`Debug`) to grow them.
+///
+/// `PartialEq` is a constant `true` for the same reason as `TDigestSlot`: two HLL sketches
+/// over the same multiset can yield slightly different internal states depending on
+/// register collisions, but their estimates converge — equality between sketches is not
+/// a useful test (Stats's `PartialEq` is used only in tests for non-sketch fields).
+///
+/// Serde is intentionally NOT implemented: the field is annotated `#[serde(skip)]` on
+/// `Stats::hll`, so the derived `Serialize`/`Deserialize` on `Stats` skip this field
+/// entirely. HLL state is intermediate; cache invalidation on `--cardinality-method`
+/// change rides on `StatsArgs` serialization instead.
+#[derive(Default)]
+struct HllSlot(Option<datasketches::hll::HllSketch>);
+
+impl Clone for HllSlot {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl PartialEq for HllSlot {
+    #[inline]
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 #[allow(clippy::unsafe_derive_deserialize)]
 #[allow(clippy::struct_field_names)]
 #[repr(C, align(64))] // Align to cache line size for better performance
@@ -2849,6 +2941,14 @@ struct Stats {
     // values flow into `tdigest` instead of `unsorted_stats`.
     #[serde(skip)]
     tdigest:                 TDigestSlot,
+
+    // Approximate-cardinality engine. Independent of modes: when
+    // `which.approx_cardinality && which.cardinality`, every sample is fed to the HLL
+    // sketch (regardless of `--mode-cardinality-cap`), and `to_record` emits the HLL
+    // estimate in the cardinality column. Mode/antimode tracking is unaffected — they
+    // still come from `modes` / `weighted_modes` and obey the cap.
+    #[serde(skip)]
+    hll: HllSlot,
 
     // CACHE LINE 6+: Min/Max tracking (largest field, least cache-friendly)
     minmax: Option<TypedMinMax>, // 432 bytes - largest field, accessed less frequently
@@ -3376,7 +3476,13 @@ impl Stats {
         // if we dont't have a record count, we use a default of 10,000
         // to avoid allocating too much memory
         let record_count = *RECORD_COUNT.get().unwrap_or(&10_000) as usize;
-        if which.mode || which.cardinality {
+        // Under --cardinality-method approx with mode tracking off, the HLL sketch
+        // alone covers the cardinality column — skip allocating the exact modes
+        // tracker (Unsorted/HashMap) entirely. When mode/antimode are also requested
+        // we still need the exact tracker for those columns.
+        let need_exact_modes_tracker =
+            which.mode || (which.cardinality && !which.approx_cardinality);
+        if need_exact_modes_tracker {
             if use_weights {
                 // When using weights, weighted_modes handles both mode/antimode and cardinality
                 // computation, so we don't need the separate modes (Unsorted) tracker
@@ -3403,6 +3509,17 @@ impl Stats {
                 }
             }
         }
+        // HyperLogLog cardinality engine: allocate when --cardinality-method approx
+        // is selected AND cardinality output is enabled. lg_k=12 gives ~1.5% RSE with
+        // ~5KB per column. Hll8 stores 8 bits per register (no decode work on update);
+        // memory is the same order whether sparse or dense.
+        let mut hll = HllSlot::default();
+        if which.cardinality && which.approx_cardinality {
+            hll = HllSlot(Some(datasketches::hll::HllSketch::new(
+                12,
+                datasketches::hll::HllType::Hll8,
+            )));
+        }
         Stats {
             typ: FieldType::default(),
             is_ascii: true,
@@ -3421,6 +3538,7 @@ impl Stats {
             unsorted_stats,
             weighted_unsorted_stats,
             tdigest,
+            hll,
             minmax,
         }
     }
@@ -3472,6 +3590,13 @@ impl Stats {
     #[allow(clippy::inline_always)]
     #[inline(always)]
     fn update_modes(&mut self, sample: &[u8], weight: f64) {
+        // HLL is independent of the mode-cardinality cap: feed every sample regardless
+        // of whether the exact mode tracker has been dropped. This is what lets us
+        // surface a precise cardinality estimate even when modes/antimodes are gated.
+        if let Some(hll_sketch) = self.hll.0.as_mut() {
+            hll_sketch.update(sample);
+        }
+
         // --mode-cardinality-cap: when set, drop the tracker once it grows past the cap
         // and surface the abandonment via `modes_dropped` so to_record() can emit
         // sentinels. cap == 0 (default) means unbounded — preserves today's behavior.
@@ -4056,6 +4181,26 @@ impl Stats {
                     }
                 },
             }
+        }
+
+        // --cardinality-method approx: override the cardinality and uniqueness_ratio
+        // slots with the HyperLogLog estimate. The mode/antimode slots (positions 2-7
+        // when present) are untouched — modes still come from the exact tracker,
+        // gated by --mode-cardinality-cap. Stats::new guarantees mc_pieces has
+        // positions 0 and 1 reserved when which.cardinality is true (every reachable
+        // branch above either pushes 2 cardinality fields or starts with EMPTY_STRING
+        // placeholders).
+        if self.which.cardinality
+            && let Some(hll_sketch) = self.hll.0.as_ref()
+            && mc_pieces.len() >= 2
+        {
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let est = hll_sketch.estimate().round() as u64;
+            cardinality = est;
+            mc_pieces[0] = itoa_buf.format(est).to_owned();
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = (est as f64) / (record_count as f64);
+            mc_pieces[1] = util::round_num(ratio, round_places);
         }
 
         // type
@@ -4667,6 +4812,20 @@ impl Commute for Stats {
         // --quantile-method help text documents the caveat for users.
         match (&mut self.tdigest.0, other.tdigest.0) {
             (Some(s), Some(o)) => s.merge(&o),
+            (slot @ None, Some(o)) => *slot = Some(o),
+            _ => {},
+        }
+        // Merge HLL sketches via a transient HllUnion. Unlike t-digest, HLL union is
+        // associative and order-invariant — the merged estimate is bit-identical
+        // regardless of chunk completion order, so --jobs >= 2 is fully reproducible
+        // for the cardinality column under --cardinality-method approx.
+        match (&mut self.hll.0, other.hll.0) {
+            (Some(s), Some(o)) => {
+                let mut union = datasketches::hll::HllUnion::new(12);
+                union.update(s);
+                union.update(&o);
+                *s = union.get_result(datasketches::hll::HllType::Hll8);
+            },
             (slot @ None, Some(o)) => *slot = Some(o),
             _ => {},
         }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -744,6 +744,13 @@ const DAY_DECIMAL_PLACES: u32 = 5;
 // maximum number of output columns
 const MAX_STAT_COLUMNS: usize = 47;
 
+// HyperLogLog precision parameter for `--cardinality-method approx`. lg_k=12
+// gives ~1.5% relative standard error and ~5KB per column at the dense Hll8
+// representation. Used in `Stats::new` (per-row sketch construction) and in
+// `Commute::merge` (the transient `HllUnion` used to combine two sketches);
+// keep both call sites in lock-step by reading from this constant.
+const HLL_LG_K: u8 = 12;
+
 // the first N columns of each full stats record are used for the dataset
 // fingerprint hash. For the normal (non-`--typesonly`) output, N must equal
 // the number of "streaming" stats columns emitted by `stats_headers()`
@@ -3510,13 +3517,13 @@ impl Stats {
             }
         }
         // HyperLogLog cardinality engine: allocate when --cardinality-method approx
-        // is selected AND cardinality output is enabled. lg_k=12 gives ~1.5% RSE with
-        // ~5KB per column. Hll8 stores 8 bits per register (no decode work on update);
-        // memory is the same order whether sparse or dense.
+        // is selected AND cardinality output is enabled. HLL_LG_K (12) gives ~1.5%
+        // RSE with ~5KB per column. Hll8 stores 8 bits per register (no decode work
+        // on update); memory is the same order whether sparse or dense.
         let mut hll = HllSlot::default();
         if which.cardinality && which.approx_cardinality {
             hll = HllSlot(Some(datasketches::hll::HllSketch::new(
-                12,
+                HLL_LG_K,
                 datasketches::hll::HllType::Hll8,
             )));
         }
@@ -4818,10 +4825,12 @@ impl Commute for Stats {
         // Merge HLL sketches via a transient HllUnion. Unlike t-digest, HLL union is
         // associative and order-invariant — the merged estimate is bit-identical
         // regardless of chunk completion order, so --jobs >= 2 is fully reproducible
-        // for the cardinality column under --cardinality-method approx.
+        // for the cardinality column under --cardinality-method approx. The lg_k
+        // here MUST match the HLL_LG_K used in `Stats::new`; reading from the same
+        // constant prevents a silent precision downgrade if one site is bumped.
         match (&mut self.hll.0, other.hll.0) {
             (Some(s), Some(o)) => {
-                let mut union = datasketches::hll::HllUnion::new(12);
+                let mut union = datasketches::hll::HllUnion::new(HLL_LG_K);
                 union.update(s);
                 union.update(&o);
                 *s = union.get_result(datasketches::hll::HllType::Hll8);

--- a/src/util.rs
+++ b/src/util.rs
@@ -2875,6 +2875,7 @@ pub fn get_stats_records(
             flag_percentiles:          false,
             flag_percentile_list:      "5,10,40,60,90,95".to_string(),
             flag_quantile_method:      "exact".to_string(),
+            flag_cardinality_method:   "exact".to_string(),
             flag_mode_cardinality_cap: 0,
             flag_nulls:                false,
             flag_round:                4,

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -6422,3 +6422,158 @@ fn param_prop_frequency_desc_order(name: &str, rows: CsvData) -> bool {
     }
     true
 }
+
+#[test]
+fn frequency_sketch_method_frequent_items_top_k_within_envelope() {
+    // Build a Zipfian-ish fixture: 5 heavy hitters with counts [10000, 5000, 2500,
+    // 1250, 625] plus 1000 noise singletons. The FI sketch should rank the heavy
+    // hitters in the same order as the exact path; counts should be within ~5%.
+    let wrk = Workdir::new("frequency_sketch_method_frequent_items_top_k_within_envelope");
+    let mut rows: Vec<Vec<String>> = vec![vec!["v".to_string()]];
+    let heavy = [
+        ("h1", 10000usize),
+        ("h2", 5000),
+        ("h3", 2500),
+        ("h4", 1250),
+        ("h5", 625),
+    ];
+    for (label, n) in &heavy {
+        for _ in 0..*n {
+            rows.push(vec![(*label).to_string()]);
+        }
+    }
+    for i in 0..1000 {
+        rows.push(vec![format!("noise{i}")]);
+    }
+    wrk.create("data.csv", rows);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method")
+        .arg("frequent_items")
+        .arg("--limit")
+        .arg("5")
+        .arg("--no-other")
+        .arg("data.csv");
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "frequency command failed: stderr = {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let _header = lines.next().unwrap();
+
+    // Parse: field,value,count,percentage,rank
+    let mut got: Vec<(String, u64)> = Vec::new();
+    for line in lines {
+        let cols: Vec<&str> = line.split(',').collect();
+        let value = cols[1].to_string();
+        let count: u64 = cols[2].parse().unwrap();
+        got.push((value, count));
+    }
+
+    assert_eq!(
+        got.len(),
+        5,
+        "FI top-5 should produce exactly 5 rows, got {got:?}"
+    );
+
+    // Top-K identity: the first 5 rows should be the 5 heavy hitters in count order.
+    for (i, (label, true_count)) in heavy.iter().enumerate() {
+        assert_eq!(
+            got[i].0,
+            *label,
+            "rank {} should be {label}, got {got:?}",
+            i + 1
+        );
+        let est = got[i].1;
+        let lo = ((*true_count as f64) * 0.95) as u64;
+        let hi = ((*true_count as f64) * 1.05) as u64;
+        assert!(
+            (lo..=hi).contains(&est),
+            "{label}: estimate {est} not within 5% of true count {true_count}"
+        );
+    }
+}
+
+#[test]
+fn frequency_sketch_method_frequent_items_with_asc_is_rejected() {
+    let wrk = Workdir::new("frequency_sketch_method_frequent_items_with_asc_is_rejected");
+    wrk.create("data.csv", vec![svec!["v"], svec!["a"], svec!["b"]]);
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method")
+        .arg("frequent_items")
+        .arg("--asc")
+        .arg("data.csv");
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "frequent_items + --asc should be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--asc") && stderr.contains("frequent_items"),
+        "error should mention both --asc and frequent_items, got: {stderr}"
+    );
+}
+
+#[test]
+fn frequency_sketch_method_frequent_items_with_weight_is_rejected() {
+    let wrk = Workdir::new("frequency_sketch_method_frequent_items_with_weight_is_rejected");
+    wrk.create(
+        "data.csv",
+        vec![svec!["v", "w"], svec!["a", "1"], svec!["b", "1"]],
+    );
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method")
+        .arg("frequent_items")
+        .arg("--weight")
+        .arg("w")
+        .arg("data.csv");
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "frequent_items + --weight should be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--weight") || stderr.contains("weight"),
+        "error should mention weight rejection, got: {stderr}"
+    );
+}
+
+#[test]
+fn frequency_sketch_method_invalid_value_is_rejected() {
+    let wrk = Workdir::new("frequency_sketch_method_invalid_value_is_rejected");
+    wrk.create("data.csv", vec![svec!["v"], svec!["a"]]);
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method").arg("bogus").arg("data.csv");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--sketch-method") && stderr.contains("bogus"),
+        "error should mention bad flag and value, got: {stderr}"
+    );
+}
+
+#[test]
+fn frequency_sketch_method_invalid_map_size_is_rejected() {
+    let wrk = Workdir::new("frequency_sketch_method_invalid_map_size_is_rejected");
+    wrk.create("data.csv", vec![svec!["v"], svec!["a"]]);
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method")
+        .arg("frequent_items")
+        .arg("--sketch-map-size")
+        .arg("100")
+        .arg("data.csv");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--sketch-map-size") && stderr.contains("power of two"),
+        "error should mention --sketch-map-size and power of two, got: {stderr}"
+    );
+}

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -6650,12 +6650,15 @@ fn frequency_sketch_method_frequent_items_other_row_emission() {
         .expect("Other count must be a plain integer (no decimals/scientific notation)");
     let other_rank_str = &other_row.3;
 
-    // Rank must be the integer "4" (3 kept top-K rows + 1) — NOT "4.0" or "4e0",
-    // matching the per-item rank rendering. Regression guard for the Medium
-    // finding from the review.
+    // Rank must be the integer "0" (sentinel for synthetic rows like Other and
+    // *ALL_UNIQUE) — matching the exact path's Other-row convention. Regression
+    // guard for both review findings: the Medium float-formatter bug (would have
+    // emitted "4.0"/"4e0") and the divergence from exact's rank-0 sentinel
+    // (would have emitted "4").
     assert_eq!(
-        other_rank_str, "4",
-        "Other rank must render as integer '4' to match per-item rows, got '{other_rank_str}'"
+        other_rank_str, "0",
+        "Other rank must render as integer '0' to match the exact path's synthetic-row \
+         convention, got '{other_rank_str}'"
     );
 
     // Other count = total_weight - kept_top3_estimates ≈ 1250 + 625 + 1000 noise = 2875.
@@ -6666,5 +6669,47 @@ fn frequency_sketch_method_frequent_items_other_row_emission() {
     assert!(
         (lo..=hi).contains(&other_count),
         "Other count {other_count} not within 5% of expected ~{true_other} (total={total})"
+    );
+}
+
+#[test]
+fn frequency_sketch_method_frequent_items_with_other_sorted_is_rejected() {
+    let wrk = Workdir::new("frequency_sketch_method_frequent_items_with_other_sorted_is_rejected");
+    wrk.create("data.csv", vec![svec!["v"], svec!["a"], svec!["b"]]);
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method")
+        .arg("frequent_items")
+        .arg("--other-sorted")
+        .arg("data.csv");
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "frequent_items + --other-sorted should be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--other-sorted") && stderr.contains("frequent_items"),
+        "error should mention both --other-sorted and frequent_items, got: {stderr}"
+    );
+}
+
+#[test]
+fn frequency_sketch_method_frequent_items_with_null_sorted_is_rejected() {
+    let wrk = Workdir::new("frequency_sketch_method_frequent_items_with_null_sorted_is_rejected");
+    wrk.create("data.csv", vec![svec!["v"], svec!["a"], svec!["b"]]);
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method")
+        .arg("frequent_items")
+        .arg("--null-sorted")
+        .arg("data.csv");
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "frequent_items + --null-sorted should be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--null-sorted") && stderr.contains("frequent_items"),
+        "error should mention both --null-sorted and frequent_items, got: {stderr}"
     );
 }

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -6632,11 +6632,18 @@ fn frequency_sketch_method_frequent_items_other_row_emission() {
         })
         .collect();
 
-    // Find the Other row.
-    let other_row = parsed.iter().find(|(v, _, _, _)| v == "Other").expect(
-        "Other row must be emitted by default (no --no-other given) — current rows: \
-         {parsed:?}",
-    );
+    // Find the Other row. Use unwrap_or_else+panic! so the {parsed:?} format
+    // string is actually interpolated on failure — `expect` takes a plain &str
+    // and would print the placeholder verbatim, hiding the diagnostic context.
+    let other_row = parsed
+        .iter()
+        .find(|(v, _, _, _)| v == "Other")
+        .unwrap_or_else(|| {
+            panic!(
+                "Other row must be emitted by default (no --no-other given) — current rows: \
+                 {parsed:?}"
+            )
+        });
     let other_count: u64 = other_row
         .1
         .parse()

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -6577,3 +6577,87 @@ fn frequency_sketch_method_invalid_map_size_is_rejected() {
         "error should mention --sketch-map-size and power of two, got: {stderr}"
     );
 }
+
+#[test]
+fn frequency_sketch_method_frequent_items_other_row_emission() {
+    // Exercise the "Other" row: 5 heavy hitters [10000, 5000, 2500, 1250, 625]
+    // plus 1000 noise singletons, asking for top-3. Other should aggregate the
+    // remaining heavy hitters (h4, h5) plus the noise stream length.
+    let wrk = Workdir::new("frequency_sketch_method_frequent_items_other_row_emission");
+    let mut rows: Vec<Vec<String>> = vec![vec!["v".to_string()]];
+    let heavy = [
+        ("h1", 10000usize),
+        ("h2", 5000),
+        ("h3", 2500),
+        ("h4", 1250),
+        ("h5", 625),
+    ];
+    for (label, n) in &heavy {
+        for _ in 0..*n {
+            rows.push(vec![(*label).to_string()]);
+        }
+    }
+    for i in 0..1000 {
+        rows.push(vec![format!("noise{i}")]);
+    }
+    let total: u64 = heavy.iter().map(|(_, n)| *n as u64).sum::<u64>() + 1000;
+    wrk.create("data.csv", rows);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("--sketch-method")
+        .arg("frequent_items")
+        .arg("--limit")
+        .arg("3")
+        .arg("data.csv");
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "frequency command failed: stderr = {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let _header = lines.next().unwrap();
+
+    let parsed: Vec<(String, String, String, String)> = lines
+        .map(|line| {
+            let cols: Vec<&str> = line.split(',').collect();
+            (
+                cols[1].to_string(),
+                cols[2].to_string(),
+                cols[3].to_string(),
+                cols[4].to_string(),
+            )
+        })
+        .collect();
+
+    // Find the Other row.
+    let other_row = parsed.iter().find(|(v, _, _, _)| v == "Other").expect(
+        "Other row must be emitted by default (no --no-other given) — current rows: \
+         {parsed:?}",
+    );
+    let other_count: u64 = other_row
+        .1
+        .parse()
+        .expect("Other count must be a plain integer (no decimals/scientific notation)");
+    let other_rank_str = &other_row.3;
+
+    // Rank must be the integer "4" (3 kept top-K rows + 1) — NOT "4.0" or "4e0",
+    // matching the per-item rank rendering. Regression guard for the Medium
+    // finding from the review.
+    assert_eq!(
+        other_rank_str, "4",
+        "Other rank must render as integer '4' to match per-item rows, got '{other_rank_str}'"
+    );
+
+    // Other count = total_weight - kept_top3_estimates ≈ 1250 + 625 + 1000 noise = 2875.
+    // FI estimates can be slightly off; allow a 5% slack.
+    let true_other: u64 = heavy[3..].iter().map(|(_, n)| *n as u64).sum::<u64>() + 1000;
+    let lo = ((true_other as f64) * 0.95) as u64;
+    let hi = ((true_other as f64) * 1.05) as u64;
+    assert!(
+        (lo..=hi).contains(&other_count),
+        "Other count {other_count} not within 5% of expected ~{true_other} (total={total})"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -6566,3 +6566,164 @@ fn stats_mode_cardinality_cap_cardinality_only_emits_two_fields() {
         "antimode column should not be present when --mode is not set: {headers:?}"
     );
 }
+
+/// Build a fixture with `unique` distinct strings each repeated `reps` times. The true
+/// cardinality is exactly `unique`; we use this to gauge HLL's relative error.
+fn approx_cardinality_fixture(unique: usize, reps: usize) -> Vec<Vec<String>> {
+    let mut rows: Vec<Vec<String>> = Vec::with_capacity(unique * reps + 1);
+    rows.push(vec!["value".to_string()]);
+    for _ in 0..reps {
+        for i in 0..unique {
+            rows.push(vec![format!("v{i}")]);
+        }
+    }
+    rows
+}
+
+#[test]
+fn stats_cardinality_method_approx_within_envelope() {
+    // 10_000 distinct strings × 10 reps = 100_000 rows, true cardinality = 10_000.
+    // HLL with lg_k=12 has ~1.5% RSE; allow 3% slack for safety.
+    let wrk = Workdir::new("stats_cardinality_method_approx_within_envelope");
+    wrk.create("data.csv", approx_cardinality_fixture(10_000, 10));
+
+    let mut cmd = wrk.command("stats");
+    // Pin --jobs 1 for reproducibility (HLL union is associative + order-invariant,
+    // but we want exact reproducibility regardless).
+    cmd.arg("--cardinality")
+        .arg("--cardinality-method")
+        .arg("approx")
+        .arg("--jobs")
+        .arg("1")
+        .arg("data.csv");
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stats command failed: stderr = {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let headers: Vec<&str> = lines
+        .next()
+        .expect("stats output should have a header row")
+        .split(',')
+        .collect();
+    let value_row: Vec<&str> = lines
+        .next()
+        .expect("stats output should have at least one data row")
+        .split(',')
+        .collect();
+    let card: f64 = value_row[headers.iter().position(|h| *h == "cardinality").unwrap()]
+        .parse()
+        .expect("cardinality should be a plain integer under approx (no '>=' sentinel)");
+
+    let tol = 0.03_f64;
+    assert!(
+        (card - 10_000.0).abs() / 10_000.0 < tol,
+        "approx cardinality = {card} not within 3% of 10_000"
+    );
+}
+
+#[test]
+fn stats_cardinality_method_approx_no_cap_sentinel() {
+    // Under approx, the --mode-cardinality-cap should NOT cause the cardinality column
+    // to emit ">=<cap>" — HLL provides an estimate at fixed memory regardless of cap.
+    let wrk = Workdir::new("stats_cardinality_method_approx_no_cap_sentinel");
+    wrk.create("data.csv", approx_cardinality_fixture(10_000, 2));
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--cardinality")
+        .arg("--cardinality-method")
+        .arg("approx")
+        .arg("--mode-cardinality-cap")
+        .arg("100")
+        .arg("--jobs")
+        .arg("1")
+        .arg("data.csv");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let headers: Vec<&str> = lines.next().unwrap().split(',').collect();
+    let row: Vec<&str> = lines.next().unwrap().split(',').collect();
+    let card_str = row[headers.iter().position(|h| *h == "cardinality").unwrap()];
+    assert!(
+        !card_str.starts_with(">="),
+        "approx cardinality should never emit '>=cap' sentinel, got: {card_str}"
+    );
+    let card: f64 = card_str.parse().expect("cardinality should be numeric");
+    assert!(
+        card > 5_000.0,
+        "approx cardinality should reflect true ~10_000 unique values, got: {card}"
+    );
+}
+
+#[test]
+fn stats_cardinality_method_approx_with_infer_boolean_falls_back_to_exact() {
+    // --infer-boolean needs cardinality == 2 to be exact, so run() forces exact mode
+    // and emits a warning. The cardinality output for a known boolean column must be
+    // exactly 2, with no '>=' sentinel and no approximation.
+    let wrk = Workdir::new("stats_cardinality_method_approx_with_infer_boolean_falls_back");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["flag"],
+            svec!["yes"],
+            svec!["no"],
+            svec!["yes"],
+            svec!["no"],
+        ],
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-boolean")
+        .arg("--cardinality-method")
+        .arg("approx")
+        .arg("--jobs")
+        .arg("1")
+        .arg("data.csv");
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stats command failed: stderr = {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let headers: Vec<&str> = lines.next().unwrap().split(',').collect();
+    let row: Vec<&str> = lines.next().unwrap().split(',').collect();
+    let card: u64 = row[headers.iter().position(|h| *h == "cardinality").unwrap()]
+        .parse()
+        .unwrap();
+    assert_eq!(card, 2, "boolean column should report exact cardinality 2");
+    let typ = row[headers.iter().position(|h| *h == "type").unwrap()];
+    assert_eq!(typ, "Boolean", "type should infer as Boolean, got: {typ}");
+}
+
+#[test]
+fn stats_cardinality_method_invalid_value_is_rejected() {
+    let wrk = Workdir::new("stats_cardinality_method_invalid_value_is_rejected");
+    wrk.create("data.csv", vec![svec!["value"], svec!["1"], svec!["2"]]);
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--cardinality")
+        .arg("--cardinality-method")
+        .arg("bogus")
+        .arg("data.csv");
+
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "should fail on invalid --cardinality-method value"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--cardinality-method") && stderr.contains("bogus"),
+        "error should mention the bad flag and value, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Two new opt-in sketch-backed modes that reuse the existing `datasketches` crate dependency. Both default to the existing exact behavior — no migration required.

- **`stats --cardinality-method approx`** routes the cardinality column through a HyperLogLog sketch (`HLL_LG_K = 12`, ~1.5% RSE, ~5KB/column). The `--mode-cardinality-cap` no longer corrupts cardinality output under approx — the `>=<cap>` sentinel is never emitted; mode/antimode columns still respect the cap. `--infer-boolean` forces exact with a warning (boolean inference needs `cardinality == 2` exactness). Merging uses `HllUnion` (associative + order-invariant, fully reproducible across `--jobs`).
- **`frequency --sketch-method frequent_items`** routes through a Misra-Gries heavy-hitters sketch (`--sketch-map-size`, default 4096). Rejects flag combinations that don't compose with a streaming top-K sketch: `--asc`, `--weight`, `--ignore-case`, `--no-trim`, `--frequency-jsonl`, `--stats-filter`, `--json/--pretty-json/--toon`. Cache is bypassed; counts are estimates from `frequent_items(NoFalsePositives)`. The "Other" row is computed from `total_weight − Σ(top_k_estimates)`.

Cache invalidation rides on the `StatsArgs` derived `PartialEq`; old cache files deserialize cleanly via `get_str_or("flag_cardinality_method", "exact")`.

Plan A (HLL) and Plan B (Frequent Items) are sequenced so they could land independently — both go through their own opt-in flag.

## Tests

- `tests/test_stats.rs`: +4 tests — envelope accuracy on 100k rows / 10k unique (within 3% of true), no `>=cap` sentinel under cap+approx, `--infer-boolean` fallback to exact, invalid value rejection.
- `tests/test_frequency.rs`: +6 tests — Zipfian top-K identity & 5% accuracy, "Other" row emission with integer rank rendering, `--asc` rejection, `--weight` rejection, invalid method rejection, invalid map-size rejection.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features`
- [x] `cargo t stats -F all_features` (744 passed, 3 ignored)
- [x] `cargo t frequency -F all_features` (166 passed)
- [x] `cargo clippy -F all_features --bin qsv` (clean)
- [ ] CI: full test matrix + lints

## Survey of remaining sketch opportunities (not in scope)

For follow-up: Theta in `moarstats` (set ops on join cardinality), per-group t-digest in `pivotp`, Bloom filter in `dedup`/`extdedup` (likely skip — users want exact). Documented in the plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)