### PR TITLE
fix(apply,applydp): Thousands neg fractions, scope <NULL> to regex_replace

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -565,20 +565,34 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         wtr.write_record(&headers)?;
     }
 
-    // <NULL> (case-insensitive) is recognized as "delete matches" when regex_replace is in
-    // the operation chain. Note this clears flag_replacement for ALL ops in the chain, so
-    // a chained `regex_replace,replace` with --replacement <NULL> deletes matches in both.
-    let flag_replacement = if apply_cmd == ApplySubCmd::Operations
+    // <NULL> (case-insensitive) on --replacement is recognized as "delete matches" by
+    // regex_replace. Scope this rewrite to regex_replace only — other ops in the same chain
+    // (e.g. `replace`, `numtocurrency`) still see the user's literal --replacement value, so
+    // they aren't silently turned into no-ops.
+    let flag_replacement = args.flag_replacement;
+    let regex_replace_replacement = if apply_cmd == ApplySubCmd::Operations
         && ops_vec.contains(&Operations::Regex_Replace)
-        && args.flag_replacement.eq_ignore_ascii_case(NULL_VALUE)
+        && flag_replacement.eq_ignore_ascii_case(NULL_VALUE)
     {
         String::new()
     } else {
-        args.flag_replacement
+        flag_replacement.clone()
     };
     let flag_comparand = args.flag_comparand;
     let flag_formatstr = args.flag_formatstr;
     let flag_new_column = args.flag_new_column;
+
+    // pre-compute a per-column selection mask so multi-column in-place transforms can
+    // rebuild each record once per row instead of once per selected column. Mask indices
+    // align with input-record field indices; the trailing `false` slot (if --new-column
+    // appended one to `headers`) is never read because that branch handles --new-column.
+    let is_selected: Vec<bool> = {
+        let mut mask = vec![false; headers.len()];
+        for col_index in &*sel {
+            mask[*col_index] = true;
+        }
+        mask
+    };
 
     // prep progress bar
     let show_progress =
@@ -630,34 +644,69 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 match apply_cmd {
                     ApplySubCmd::Operations => {
                         let mut cell = String::new();
-                        for col_index in &*sel {
-                            record[*col_index].clone_into(&mut cell);
+                        if flag_new_column.is_some() {
+                            // single-column case (validated upstream: --new-column requires
+                            // sel.len() == 1 for operations/emptyreplace)
+                            let col_index = *sel.iter().next().unwrap();
+                            record[col_index].clone_into(&mut cell);
                             apply_operations(
                                 &ops_vec,
                                 &mut cell,
                                 &flag_comparand,
                                 &flag_replacement,
+                                &regex_replace_replacement,
                                 &flag_formatstr,
                             );
-                            if flag_new_column.is_some() {
-                                record.push_field(&cell);
-                            } else {
-                                record = replace_column_value(&record, *col_index, &cell);
+                            record.push_field(&cell);
+                        } else {
+                            // multi-column (or single-column) in-place: rebuild the record
+                            // once instead of once per selected column (replace_column_value
+                            // allocates a fresh StringRecord per call).
+                            let mut new_record = csv::StringRecord::new();
+                            for (i, field) in record.iter().enumerate() {
+                                if is_selected[i] {
+                                    cell.clear();
+                                    cell.push_str(field);
+                                    apply_operations(
+                                        &ops_vec,
+                                        &mut cell,
+                                        &flag_comparand,
+                                        &flag_replacement,
+                                        &regex_replace_replacement,
+                                        &flag_formatstr,
+                                    );
+                                    new_record.push_field(&cell);
+                                } else {
+                                    new_record.push_field(field);
+                                }
                             }
+                            record = new_record;
                         }
                     },
                     ApplySubCmd::EmptyReplace => {
-                        let mut cell = String::new();
-                        for col_index in &*sel {
-                            record[*col_index].clone_into(&mut cell);
-                            if cell.trim().is_empty() {
-                                cell.clone_from(&flag_replacement);
-                            }
-                            if flag_new_column.is_some() {
-                                record.push_field(&cell);
+                        if flag_new_column.is_some() {
+                            // single-column case (validated upstream)
+                            let col_index = *sel.iter().next().unwrap();
+                            let field = &record[col_index];
+                            let new_field = if field.trim().is_empty() {
+                                flag_replacement.as_str()
                             } else {
-                                record = replace_column_value(&record, *col_index, &cell);
+                                field
+                            };
+                            // borrow ends before push_field
+                            let new_field = new_field.to_owned();
+                            record.push_field(&new_field);
+                        } else {
+                            // rebuild once instead of once per selected column
+                            let mut new_record = csv::StringRecord::new();
+                            for (i, field) in record.iter().enumerate() {
+                                if is_selected[i] && field.trim().is_empty() {
+                                    new_record.push_field(&flag_replacement);
+                                } else {
+                                    new_record.push_field(field);
+                                }
                             }
+                            record = new_record;
                         }
                     },
                     ApplySubCmd::DynFmt => {
@@ -735,8 +784,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     Ok(wtr.flush()?)
 }
 
-// validate apply operations for required options
-// and prepare operations enum vec
 fn validate_operations(
     operations: &Vec<&str>,
     flag_comparand: &str,
@@ -754,7 +801,9 @@ fn validate_operations(
     let mut strip_invokes = 0_u8;
     let mut whatlang_invokes = 0_u8;
 
-    let mut ops_vec = SmallVec::with_capacity(operations.len());
+    // SmallVec::new() preserves inline storage for the common case of <=4 ops;
+    // with_capacity(n) forces a heap allocation when n > 0, even when n <= 4.
+    let mut ops_vec = SmallVec::new();
 
     for op in operations {
         let Ok(operation) = Operations::from_str(op) else {
@@ -767,18 +816,14 @@ fn validate_operations(
                         "--new-column (-c) is required for censor operations."
                     );
                 }
-                if censor_invokes == 0
-                    && CENSOR
-                        .set({
-                            let mut censored_words = Censor::Standard + Zealous + Sex;
-                            for word in flag_comparand.split(',') {
-                                censored_words += word.trim();
-                            }
-                            censored_words
-                        })
-                        .is_err()
-                {
-                    return fail!("Cannot initialize Censor engine.");
+                if censor_invokes == 0 {
+                    // OnceLock::set can only fail if already set; the invokes guard makes
+                    // that path unreachable here.
+                    let mut censored_words = Censor::Standard + Zealous + Sex;
+                    for word in flag_comparand.split(',') {
+                        censored_words += word.trim();
+                    }
+                    let _ = CENSOR.set(censored_words);
                 }
                 censor_invokes = censor_invokes.saturating_add(1);
             },
@@ -796,12 +841,8 @@ fn validate_operations(
                         "--comparand (-C) and --new-column (-c) are required for eudex."
                     );
                 }
-                if eudex_invokes == 0
-                    && EUDEX_COMPARAND_HASH
-                        .set(eudex::Hash::new(flag_comparand))
-                        .is_err()
-                {
-                    return fail!("Cannot initialize Eudex.");
+                if eudex_invokes == 0 {
+                    let _ = EUDEX_COMPARAND_HASH.set(eudex::Hash::new(flag_comparand));
                 }
                 eudex_invokes = eudex_invokes.saturating_add(1);
             },
@@ -823,10 +864,11 @@ fn validate_operations(
                     let re = match regex::Regex::new(flag_comparand) {
                         Ok(re) => re,
                         Err(err) => {
-                            return fail_clierror!("regex_replace expression error: {err:?}");
+                            return fail_incorrectusage_clierror!(
+                                "regex_replace expression error: {err:?}"
+                            );
                         },
                     };
-                    #[allow(clippy::let_underscore_untyped)]
                     let _ = REGEX_REPLACE.set(re);
                 }
                 regex_replace_invokes = regex_replace_invokes.saturating_add(1);
@@ -846,14 +888,9 @@ fn validate_operations(
                         "--new-column (-c) is required for sentiment operation."
                     );
                 }
-                if sentiment_invokes == 0
-                    && SENTIMENT_ANALYZER
-                        .set(SentimentIntensityAnalyzer::new())
-                        .is_err()
-                {
-                    return fail!("Cannot initialize Sentiment Analyzer.");
+                if sentiment_invokes == 0 {
+                    let _ = SENTIMENT_ANALYZER.set(SentimentIntensityAnalyzer::new());
                 }
-
                 sentiment_invokes = sentiment_invokes.saturating_add(1);
             },
             Operations::Simdl
@@ -872,7 +909,9 @@ fn validate_operations(
             },
             Operations::Strip_Prefix | Operations::Strip_Suffix => {
                 if flag_comparand.is_empty() {
-                    return fail!("--comparand (-C) is required for strip operations.");
+                    return fail_incorrectusage_clierror!(
+                        "--comparand (-C) is required for strip operations."
+                    );
                 }
                 strip_invokes = strip_invokes.saturating_add(1);
             },
@@ -900,39 +939,36 @@ fn validate_operations(
                     );
                 }
 
-                if whatlang_invokes == 0
-                    && WHATLANG_CONFIDENCE_THRESHOLD
-                        .set(if flag_comparand.is_empty() {
-                            DEFAULT_THRESHOLD
+                if whatlang_invokes == 0 {
+                    let threshold = if flag_comparand.is_empty() {
+                        DEFAULT_THRESHOLD
+                    } else {
+                        let preparsed_threshold;
+                        let show_confidence = if flag_comparand.ends_with('?') {
+                            preparsed_threshold = flag_comparand.trim_end_matches('?');
+                            true
                         } else {
-                            let preparsed_threshold;
-                            let show_confidence = if flag_comparand.ends_with('?') {
-                                preparsed_threshold = flag_comparand.trim_end_matches('?');
-                                true
-                            } else {
-                                preparsed_threshold = flag_comparand;
-                                false
-                            };
-                            let desired_threshold = preparsed_threshold
-                                .parse::<f64>()
-                                .unwrap_or(DEFAULT_THRESHOLD);
-                            // desired threshold can be 0.0 to 1.0
-                            let final_threshold = if (0.0..=1.0).contains(&desired_threshold) {
-                                desired_threshold
-                            } else {
-                                // its outside the valid range
-                                // just set it to the default threshold
-                                DEFAULT_THRESHOLD
-                            };
-                            if show_confidence {
-                                -final_threshold
-                            } else {
-                                final_threshold
-                            }
-                        })
-                        .is_err()
-                {
-                    return fail!("cannot initialize WhatLang language detection.");
+                            preparsed_threshold = flag_comparand;
+                            false
+                        };
+                        let desired_threshold = preparsed_threshold
+                            .parse::<f64>()
+                            .unwrap_or(DEFAULT_THRESHOLD);
+                        // desired threshold can be 0.0 to 1.0
+                        let final_threshold = if (0.0..=1.0).contains(&desired_threshold) {
+                            desired_threshold
+                        } else {
+                            // its outside the valid range
+                            // just set it to the default threshold
+                            DEFAULT_THRESHOLD
+                        };
+                        if show_confidence {
+                            -final_threshold
+                        } else {
+                            final_threshold
+                        }
+                    };
+                    let _ = WHATLANG_CONFIDENCE_THRESHOLD.set(threshold);
                 }
                 whatlang_invokes = whatlang_invokes.saturating_add(1);
             },
@@ -976,6 +1012,7 @@ fn apply_operations(
     cell: &mut String,
     comparand: &str,
     replacement: &str,
+    regex_replacement: &str,
     formatstr: &str,
 ) {
     for op in ops_vec {
@@ -1081,7 +1118,9 @@ fn apply_operations(
             Operations::Regex_Replace => {
                 // safety: we set REGEX_REPLACE in validate_operations()
                 let regexreplace = REGEX_REPLACE.get().unwrap();
-                *cell = regexreplace.replace_all(cell, replacement).into_owned();
+                *cell = regexreplace
+                    .replace_all(cell, regex_replacement)
+                    .into_owned();
             },
             Operations::Censor => {
                 // safety: we set CENSOR in validate_operations()
@@ -1105,9 +1144,12 @@ fn apply_operations(
                     //safety: we set THOUSANDS_POLICY in validate_operations()
                     let mut temp_string = num.separate_by_policy(*THOUSANDS_POLICY.get().unwrap());
 
-                    // if there is a decimal separator (fractional part > 0.0), use the requested
-                    // decimal separator in --replacement
-                    if num.fract() > 0.0 {
+                    // if there is a decimal separator (i.e. a non-zero fractional part), use
+                    // the requested decimal separator in --replacement. Compare against != 0.0
+                    // because f64::fract() preserves sign: (-1.5).fract() == -0.5, so a
+                    // `> 0.0` check would skip negative fractional numbers and leave their
+                    // decimal point as `.` regardless of --replacement.
+                    if num.fract() != 0.0 {
                         // if replacement is empty, use the default decimal separator (.)
                         *cell = if replacement.is_empty() {
                             temp_string

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -583,10 +583,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let flag_new_column = args.flag_new_column;
 
     // pre-compute a per-column selection mask so multi-column in-place transforms can
-    // rebuild each record once per row instead of once per selected column. Mask indices
-    // align with input-record field indices; the trailing `false` slot (if --new-column
-    // appended one to `headers`) is never read because that branch handles --new-column.
-    let is_selected: Vec<bool> = {
+    // rebuild each record once per row instead of once per selected column. Only built
+    // when --new-column is NOT set: the --new-column branch uses the single selected
+    // column index directly and never consults the mask, so allocating it there would
+    // be wasted, and skipping it also keeps the mask's len() == input-record width
+    // (avoiding any reliance on `headers` not having been extended yet).
+    let is_selected: Vec<bool> = if flag_new_column.is_some() {
+        Vec::new()
+    } else {
         let mut mask = vec![false; headers.len()];
         for col_index in &*sel {
             mask[*col_index] = true;

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -665,8 +665,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         } else {
                             // multi-column (or single-column) in-place: rebuild the record
                             // once instead of once per selected column (replace_column_value
-                            // allocates a fresh StringRecord per call).
-                            let mut new_record = csv::StringRecord::new();
+                            // allocates a fresh StringRecord per call). Pre-size the new
+                            // record to the input's exact byte/field footprint to avoid
+                            // per-push growth reallocations on wide CSVs.
+                            let mut new_record = csv::StringRecord::with_capacity(
+                                record.as_byte_record().as_slice().len(),
+                                record.len(),
+                            );
                             for (i, field) in record.iter().enumerate() {
                                 if is_selected[i] {
                                     cell.clear();
@@ -701,8 +706,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             let new_field = new_field.to_owned();
                             record.push_field(&new_field);
                         } else {
-                            // rebuild once instead of once per selected column
-                            let mut new_record = csv::StringRecord::new();
+                            // rebuild once instead of once per selected column. Pre-size
+                            // to the input record's footprint to avoid push-growth reallocs.
+                            let mut new_record = csv::StringRecord::with_capacity(
+                                record.as_byte_record().as_slice().len(),
+                                record.len(),
+                            );
                             for (i, field) in record.iter().enumerate() {
                                 if is_selected[i] && field.trim().is_empty() {
                                     new_record.push_field(&flag_replacement);

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -369,19 +369,33 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         wtr.write_record(&headers)?;
     }
 
-    // <NULL> (case-insensitive) is recognized as "delete matches" when regex_replace is in
-    // the operation chain. Note this clears flag_replacement for ALL ops in the chain, so
-    // a chained `regex_replace,replace` with --replacement <NULL> deletes matches in both.
-    let flag_replacement = if applydp_cmd == ApplydpSubCmd::Operations
+    // <NULL> (case-insensitive) on --replacement is recognized as "delete matches" by
+    // regex_replace. Scope this rewrite to regex_replace only — chained ops (e.g. `replace`)
+    // still see the user's literal --replacement value, so they aren't silently turned into
+    // no-ops.
+    let flag_replacement = args.flag_replacement;
+    let regex_replace_replacement = if applydp_cmd == ApplydpSubCmd::Operations
         && ops_vec.contains(&Operations::Regex_Replace)
-        && args.flag_replacement.eq_ignore_ascii_case(NULL_VALUE)
+        && flag_replacement.eq_ignore_ascii_case(NULL_VALUE)
     {
         String::new()
     } else {
-        args.flag_replacement
+        flag_replacement.clone()
     };
     let flag_comparand = args.flag_comparand;
     let flag_new_column = args.flag_new_column;
+
+    // pre-compute a per-column selection mask so multi-column in-place transforms can
+    // rebuild each record once per row instead of once per selected column. The trailing
+    // `false` slot (if --new-column appended one to `headers`) is never read because that
+    // branch handles --new-column.
+    let is_selected: Vec<bool> = {
+        let mut mask = vec![false; headers.len()];
+        for col_index in &*sel {
+            mask[*col_index] = true;
+        }
+        mask
+    };
 
     // amortize memory allocation by reusing record
     #[allow(unused_assignments)]
@@ -432,33 +446,66 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 match applydp_cmd {
                     ApplydpSubCmd::Operations => {
                         let mut cell = String::new();
-                        for col_index in sel.iter() {
-                            record[*col_index].clone_into(&mut cell);
+                        if flag_new_column.is_some() {
+                            // single-column case (validated upstream: --new-column requires
+                            // sel.len() == 1 for operations/emptyreplace)
+                            let col_index = *sel.iter().next().unwrap();
+                            record[col_index].clone_into(&mut cell);
                             applydp_operations(
                                 &ops_vec,
                                 &mut cell,
                                 &flag_comparand,
                                 &flag_replacement,
+                                &regex_replace_replacement,
                             );
-                            if flag_new_column.is_some() {
-                                record.push_field(&cell);
-                            } else {
-                                record = replace_column_value(&record, *col_index, &cell);
+                            record.push_field(&cell);
+                        } else {
+                            // multi-column (or single-column) in-place: rebuild the record
+                            // once instead of once per selected column (replace_column_value
+                            // allocates a fresh StringRecord per call).
+                            let mut new_record = csv::StringRecord::new();
+                            for (i, field) in record.iter().enumerate() {
+                                if is_selected[i] {
+                                    cell.clear();
+                                    cell.push_str(field);
+                                    applydp_operations(
+                                        &ops_vec,
+                                        &mut cell,
+                                        &flag_comparand,
+                                        &flag_replacement,
+                                        &regex_replace_replacement,
+                                    );
+                                    new_record.push_field(&cell);
+                                } else {
+                                    new_record.push_field(field);
+                                }
                             }
+                            record = new_record;
                         }
                     },
                     ApplydpSubCmd::EmptyReplace => {
-                        let mut cell = String::new();
-                        for col_index in sel.iter() {
-                            record[*col_index].clone_into(&mut cell);
-                            if cell.trim().is_empty() {
-                                cell = flag_replacement.clone();
-                            }
-                            if flag_new_column.is_some() {
-                                record.push_field(&cell);
+                        if flag_new_column.is_some() {
+                            // single-column case (validated upstream)
+                            let col_index = *sel.iter().next().unwrap();
+                            let field = &record[col_index];
+                            let new_field = if field.trim().is_empty() {
+                                flag_replacement.as_str()
                             } else {
-                                record = replace_column_value(&record, *col_index, &cell);
+                                field
+                            };
+                            let new_field = new_field.to_owned();
+                            record.push_field(&new_field);
+                        } else {
+                            // rebuild once instead of once per selected column
+                            let mut new_record = csv::StringRecord::new();
+                            for (i, field) in record.iter().enumerate() {
+                                if is_selected[i] && field.trim().is_empty() {
+                                    new_record.push_field(&flag_replacement);
+                                } else {
+                                    new_record.push_field(field);
+                                }
                             }
+                            record = new_record;
                         }
                     },
                     ApplydpSubCmd::DynFmt => {
@@ -506,7 +553,9 @@ fn validate_operations(
     let mut replace_invokes = 0_u8;
     let mut strip_invokes = 0_u8;
 
-    let mut ops_vec = SmallVec::with_capacity(operations.len());
+    // SmallVec::new() preserves inline storage for the common case of <=4 ops;
+    // with_capacity(n) forces a heap allocation when n > 0, even when n <= 4.
+    let mut ops_vec = SmallVec::new();
 
     for op in operations {
         let Ok(operation) = Operations::from_str(op) else {
@@ -539,7 +588,9 @@ fn validate_operations(
                     let re = match regex::Regex::new(flag_comparand) {
                         Ok(re) => re,
                         Err(err) => {
-                            return fail_clierror!("regex_replace expression error: {err:?}");
+                            return fail_incorrectusage_clierror!(
+                                "regex_replace expression error: {err:?}"
+                            );
                         },
                     };
                     let _ = REGEX_REPLACE.set(re);
@@ -590,6 +641,7 @@ fn applydp_operations(
     cell: &mut String,
     comparand: &str,
     replacement: &str,
+    regex_replacement: &str,
 ) {
     for op in ops_vec {
         match op {
@@ -648,7 +700,9 @@ fn applydp_operations(
             Operations::Regex_Replace => {
                 // safety: we set REGEX_REPLACE in validate_operations()
                 let regexreplace = REGEX_REPLACE.get().unwrap();
-                *cell = regexreplace.replace_all(cell, replacement).into_owned();
+                *cell = regexreplace
+                    .replace_all(cell, regex_replacement)
+                    .into_owned();
             },
             Operations::Round => {
                 if let Ok(num) = cell.parse::<f64>() {

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -386,10 +386,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let flag_new_column = args.flag_new_column;
 
     // pre-compute a per-column selection mask so multi-column in-place transforms can
-    // rebuild each record once per row instead of once per selected column. The trailing
-    // `false` slot (if --new-column appended one to `headers`) is never read because that
-    // branch handles --new-column.
-    let is_selected: Vec<bool> = {
+    // rebuild each record once per row instead of once per selected column. Only built
+    // when --new-column is NOT set: the --new-column branch uses the single selected
+    // column index directly and never consults the mask, so allocating it there would
+    // be wasted, and skipping it also keeps the mask's len() == input-record width
+    // (avoiding any reliance on `headers` not having been extended yet).
+    let is_selected: Vec<bool> = if flag_new_column.is_some() {
+        Vec::new()
+    } else {
         let mut mask = vec![false; headers.len()];
         for col_index in &*sel {
             mask[*col_index] = true;

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -466,8 +466,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         } else {
                             // multi-column (or single-column) in-place: rebuild the record
                             // once instead of once per selected column (replace_column_value
-                            // allocates a fresh StringRecord per call).
-                            let mut new_record = csv::StringRecord::new();
+                            // allocates a fresh StringRecord per call). Pre-size the new
+                            // record to the input's exact byte/field footprint to avoid
+                            // per-push growth reallocations on wide CSVs.
+                            let mut new_record = csv::StringRecord::with_capacity(
+                                record.as_byte_record().as_slice().len(),
+                                record.len(),
+                            );
                             for (i, field) in record.iter().enumerate() {
                                 if is_selected[i] {
                                     cell.clear();
@@ -500,8 +505,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             let new_field = new_field.to_owned();
                             record.push_field(&new_field);
                         } else {
-                            // rebuild once instead of once per selected column
-                            let mut new_record = csv::StringRecord::new();
+                            // rebuild once instead of once per selected column. Pre-size
+                            // to the input record's footprint to avoid push-growth reallocs.
+                            let mut new_record = csv::StringRecord::with_capacity(
+                                record.as_byte_record().as_slice().len(),
+                                record.len(),
+                            );
                             for (i, field) in record.iter().enumerate() {
                                 if is_selected[i] && field.trim().is_empty() {
                                     new_record.push_field(&flag_replacement);

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1203,10 +1203,18 @@ fn apply_ops_regex_replace() {
 #[test]
 fn apply_ops_regex_replace_null_scoped_to_regex_replace() {
     // Regression test: previously `--replacement <NULL>` was rewritten to "" globally
-    // whenever regex_replace appeared anywhere in the chain, which also turned a chained
-    // `replace` into a no-op (it would replace its match with an empty string). The
-    // <NULL> sentinel must apply only to regex_replace; `replace` should still see the
-    // literal "<NULL>" string and replace its matches with that text.
+    // whenever regex_replace appeared anywhere in the chain, which silently turned a
+    // chained `replace` into a deletion. The <NULL> sentinel must apply only to
+    // regex_replace; `replace` should still see the literal "<NULL>" string.
+    //
+    // The chain is `replace,regex_replace` and both ops share --comparand "KEEPME".
+    // `replace` runs first (literal-string match) and is what makes this test
+    // distinguish the buggy and fixed code paths:
+    //   - buggy:  "KEEPME" -> ""       (flag_replacement was globally cleared)
+    //   - fixed:  "KEEPME" -> "<NULL>" (flag_replacement preserved for `replace`)
+    // regex_replace then runs on the already-substituted text; "KEEPME" is no longer
+    // present, so the regex match is empty either way and the difference in output
+    // is attributable solely to `replace`.
     let wrk = Workdir::new("apply");
     wrk.create(
         "data.csv",
@@ -1218,20 +1226,17 @@ fn apply_ops_regex_replace_null_scoped_to_regex_replace() {
     );
     let mut cmd = wrk.command("apply");
     cmd.arg("operations")
-        .arg("regex_replace,replace")
+        .arg("replace,regex_replace")
         .arg("description")
-        .args(["--comparand", "\\d{3}-\\d{4}"])
+        .args(["--comparand", "KEEPME"])
         .args(["--replacement", "<NULL>"])
         .arg("data.csv");
 
-    // regex_replace deletes the phone number; the chained `replace` does NOT match
-    // (its --comparand is the regex pattern, not present literally in the data),
-    // so the rows are unchanged apart from the regex deletion.
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["description"],
-        svec!["call  and ask for KEEPME"],
-        svec!["no match here, just KEEPME"],
+        svec!["call 555-1212 and ask for <NULL>"],
+        svec!["no match here, just <NULL>"],
     ];
     assert_eq!(got, expected);
 }

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1201,6 +1201,42 @@ fn apply_ops_regex_replace() {
 }
 
 #[test]
+fn apply_ops_regex_replace_null_scoped_to_regex_replace() {
+    // Regression test: previously `--replacement <NULL>` was rewritten to "" globally
+    // whenever regex_replace appeared anywhere in the chain, which also turned a chained
+    // `replace` into a no-op (it would replace its match with an empty string). The
+    // <NULL> sentinel must apply only to regex_replace; `replace` should still see the
+    // literal "<NULL>" string and replace its matches with that text.
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["description"],
+            svec!["call 555-1212 and ask for KEEPME"],
+            svec!["no match here, just KEEPME"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("regex_replace,replace")
+        .arg("description")
+        .args(["--comparand", "\\d{3}-\\d{4}"])
+        .args(["--replacement", "<NULL>"])
+        .arg("data.csv");
+
+    // regex_replace deletes the phone number; the chained `replace` does NOT match
+    // (its --comparand is the regex pattern, not present literally in the data),
+    // so the rows are unchanged apart from the regex deletion.
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["description"],
+        svec!["call  and ask for KEEPME"],
+        svec!["no match here, just KEEPME"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn apply_ops_regex_replace_validation_error() {
     let wrk = Workdir::new("apply");
     wrk.create(
@@ -1251,7 +1287,9 @@ fn apply_ops_regex_replace_error() {
     wrk.assert_err(&mut cmd);
 
     let got: String = wrk.output_stderr(&mut cmd);
-    assert!(got.starts_with("regex_replace expression error"));
+    // invalid user-supplied regex is an IncorrectUsage error, so stderr is prefixed
+    // with "usage error: " (consistent with other validate_operations failures).
+    assert!(got.starts_with("usage error: regex_replace expression error"));
 }
 
 #[test]
@@ -1768,6 +1806,41 @@ fn apply_ops_thousands_eurostyle() {
         svec!["0"],
         svec!["5"],
         svec!["not a number, should be ignored"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_ops_thousands_eurostyle_negative_fraction() {
+    // Regression test: previously the `> 0.0` check on f64::fract() skipped negative
+    // fractional numbers (since (-x.y).fract() is negative), so --replacement was
+    // ignored and the decimal separator stayed as '.' for negatives.
+    let wrk = Workdir::new("apply");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["number"],
+            svec!["-1234.5"],
+            svec!["-1234567.89"],
+            svec!["-0.25"],
+            svec!["1234.5"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("thousands")
+        .arg("number")
+        .args(["--formatstr", "dot"])
+        .args(["--replacement", ","])
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["number"],
+        svec!["-1.234,5"],
+        svec!["-1.234.567,89"],
+        svec!["-0,25"],
+        svec!["1.234,5"],
     ];
     assert_eq!(got, expected);
 }

--- a/tests/test_applydp.rs
+++ b/tests/test_applydp.rs
@@ -399,6 +399,42 @@ fn applydp_regex_replace_issue1469() {
 }
 
 #[test]
+fn applydp_ops_regex_replace_null_scoped_to_regex_replace() {
+    // Regression test: previously `--replacement <NULL>` was rewritten to "" globally
+    // whenever regex_replace appeared anywhere in the chain, which also turned a chained
+    // `replace` into a no-op (it would replace its match with an empty string). The
+    // <NULL> sentinel must apply only to regex_replace; `replace` should still see the
+    // literal "<NULL>" string and replace its matches with that text.
+    let wrk = Workdir::new("applydp");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["description"],
+            svec!["call 555-1212 and ask for KEEPME"],
+            svec!["no match here, just KEEPME"],
+        ],
+    );
+    let mut cmd = wrk.command("applydp");
+    cmd.arg("operations")
+        .arg("regex_replace,replace")
+        .arg("description")
+        .args(["--comparand", "\\d{3}-\\d{4}"])
+        .args(["--replacement", "<NULL>"])
+        .arg("data.csv");
+
+    // regex_replace deletes the phone number; the chained `replace` does NOT match
+    // (its --comparand is the regex pattern, not present literally in the data),
+    // so the rows are unchanged apart from the regex deletion.
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["description"],
+        svec!["call  and ask for KEEPME"],
+        svec!["no match here, just KEEPME"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn applydp_ops_regex_replace_validation_error() {
     let wrk = Workdir::new("applydp");
     wrk.create(
@@ -449,7 +485,9 @@ fn applydp_ops_regex_replace_error() {
     wrk.assert_err(&mut cmd);
 
     let got: String = wrk.output_stderr(&mut cmd);
-    assert!(got.starts_with("regex_replace expression error"));
+    // invalid user-supplied regex is an IncorrectUsage error, so stderr is prefixed
+    // with "usage error: " (consistent with other validate_operations failures).
+    assert!(got.starts_with("usage error: regex_replace expression error"));
 }
 
 #[test]

--- a/tests/test_applydp.rs
+++ b/tests/test_applydp.rs
@@ -401,10 +401,15 @@ fn applydp_regex_replace_issue1469() {
 #[test]
 fn applydp_ops_regex_replace_null_scoped_to_regex_replace() {
     // Regression test: previously `--replacement <NULL>` was rewritten to "" globally
-    // whenever regex_replace appeared anywhere in the chain, which also turned a chained
-    // `replace` into a no-op (it would replace its match with an empty string). The
-    // <NULL> sentinel must apply only to regex_replace; `replace` should still see the
-    // literal "<NULL>" string and replace its matches with that text.
+    // whenever regex_replace appeared anywhere in the chain, which silently turned a
+    // chained `replace` into a deletion. The <NULL> sentinel must apply only to
+    // regex_replace; `replace` should still see the literal "<NULL>" string.
+    //
+    // The chain is `replace,regex_replace` and both ops share --comparand "KEEPME".
+    // `replace` runs first (literal-string match) and is what makes this test
+    // distinguish the buggy and fixed code paths:
+    //   - buggy:  "KEEPME" -> ""       (flag_replacement was globally cleared)
+    //   - fixed:  "KEEPME" -> "<NULL>" (flag_replacement preserved for `replace`)
     let wrk = Workdir::new("applydp");
     wrk.create(
         "data.csv",
@@ -416,20 +421,17 @@ fn applydp_ops_regex_replace_null_scoped_to_regex_replace() {
     );
     let mut cmd = wrk.command("applydp");
     cmd.arg("operations")
-        .arg("regex_replace,replace")
+        .arg("replace,regex_replace")
         .arg("description")
-        .args(["--comparand", "\\d{3}-\\d{4}"])
+        .args(["--comparand", "KEEPME"])
         .args(["--replacement", "<NULL>"])
         .arg("data.csv");
 
-    // regex_replace deletes the phone number; the chained `replace` does NOT match
-    // (its --comparand is the regex pattern, not present literally in the data),
-    // so the rows are unchanged apart from the regex deletion.
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["description"],
-        svec!["call  and ask for KEEPME"],
-        svec!["no match here, just KEEPME"],
+        svec!["call 555-1212 and ask for <NULL>"],
+        svec!["no match here, just <NULL>"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
## Summary

Bug fixes surfaced during a code review of `apply.rs`, mirrored where applicable in `applydp.rs`.

### Bugs fixed

- **`Thousands` op ignored `--replacement` decimal separator for negative fractional numbers.** `num.fract() > 0.0` skipped them because `f64::fract()` preserves sign (`(-1.5).fract() == -0.5`). E.g. `apply operations thousands col --formatstr space --replacement ,` on `-1234.5` yielded `-1 234.5` instead of `-1 234,5`. Now compares against `!= 0.0`. (apply only — applydp has no Thousands op.)

- **`<NULL>` `--replacement` was globally clearing `flag_replacement` for every op in the chain.** A chained `regex_replace,replace --replacement '<NULL>'` would silently turn the `replace` into a deletion. NULL detection is now scoped to `regex_replace` only via a new `regex_replacement` parameter threaded into `apply_operations` / `applydp_operations`; `replace` and other ops see the user's literal `--replacement` value.

### Behavior changes worth a changelog note

- Invalid user-supplied `regex_replace` `--comparand` now returns `CliError::IncorrectUsage` (exit code **2**) instead of `CliError::Other`, with stderr prefixed by `usage error:` — consistent with every other user-input failure in `validate_operations`.
- `regex_replace,replace --replacement <NULL>` no longer silently nullifies the chained `replace`. If anyone relied on this, they should supply an explicit empty `--replacement` or drop the chained `replace`.

### Refactors / cleanups

- Multi-column in-place transforms in both `apply` and `applydp` now rebuild each `StringRecord` **once per row** via a precomputed `is_selected: Vec<bool>` mask, instead of N times via `replace_column_value` (one rebuild per selected column).
- `SmallVec::with_capacity(operations.len())` → `SmallVec::new()` in `validate_operations` so the inline-storage path is preserved for the common ≤4 ops case.
- `apply::validate_operations`: dropped unreachable `OnceLock`-error paths in favor of `let _ = X.set(...)` under the existing invokes guard; `fail!` / `fail_clierror!` for user-input errors are now consistently `fail_incorrectusage_clierror!`.

## Test plan

- [x] `cargo test -F all_features --test tests apply` — 71/71 pass (68 original + 1 multi-column rejection test + 2 new regression tests)
- [x] `cargo test --features datapusher_plus --test tests applydp` — 32/32 pass (31 original + 1 new regression test)
- [x] `cargo build --locked --bin qsv -F all_features` — clean
- [x] `cargo clippy -F all_features --bin qsv` — no new warnings
- [x] New regression tests:
  - `apply_ops_thousands_eurostyle_negative_fraction` — exercises negative fractional Thousands path
  - `apply_ops_regex_replace_null_scoped_to_regex_replace`
  - `applydp_ops_regex_replace_null_scoped_to_regex_replace`
- [x] `apply_ops_regex_replace_error` / `applydp_ops_regex_replace_error` updated to expect the new `usage error:` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)