### PR TITLE
feat(pivotp): --agg quantile@<p> (alias q@<p>) with linear interpolation

### DIFF
--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -52,6 +52,9 @@ pivotp options:
                               max - Maximum value
                               mean - Average value
                               median - Median value
+                              quantile@<p> - Quantile at probability p in [0, 1] using linear interpolation.
+                                             Alias: q@<p>. Examples: quantile@0.95, q@0.5
+                                             (q@0.5 is equivalent to median for even-length groups).
                               len - Count of values
                               item - Get single value from group. Raises error if there are multiple values.
                               smart - use value column data type & statistics to pick an aggregation.
@@ -124,6 +127,13 @@ static STATS_RECORDS: OnceLock<(ByteRecord, Vec<StatsData>)> = OnceLock::new();
 /// Helper function to convert a Vec<String> to a vector of Expr for column selection
 fn cols_to_exprs(cols: &[String]) -> Vec<Expr> {
     cols.iter().map(col).collect()
+}
+
+/// Parse `quantile@<p>` or `q@<p>` -> Some(p) iff p ∈ [0, 1]; else None.
+fn parse_quantile_agg(s: &str) -> Option<f64> {
+    let suffix = s.strip_prefix("quantile@").or_else(|| s.strip_prefix("q@"))?;
+    let p: f64 = suffix.parse().ok()?;
+    (p.is_finite() && (0.0..=1.0).contains(&p)).then_some(p)
 }
 
 /// Build the SchemaArgs used for stats/frequency lookups.
@@ -952,6 +962,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         return fail_incorrectusage_clierror!("--agg \"none\" is not supported in group-by mode.");
     }
 
+    // Reject malformed quantile probabilities with a precise error so users see *why*
+    // their probability is bad rather than the generic "Invalid pivot aggregation function".
+    // Works in both pivot and group-by mode; no mode-conditional check needed.
+    if (agg_name.starts_with("quantile@") || agg_name.starts_with("q@"))
+        && parse_quantile_agg(&agg_name).is_none()
+    {
+        return fail_incorrectusage_clierror!(
+            "Invalid quantile probability in --agg {agg_name}: must be a float in [0, 1] (e.g. \
+             quantile@0.95)"
+        );
+    }
+
     // Get aggregation function - using generic expressions that pivot will apply to value columns
     // NOTE: This match must stay in sync with the group-by agg_exprs match below.
     let agg_expr = if agg_name == "none" {
@@ -967,6 +989,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             "median" => Expr::Element.median(),
             "len" => Expr::Element.len(),
             "item" => Expr::Element.item(true),
+            s if parse_quantile_agg(s).is_some() => {
+                // safe: guard above already validated the suffix
+                let p = parse_quantile_agg(s).unwrap();
+                Expr::Element.quantile(lit(p), QuantileMethod::Linear)
+            },
             "smart" => {
                 if is_groupby_mode {
                     // In group-by mode, smart defaults to len (count)
@@ -1124,9 +1151,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         "mean" => c.mean().alias(PlSmallStr::from_str(vc)),
                         "median" => c.median().alias(PlSmallStr::from_str(vc)),
                         "len" | "smart" => len().alias(PlSmallStr::from_str(vc)),
+                        s if parse_quantile_agg(s).is_some() => {
+                            // safe: guard above already validated the suffix
+                            let p = parse_quantile_agg(s).unwrap();
+                            c.quantile(lit(p), QuantileMethod::Linear)
+                                .alias(PlSmallStr::from_str(vc))
+                        },
                         // Unreachable because:
                         //   - "none" and "item" are rejected in the group-by validation block in
                         //     `run` (see the `is_groupby_mode` checks).
+                        //   - malformed quantile@/q@ names are rejected in the same validation
+                        //     block.
                         //   - any other unknown name is rejected in the pivot `agg_expr` match
                         //     above, where `agg_expr` is first constructed.
                         _ => unreachable!(

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -255,6 +255,155 @@ pivotp_test!(
     }
 );
 
+// Test pivot with quantile@0.95 aggregation (linear interpolation)
+// Fixture: North/A=[100,300] -> q95 = 100 + 0.95*200 = 290.0
+//          North/B=[150,350] -> q95 = 150 + 0.95*200 = 340.0
+//          South/A=[200], South/B=[250] -> single-element groups return that value
+pivotp_test!(
+    pivotp_quantile_p95_agg,
+    |wrk: Workdir, mut cmd: process::Command| {
+        cmd.args(&[
+            "product",
+            "--index",
+            "region",
+            "--values",
+            "sales",
+            "--agg",
+            "quantile@0.95",
+            "sales.csv",
+        ]);
+
+        wrk.assert_success(&mut cmd);
+
+        let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+        let expected = vec![
+            svec!["region", "A", "B"],
+            svec!["North", "290.0", "340.0"],
+            svec!["South", "200.0", "250.0"],
+        ];
+        assert_eq!(got, expected);
+    }
+);
+
+// Test that q@0.5 alias produces the same output as median for the sales fixture.
+// For 2-element sorted groups, Polars' median() == linear quantile(0.5) == midpoint.
+pivotp_test!(
+    pivotp_q_alias_p50_equals_median,
+    |wrk: Workdir, mut cmd: process::Command| {
+        cmd.args(&[
+            "product",
+            "--index",
+            "region",
+            "--values",
+            "sales",
+            "--agg",
+            "q@0.5",
+            "sales.csv",
+        ]);
+
+        wrk.assert_success(&mut cmd);
+
+        let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+        // Same expected output as pivotp_median_agg above.
+        let expected = vec![
+            svec!["region", "A", "B"],
+            svec!["North", "200.0", "250.0"],
+            svec!["South", "200.0", "250.0"],
+        ];
+        assert_eq!(got, expected);
+    }
+);
+
+// Test that malformed quantile probabilities are rejected with a precise error.
+pivotp_test!(
+    pivotp_quantile_invalid_p_rejected,
+    |wrk: Workdir, mut cmd: process::Command| {
+        // Out-of-range high
+        cmd.args(&[
+            "product",
+            "--index",
+            "region",
+            "--values",
+            "sales",
+            "--agg",
+            "quantile@1.5",
+            "sales.csv",
+        ]);
+        wrk.assert_err(&mut cmd);
+        let stderr = wrk.output_stderr(&mut cmd);
+        assert!(
+            stderr.contains("Invalid quantile probability"),
+            "expected 'Invalid quantile probability' in stderr, got: {stderr}"
+        );
+
+        // Out-of-range low (negative)
+        let mut cmd2 = wrk.command("pivotp");
+        cmd2.args(&[
+            "product",
+            "--index",
+            "region",
+            "--values",
+            "sales",
+            "--agg",
+            "q@-0.1",
+            "sales.csv",
+        ]);
+        wrk.assert_err(&mut cmd2);
+        let stderr2 = wrk.output_stderr(&mut cmd2);
+        assert!(
+            stderr2.contains("Invalid quantile probability"),
+            "expected 'Invalid quantile probability' in stderr, got: {stderr2}"
+        );
+
+        // Non-numeric suffix
+        let mut cmd3 = wrk.command("pivotp");
+        cmd3.args(&[
+            "product",
+            "--index",
+            "region",
+            "--values",
+            "sales",
+            "--agg",
+            "quantile@abc",
+            "sales.csv",
+        ]);
+        wrk.assert_err(&mut cmd3);
+        let stderr3 = wrk.output_stderr(&mut cmd3);
+        assert!(
+            stderr3.contains("Invalid quantile probability"),
+            "expected 'Invalid quantile probability' in stderr, got: {stderr3}"
+        );
+    }
+);
+
+// Test quantile in group-by mode (no <on-cols>).
+// North sales sorted = [100, 150, 300, 350] -> q25 linear at index 0.75 = 100 + 0.75*50 = 137.5
+// South sales sorted = [200, 250]           -> q25 linear at index 0.25 = 200 + 0.25*50 = 212.5
+pivotp_test!(
+    pivotp_quantile_groupby_mode,
+    |wrk: Workdir, mut cmd: process::Command| {
+        cmd.args(&[
+            "--index",
+            "region",
+            "--values",
+            "sales",
+            "--agg",
+            "q@0.25",
+            "sales.csv",
+        ]);
+
+        wrk.assert_success(&mut cmd);
+
+        let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+        let expected = vec![
+            svec!["region", "sales"],
+            svec!["North", "137.5"],
+            svec!["South", "212.5"],
+        ];
+        assert_eq!(got, expected);
+    }
+);
+
 // Test pivot with len aggregation
 pivotp_test!(pivotp_len_agg, |wrk: Workdir, mut cmd: process::Command| {
     cmd.args(&[


### PR DESCRIPTION
## Summary

- Adds per-group quantile aggregation to `pivotp` via a new `--agg quantile@<p>` aggregation function (alias `q@<p>`), where `p` is a float in `[0, 1]`. Examples: `--agg quantile@0.95`, `--agg q@0.5`.
- Backed by Polars' `Expr::quantile` with `QuantileMethod::Linear` — exact, fast, and matches numpy/pandas/scipy/`stats --quantile-method linear` defaults. No new dependency.
- Works in both pivot mode and group-by mode. Malformed probabilities (out of range, non-numeric) are caught by a precise pre-match validation error rather than the generic "Invalid pivot aggregation function" message.
- Method override (`quantile@p@method`) is intentionally deferred — the surface stays minimal until someone asks for it.

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features` — clean
- [x] `cargo t pivotp -F all_features` — 62/62 pass
- [x] `cargo clippy -F all_features` — no warnings
- [x] Four new tests added in `tests/test_pivotp.rs`:
  - `pivotp_quantile_p95_agg` — pivot mode, `--agg quantile@0.95`, asserts exact linear-interpolated p95
  - `pivotp_q_alias_p50_equals_median` — `--agg q@0.5` produces byte-identical output to `--agg median` on the standard fixture
  - `pivotp_quantile_invalid_p_rejected` — `quantile@1.5`, `q@-0.1`, and `quantile@abc` all exit non-zero with "Invalid quantile probability" in stderr
  - `pivotp_quantile_groupby_mode` — group-by mode (no `<on-cols>`), `--agg q@0.25`, asserts Q1 per group

🤖 Generated with [Claude Code](https://claude.com/claude-code)